### PR TITLE
Improved pipeline tooltip, with duration and status

### DIFF
--- a/app/components/organization/Pipeline/build-tooltip.js
+++ b/app/components/organization/Pipeline/build-tooltip.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Relay from 'react-relay';
 import shallowCompare from 'react-addons-shallow-compare';
+import moment from 'moment';
 
 import Emojify from '../../shared/Emojify';
 import UserAvatar from "../../shared/UserAvatar";
@@ -39,8 +40,8 @@ class BuildTooltip extends React.Component {
               <Media.Image className="mr2" style={{ width: 30, height: 30 }} >
                 <UserAvatar user={this.props.build.createdBy} className="fit" />
               </Media.Image>
-              <Media.Description className="truncate">
-                <Emojify className="block line-height-1 truncate" text={this.props.build.message} />
+              <Media.Description className="line-height-1">
+                <Emojify className="block truncate line-height-3" text={this.props.build.message} />
                 <small className="dark-gray">{this.renderTime()}</small>
               </Media.Description>
             </Media>
@@ -53,15 +54,26 @@ class BuildTooltip extends React.Component {
   }
 
   renderTime() {
+    let timeValue = (
+      <span>Waiting</span>
+    );
+
     if (this.props.build.startedAt || this.props.build.finishedAt) {
-      return (
-        <FriendlyTime value={this.props.build.finishedAt || this.props.build.startedAt} capitalized={true} />
-      );
-    } else {
-      return (
-        <div>something</div>
+      timeValue = (
+        <span>
+          {this.props.build.finishedAt
+            ? 'Finished '
+            : 'Started '
+          }
+          <FriendlyTime value={this.props.build.finishedAt || this.props.build.startedAt} capitalized={false} />
+          {this.props.build.finishedAt &&
+            `. Took ${moment.duration(moment(this.props.build.finishedAt || undefined).diff(moment(this.props.build.startedAt))).humanize()}`
+          }
+        </span>
       );
     }
+
+    return timeValue;
   }
 }
 

--- a/app/components/organization/Pipeline/build-tooltip.js
+++ b/app/components/organization/Pipeline/build-tooltip.js
@@ -41,7 +41,7 @@ class BuildTooltip extends React.Component {
                 <UserAvatar user={this.props.build.createdBy} className="fit" />
               </Media.Image>
               <Media.Description className="line-height-1">
-                <Emojify className="block truncate line-height-3" text={this.props.build.message} />
+                <Emojify className="block line-height-3" text={this.props.build.message.split("\n")[0]} />
                 <small className="dark-gray">{this.renderTime()}</small>
               </Media.Description>
             </Media>

--- a/app/components/organization/Pipeline/status.js
+++ b/app/components/organization/Pipeline/status.js
@@ -34,11 +34,11 @@ class Status extends React.Component {
 
       return (
         <a href={build.url}
-          className="block line-height-1 color-inherit relative"
+          className="color-inherit relative"
           onMouseOver={this.handleMouseOver}
           onMouseOut={this.handleMouseOut}
         >
-          <BuildState state={build.state} />
+          <span className="block line-height-1"><BuildState state={build.state} /></span>
           <BuildTooltip build={build} visible={this.state.hover} left={-8} top={44} />
         </a>
       );


### PR DESCRIPTION
<img width="269" alt="screen shot 2016-09-22 at 10 22 23 am" src="https://cloud.githubusercontent.com/assets/282113/18733721/c89974a6-80b0-11e6-990c-936601ca8423.png">

From the _I-need-this-somewhere-other-than-git-stash_ department