### PR TITLE
Split out queries into their own files

### DIFF
--- a/app/queries/Agent.js
+++ b/app/queries/Agent.js
@@ -1,0 +1,14 @@
+import Relay from 'react-relay';
+
+export const query = () => Relay.QL`
+  query {
+    agent(slug: $slug)
+  }
+`;
+
+export const prepareParams = (params) => {
+  return {
+    ...params,
+    slug: [params.organization, params.agent].join("/")
+  };
+};

--- a/app/queries/Build.js
+++ b/app/queries/Build.js
@@ -1,0 +1,18 @@
+import Relay from 'react-relay';
+
+export const query = () => Relay.QL`
+  query {
+    build(slug: $slug)
+  }
+`;
+
+// Since relay doesn't currently support root fields with multiple
+// parameters, it means we can't have queries like: build(org: "...",
+// pipeline: "...", number: "12"), so we have to do this hacky thing where we
+// include them all in the `slug` param.
+export const prepareParams = (params) => {
+  return {
+    ...params,
+    slug: [params.organization, params.pipeline, params.number].join("/")
+  };
+};

--- a/app/queries/Organization.js
+++ b/app/queries/Organization.js
@@ -1,0 +1,7 @@
+import Relay from 'react-relay';
+
+export const query = () => Relay.QL`
+  query {
+    organization(slug: $organization)
+  }
+`;

--- a/app/queries/Pipeline.js
+++ b/app/queries/Pipeline.js
@@ -1,0 +1,14 @@
+import Relay from 'react-relay';
+
+export const query = () => Relay.QL`
+  query {
+    pipeline(slug: $slug)
+  }
+`;
+
+export const prepareParams = (params) => {
+  return {
+    ...params,
+    slug: [params.organization, params.pipeline].join("/")
+  };
+};

--- a/app/queries/PipelineSchedule.js
+++ b/app/queries/PipelineSchedule.js
@@ -1,0 +1,14 @@
+import Relay from 'react-relay';
+
+export const query = () => Relay.QL`
+  query {
+    pipelineSchedule(slug: $slug)
+  }
+`;
+
+export const prepareParams = (params) => {
+  return {
+    ...params,
+    slug: [params.organization, params.pipeline, params.schedule].join("/")
+  };
+};

--- a/app/queries/Team.js
+++ b/app/queries/Team.js
@@ -1,0 +1,20 @@
+import Relay from 'react-relay';
+
+export const query = () => Relay.QL`
+  query {
+    team(slug: $slug)
+  }
+`;
+
+export const prepareParams = (params) => {
+  // Send through `isEveryoneTeam` as a variable to the compoent, so we can
+  // dynamically decide whether or not to do a GraphQL for all the members.
+  // If we don't set it at this level, we'd need to do a GraphQL to get the
+  // team, see if it's the "everyone" team, and then decide to do another
+  // query to get the members.
+  return {
+    ...params,
+    slug: [params.organization, params.team].join("/"),
+    isEveryoneTeam: params.team === "everyone"
+  };
+};

--- a/app/queries/Viewer.js
+++ b/app/queries/Viewer.js
@@ -1,0 +1,7 @@
+import Relay from 'react-relay';
+
+export const query = () => Relay.QL`
+  query {
+    viewer
+  }
+`;


### PR DESCRIPTION
This is in preparation for making the navigation use Relay always, which requires us to optionally use these queries in pre-ES6 code, thus exporting them to `window.Webpack`