### PR TITLE
Add Users to the top nav

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -209,7 +209,12 @@ class Navigation extends React.Component {
       },
       {
         any: true,
-        render: () => <NavigationButton href={`/organizations/${organization.slug}/settings`}>Settings</NavigationButton>
+        render: () => {
+          return [
+            <NavigationButton key={1} href={`/organizations/${organization.slug}/users`}>Users</NavigationButton>,
+            <NavigationButton key={2} href={`/organizations/${organization.slug}/settings`}>Settings</NavigationButton>
+          ]
+        }
       }
     )
   }


### PR DESCRIPTION
To help people see that they can add users, this adds Users to the top nav:

<img width="584" alt="users" src="https://cloud.githubusercontent.com/assets/153/17048029/2ea1bec2-5026-11e6-9131-a7771dc37aff.png">

I'm not 100% sold on it here, but without a nav rejig I'm not sure what another solution is for now.