### PR TITLE
Improve naming of components

### DIFF
--- a/app/components/organization/Show.js
+++ b/app/components/organization/Show.js
@@ -11,7 +11,7 @@ import Pipeline from './Pipeline';
 import Teams from './Teams';
 import Welcome from './Welcome';
 
-class Show extends React.Component {
+class OrganizationShow extends React.Component {
   static propTypes = {
     organization: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
@@ -142,7 +142,7 @@ class Show extends React.Component {
   };
 }
 
-export default Relay.createContainer(Show, {
+export default Relay.createContainer(OrganizationShow, {
   initialVariables: {
     team: null,
     isMounted: false

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -10,7 +10,7 @@ import TeamForm from './Form';
 import TeamUpdateMutation from '../../mutations/TeamUpdate';
 import GraphQLErrors from '../../constants/GraphQLErrors';
 
-class New extends React.Component {
+class TeamEdit extends React.Component {
   static propTypes = {
     team: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
@@ -102,7 +102,7 @@ class New extends React.Component {
   };
 }
 
-export default Relay.createContainer(New, {
+export default Relay.createContainer(TeamEdit, {
   fragments: {
     team: () => Relay.QL`
       fragment on Team {

--- a/app/components/team/Form.js
+++ b/app/components/team/Form.js
@@ -3,7 +3,7 @@ import React from 'react';
 import FormTextField from '../shared/FormTextField';
 import ValidationErrors from '../../lib/ValidationErrors';
 
-class Form extends React.Component {
+class TeamForm extends React.Component {
   static propTypes = {
     name: React.PropTypes.string,
     description: React.PropTypes.string,
@@ -47,4 +47,4 @@ class Form extends React.Component {
   };
 }
 
-export default Form
+export default TeamForm

--- a/app/components/team/Index.js
+++ b/app/components/team/Index.js
@@ -8,7 +8,7 @@ import permissions from '../../lib/permissions';
 
 import Row from './Row';
 
-class Index extends React.Component {
+class TeamIndex extends React.Component {
   static propTypes = {
     organization: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
@@ -49,7 +49,7 @@ class Index extends React.Component {
   }
 }
 
-export default Relay.createContainer(Index, {
+export default Relay.createContainer(TeamIndex, {
   fragments: {
     organization: () => Relay.QL`
       fragment on Organization {

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -5,7 +5,7 @@ import Chooser from '../../shared/Chooser';
 import Media from '../../shared/Media';
 import Dropdown from '../../shared/Dropdown';
 
-class Role extends React.Component {
+class MemberRole extends React.Component {
   static displayName = "Team.Pipelines.Role";
 
   static propTypes = {
@@ -73,4 +73,4 @@ class Role extends React.Component {
   }
 }
 
-export default Role;
+export default MemberRole;

--- a/app/components/team/New.js
+++ b/app/components/team/New.js
@@ -11,7 +11,7 @@ import RelayBridge from '../../lib/RelayBridge';
 import TeamCreateMutation from '../../mutations/TeamCreate';
 import GraphQLErrors from '../../constants/GraphQLErrors';
 
-class New extends React.Component {
+class TeamNew extends React.Component {
   static propTypes = {
     organization: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
@@ -102,7 +102,7 @@ class New extends React.Component {
   };
 }
 
-export default Relay.createContainer(New, {
+export default Relay.createContainer(TeamNew, {
   fragments: {
     organization: () => Relay.QL`
       fragment on Organization {

--- a/app/components/team/Row.js
+++ b/app/components/team/Row.js
@@ -8,7 +8,7 @@ import Emojify from '../shared/Emojify';
 const maxAvatars = 4;
 const avatarSize = 30;
 
-class Row extends React.Component {
+class TeamRow extends React.Component {
   static propTypes = {
     team: React.PropTypes.shape({
       id: React.PropTypes.string.isRequired,
@@ -103,7 +103,7 @@ class Row extends React.Component {
   }
 }
 
-export default Relay.createContainer(Row, {
+export default Relay.createContainer(TeamRow, {
   initialVariables: {
     maxAvatars: maxAvatars
   },

--- a/app/components/team/Show.js
+++ b/app/components/team/Show.js
@@ -13,7 +13,7 @@ import Members from './Members';
 import TeamDeleteMutation from '../../mutations/TeamDelete';
 import RelayBridge from '../../lib/RelayBridge';
 
-class Show extends React.Component {
+class TeamShow extends React.Component {
   static propTypes = {
     slug: React.PropTypes.string.isRequired,
     team: React.PropTypes.shape({
@@ -140,7 +140,7 @@ class Show extends React.Component {
   }
 }
 
-export default Relay.createContainer(Show, {
+export default Relay.createContainer(TeamShow, {
   initialVariables: {
     isEveryoneTeam: false
   },


### PR DESCRIPTION
Some components have rather generic names, this updates them with their category if they have one.

Possibly worth discussing; some existing components have a `displayName` attribute applied, which sort of goes for a namespace-ish approach - which is more desirable here?