### PR TITLE
Add type="button" so they don't end up as submit buttons

### DIFF
--- a/app/components/shared/FormMarkdownEditorField.js
+++ b/app/components/shared/FormMarkdownEditorField.js
@@ -51,13 +51,13 @@ class FormMarkdownEdtiorField extends React.Component {
     return (
       <div className={containerClasses}>
         <div className="mb2">
-          <Button className="mr1" tabIndex={-1} onClick={this.handleBoldButtonClick} theme="default" outline={true}><i className="fa fa-bold"></i></Button>
-          <Button className="mr3" tabIndex={-1} onClick={this.handleItalicButtonClick} theme="default" outline={true}><i className="fa fa-italic"></i></Button>
-          <Button className="mr1" tabIndex={-1} onClick={this.handleQuoteButtonClick} theme="default" outline={true}><i className="fa fa-quote-right"></i></Button>
-          <Button className="mr1" tabIndex={-1} onClick={this.handleCodeButtonClick} theme="default" outline={true}><i className="fa fa-code"></i></Button>
-          <Button className="mr3" tabIndex={-1} onClick={this.handleLinkButtonClick} theme="default" outline={true}><i className="fa fa-link"></i></Button>
-          <Button className="mr1" tabIndex={-1} onClick={this.handleBulletedListButtonClick} theme="default" outline={true}><i className="fa fa-list"></i></Button>
-          <Button className="mr1" tabIndex={-1} onClick={this.handleNumberedListButtonClick} theme="default" outline={true}><i className="fa fa-list-ol"></i></Button>
+          <Button type="button" className="mr1" tabIndex={-1} onClick={this.handleBoldButtonClick} theme="default" outline={true}><i className="fa fa-bold"></i></Button>
+          <Button type="button" className="mr3" tabIndex={-1} onClick={this.handleItalicButtonClick} theme="default" outline={true}><i className="fa fa-italic"></i></Button>
+          <Button type="button" className="mr1" tabIndex={-1} onClick={this.handleQuoteButtonClick} theme="default" outline={true}><i className="fa fa-quote-right"></i></Button>
+          <Button type="button" className="mr1" tabIndex={-1} onClick={this.handleCodeButtonClick} theme="default" outline={true}><i className="fa fa-code"></i></Button>
+          <Button type="button" className="mr3" tabIndex={-1} onClick={this.handleLinkButtonClick} theme="default" outline={true}><i className="fa fa-link"></i></Button>
+          <Button type="button" className="mr1" tabIndex={-1} onClick={this.handleBulletedListButtonClick} theme="default" outline={true}><i className="fa fa-list"></i></Button>
+          <Button type="button" className="mr1" tabIndex={-1} onClick={this.handleNumberedListButtonClick} theme="default" outline={true}><i className="fa fa-list-ol"></i></Button>
         </div>
         {errorNode}
         <textarea


### PR DESCRIPTION
By default a browser uses the first button in the form with `type=submit` or no type at all when you submit a form with the keyboard. So if there's another field in the form, such as a Changelog Title, and you hit enter… the bold button would be clicked.

This just corrects the type of the buttons so they don't trigger on form submit.