### PR TITLE
Fix menu badge on Firefox

### DIFF
--- a/app/components/shared/Menu/button.js
+++ b/app/components/shared/Menu/button.js
@@ -1,11 +1,8 @@
 import React from "react";
 import classNames from 'classnames';
-import update from "react-addons-update";
 
 import Badge from "../Badge";
 import BaseButton from "../Button";
-
-const COLOR = (Features.NewNav) ? "lime" : "blue";
 
 class Button extends React.Component {
   static displayName = "Menu.Button";
@@ -18,35 +15,33 @@ class Button extends React.Component {
   };
 
   render() {
-    // Use a super simpe way of figuring out if the current href is active
-    let active = (window.location.pathname.indexOf(this.props.link || this.props.href) == 0)
-
-    let badge;
-    if(this.props.badge) {
-      let badgeClasses = classNames(`right hover-${COLOR}-child`, {
-        "bg-lime": (active && COLOR == "lime"),
-        "bg-blue": (active && COLOR == "blue")
-      })
-
-      badge = <Badge className={badgeClasses}>{this.props.badge}</Badge>
-    }
-
-    let buttonProps = update(this.props, {
-      theme: {
-        $set: false
-      },
-      className: {
-        $set: classNames(`block hover-${COLOR} focus-${COLOR} truncate`, {
-          "lime": (active && COLOR == "lime"),
-          "blue": (active && COLOR == "blue")
-        })
-      }
-    });
-
     return (
-      <BaseButton {...buttonProps}>{buttonProps.children}{badge}</BaseButton>
+      <BaseButton className={classNames(`block hover-lime focus-lime truncate`, { "lime": this._isActive() })}
+                  theme={false}
+                  {...this.props}>
+        <div className="flex">
+          <div className="flex-auto">{this.props.children}</div>
+          <div className="flex-none">{this._renderBadge()}</div>
+        </div>
+      </BaseButton>
     )
+  }
+
+  _isActive() {
+    // Use a super simpe way of figuring out if the current href is active
+    return window.location.pathname.indexOf(this.props.link || this.props.href) == 0;
+  }
+
+  _renderBadge() {
+    if(this.props.badge) {
+      return (
+        <Badge className={classNames(`hover-lime-child`, { "bg-lime": this._isActive() })}>
+          {this.props.badge}
+        </Badge>
+      );
+    }
   }
 }
 
 export default Button;
+  


### PR DESCRIPTION
Before:

<img width="306" alt="before" src="https://cloud.githubusercontent.com/assets/153/14198953/7f98271a-f82b-11e5-95fb-7d1b1d1f1e91.png">

After:

<img width="317" alt="after" src="https://cloud.githubusercontent.com/assets/153/14198955/815e8148-f82b-11e5-8f41-a212f5e9bd21.png">

I also made the badge class more declarative using jsx and functions, and less imperative/code style. I think for UI components trying to keep it as tags and props and not putting too much JS in there means that you can more easily see how it’s working at a glance.

Also: no more need for `Features.NewNav`! :)