### PR TITLE
More consistent build dropdown and tooltip

### DIFF
--- a/.buildkite/jest.sh
+++ b/.buildkite/jest.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "+++ :jest: Running Jest"
+npm run test --silent
+
+echo "👌 Looks good to me!"

--- a/.buildkite/jest.sh
+++ b/.buildkite/jest.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 echo "+++ :jest: Running Jest"
-npm run test --silent
+npm run test --silent | cat # remove 🐈 when this patch (https://github.com/facebook/jest/pull/1864) lands in Jest
 
 echo "👌 Looks good to me!"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,14 +14,20 @@ steps:
   - name: ":eslint:"
     command: ".buildkite/eslint.sh"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#ed68516:
+        run: frontend
+
+  - name: ":jest:"
+    command: ".buildkite/jest.sh"
+    plugins:
+      docker-compose#ed68516:
         run: frontend
 
   - name: ":webpack:"
     command: ".buildkite/webpack.sh"
     artifact_paths: "dist/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#ed68516:
         run: frontend
 
   - wait

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,5 @@
 # Webpack
 dist
+
+# Jest Snapshots
+**/__snapshots__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5
+FROM node:6
 
 WORKDIR /frontend
 

--- a/app/app.js
+++ b/app/app.js
@@ -48,6 +48,7 @@ window["Webpack"] = {
     "components/user/SettingsMenu": require("./components/user/SettingsMenu").default,
     "components/PipelinesWelcome": require("./components/organization/Welcome").default,
     "components/pipeline/Teams": require("./components/pipeline/Teams").default,
+    "lib/commits": require("./lib/commits"),
     "lib/friendlyRelativeTime": require("./lib/friendlyRelativeTime").default,
     "lib/Logger": require("./lib/Logger").default,
     "lib/Emoji": require("./lib/Emoji").default,

--- a/app/components/organization/Pipeline/build-tooltip.js
+++ b/app/components/organization/Pipeline/build-tooltip.js
@@ -37,7 +37,7 @@ class BuildTooltip extends React.Component {
     if (this.props.visible) {
       return (
         <div style={{ fontSize: 13 }}>
-          <div className="bg-white rounded shadow border border-gray p2 block absolute pointer-events-none z2" style={{ left: this.props.left, top: this.props.top, width: 230 }}>
+          <div className="bg-white rounded-2 shadow border border-gray p2 block absolute pointer-events-none z2" style={{ left: this.props.left, top: this.props.top, width: 230 }}>
             <img src={require('../../../images/up-pointing-white-nib.svg')} width={32} height={20} alt="" className="absolute pointer-events-none" style={{ top: -20, left: 7 }} />
             <Media align="top">
               <Media.Image className="mr2" style={{ width: 30, height: 30 }} >

--- a/app/components/organization/Pipeline/build-tooltip.js
+++ b/app/components/organization/Pipeline/build-tooltip.js
@@ -8,12 +8,15 @@ import UserAvatar from "../../shared/UserAvatar";
 import Media from "../../shared/Media";
 import FriendlyTime from "../../shared/FriendlyTime";
 
+import { shortMessage, shortCommit } from '../../../lib/commits';
+
 class BuildTooltip extends React.Component {
   static propTypes = {
     visible: React.PropTypes.bool.isRequired,
     top: React.PropTypes.number.isRequired,
     left: React.PropTypes.number.isRequired,
     build: React.PropTypes.shape({
+      commit: React.PropTypes.string,
       createdBy: React.PropTypes.shape({
         name: React.PropTypes.string.isRequired,
         avatar: React.PropTypes.shape({
@@ -33,15 +36,15 @@ class BuildTooltip extends React.Component {
   render() {
     if (this.props.visible) {
       return (
-        <div>
+        <div style={{ fontSize: 13 }}>
           <div className="bg-white rounded shadow border border-gray p2 block absolute pointer-events-none z2" style={{ left: this.props.left, top: this.props.top, width: 230 }}>
             <img src={require('../../../images/up-pointing-white-nib.svg')} width={32} height={20} alt="" className="absolute pointer-events-none" style={{ top: -20, left: 7 }} />
             <Media align="top">
               <Media.Image className="mr2" style={{ width: 30, height: 30 }} >
                 <UserAvatar user={this.props.build.createdBy} className="fit" />
               </Media.Image>
-              <Media.Description className="line-height-1">
-                <Emojify className="block line-height-3" text={this.props.build.message.split("\n")[0]} />
+              <Media.Description className="line-height-2">
+                <span className="block line-height-3"><Emojify className="semi-bold" text={shortMessage(this.props.build.message)} /> <span className="dark-gray">{shortCommit(this.props.build.commit)}</span></span>
                 <small className="dark-gray">{this.renderTime()}</small>
               </Media.Description>
             </Media>
@@ -86,6 +89,7 @@ export default Relay.createContainer(BuildTooltip, {
         startedAt
         finishedAt
         url
+        commit
         createdBy {
           ... on User {
             name

--- a/app/components/shared/Dropdown.js
+++ b/app/components/shared/Dropdown.js
@@ -32,7 +32,7 @@ class Dropdown extends React.Component {
 
   render() {
     return (
-      <span ref={(c) => this.rootNode = c} className={classNames("relative", this.props.className)}>
+      <span ref={(rootNode) => this.rootNode = rootNode} className={classNames("relative", this.props.className)}>
         {this.props.children[0]}
         <ReactCSSTransitionGroup transitionName="transition-popup" transitionEnterTimeout={200} transitionLeaveTimeout={200}>
           {this.renderPopupNode()}
@@ -44,13 +44,13 @@ class Dropdown extends React.Component {
   renderPopupNode() {
     if (this.state.showing) {
       const classes = classNames("absolute mt1 bg-white rounded-2 shadow border border-gray block py1 transition-popup", {
-        "transition-popup-t": this.props.align == "center",
-        "transition-popup-tl": this.props.align == "left",
-        "transition-popup-tr": this.props.align == "right"
+        "transition-popup-t": this.props.align === "center",
+        "transition-popup-tl": this.props.align === "left",
+        "transition-popup-tr": this.props.align === "right"
       });
 
       return (
-        <div ref={(c) => this.popupNode = c} className={classes} style={this.popupPositionStyles()}>
+        <div ref={(popupNode) => this.popupNode = popupNode} className={classes} style={this.popupPositionStyles()}>
           <img src={require('../../images/up-pointing-white-nib.svg')} width={32} height={20} alt="" className="pointer-events-none" style={this.nibPositionStyles()} />
           {this.popupItems()}
         </div>
@@ -65,11 +65,11 @@ class Dropdown extends React.Component {
       zIndex: 3
     };
 
-    if (this.props.align == 'right') {
+    if (this.props.align === 'right') {
       styles.right = 3;
-    } else if (this.props.align == 'left') {
+    } else if (this.props.align === 'left') {
       styles.left = 3;
-    } else if (this.props.align == 'center') {
+    } else if (this.props.align === 'center') {
       const center = styles.width / 2;
       styles.left = `calc(50% - ${center}px)`;
     }
@@ -85,11 +85,11 @@ class Dropdown extends React.Component {
       zIndex: 3
     };
 
-    if (this.props.align == 'right') {
+    if (this.props.align === 'right') {
       styles.right = 10;
-    } else if (this.props.align == 'left') {
+    } else if (this.props.align === 'left') {
       styles.left = 10;
-    } else if (this.props.align == 'center') {
+    } else if (this.props.align === 'center') {
       styles.left = '50%';
       styles.marginLeft = (styles.width / 2) * -1 + this.props.nibOffset;
     }
@@ -121,7 +121,7 @@ class Dropdown extends React.Component {
 
   handleDocumentKeyDown = (event) => {
     // Handle the escape key
-    if (this.state.showing && event.keyCode == 27) {
+    if (this.state.showing && event.keyCode === 27) {
       this.setShowing(false);
     }
   };

--- a/app/components/user/BuildsDropdown/build.js
+++ b/app/components/user/BuildsDropdown/build.js
@@ -6,6 +6,8 @@ import Emojify from '../../shared/Emojify';
 import PusherStore from '../../../stores/PusherStore';
 import BuildState from '../../icons/BuildState';
 
+import { shortMessage, shortCommit } from '../../../lib/commits';
+
 class BuildsDropdownBuild extends React.Component {
   static propTypes = {
     build: React.PropTypes.object,
@@ -25,32 +27,23 @@ class BuildsDropdownBuild extends React.Component {
   }
 
   render() {
-    const commitClassName = this.state.hover ? "lime" : "dark-gray";
+    const messageClassName = `semi-bold ${this.state.hover ? 'lime' : 'black'}`;
 
     return (
-      <div className="flex mb2" style={{ fontSize: 12 }}>
-        <a href={this.props.build.url} className="pr2">
-          <div>
-            <BuildState state={this.props.build.state} size={'small'} />
+      <div>
+        <a href={this.props.build.url} className="flex text-decoration-none dark-gray hover-lime mb2" onMouseOver={this.handleMouseOver} onMouseOut={this.handleMouseOut}>
+          <div className="pr2">
+            <BuildState state={this.props.build.state} size="small" />
+          </div>
+          <div className="flex-auto line-height-2">
+            <span className="line-height-3 block">
+              <Emojify className={messageClassName} text={shortMessage(this.props.build.message)} /> {shortCommit(this.props.build.commit)}
+            </span>
+            <small className="block">{this.props.build.organization.name} / {this.props.build.pipeline.name}</small>
           </div>
         </a>
-        <div className="flex-auto">
-          <a href={this.props.build.url} className="mb1 black text-decoration-none hover-lime block" onMouseOver={this.handleMouseOver} onMouseOut={this.handleMouseOut}>
-            <Emojify text={this.props.build.message} /> <span className={commitClassName}>{this.shortCommit(this.props.build.commit)}</span>
-          </a>
-          <a href={`/${this.props.build.organization.slug}/${this.props.build.pipeline.slug}`} className="dark-gray text-decoration-none hover-navy">{this.props.build.organization.name} / {this.props.build.pipeline.name}</a>
-        </div>
       </div>
     );
-  }
-
-  shortCommit(commit) {
-    // Does this commit look like a git sha?
-    if (commit && commit.length == 40) {
-      return commit.substring(0, 7);
-    } else {
-      return commit;
-    }
   }
 
   handleMouseOver = () => {

--- a/app/components/user/BuildsDropdown/index.js
+++ b/app/components/user/BuildsDropdown/index.js
@@ -74,7 +74,7 @@ class BuildsDropdownIndex extends React.Component {
 
   handlePusherWebsocketEvent = (payload) => {
     // Only do a relay update of the builds count changes
-    if (this._buildsCount != payload.buildsCount) {
+    if (this._buildsCount !== payload.buildsCount) {
       this.props.relay.forceFetch();
     }
 

--- a/app/lib/__snapshots__/commits.spec.js.snap
+++ b/app/lib/__snapshots__/commits.spec.js.snap
@@ -1,0 +1,9 @@
+exports[`shortCommit returns a 7-character SHA1 for a full SHA1 commitish 1`] = `"be9c03b"`;
+
+exports[`shortCommit returns the full name for a 40-character non-SHA1 commitish 1`] = `"so-this-is-a-forty-character-branch-name"`;
+
+exports[`shortCommit returns the full name for a non-SHA1 commitish 1`] = `"preload-pipeline-names-sperlunking"`;
+
+exports[`shortMessage returns the first line of a multi-line message 1`] = `"✨ Somehow this is the first spec I\'ve written for our front-end, and this seems really odd to me"`;
+
+exports[`shortMessage returns the whole message in a one-line message 1`] = `"Bump frontend"`;

--- a/app/lib/commits.js
+++ b/app/lib/commits.js
@@ -1,0 +1,12 @@
+export function shortMessage(message) {
+  return message.split("\n")[0];
+}
+
+export function shortCommit(commitish) {
+  // Does this look like a git sha?
+  if (commitish && commitish.length === 40) {
+    return commitish.substring(0, 7);
+  } else {
+    return commitish;
+  }
+}

--- a/app/lib/commits.js
+++ b/app/lib/commits.js
@@ -4,7 +4,7 @@ export function shortMessage(message) {
 
 export function shortCommit(commitish) {
   // Does this look like a git sha?
-  if (commitish && commitish.length === 40) {
+  if (commitish && commitish.length === 40 && !commitish.match(/[^a-f0-9]/i)) {
     return commitish.substring(0, 7);
   } else {
     return commitish;

--- a/app/lib/commits.spec.js
+++ b/app/lib/commits.spec.js
@@ -1,0 +1,30 @@
+/* global describe, test, expect */
+import { shortMessage, shortCommit } from './commits';
+
+describe('shortMessage', () => {
+  const BIG_MESSAGE = `✨ Somehow this is the first spec I've written for our front-end, and this seems really odd to me
+
+- this should be a big enough message to make sure we're not running into anything silly`;
+
+  test('returns the first line of a multi-line message', () => {
+    expect(shortMessage(BIG_MESSAGE)).toMatchSnapshot();
+  });
+
+  test('returns the whole message in a one-line message', () => {
+    expect(shortMessage('Bump frontend')).toMatchSnapshot();
+  });
+});
+
+describe('shortCommit', () => {
+  test('returns a 7-character SHA1 for a full SHA1 commitish', () => {
+    expect(shortCommit('be9c03b0dbddafccb0882f62182b84924579c93b')).toMatchSnapshot();
+  });
+
+  test('returns the full name for a non-SHA1 commitish', () => {
+    expect(shortCommit('preload-pipeline-names-sperlunking')).toMatchSnapshot();
+  });
+
+  test('returns the full name for a 40-character non-SHA1 commitish', () => {
+    expect(shortCommit('so-this-is-a-forty-character-branch-name')).toMatchSnapshot();
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,7 @@ services:
     volumes:
       - "./dist:/frontend/dist"
     environment:
-      FRONTEND_HOST:
+      BUILDKITE:
+      CI:
       EMOJI_HOST:
+      FRONTEND_HOST:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,5 +1,15 @@
 {
   "dependencies": {
+    "abab": {
+      "version": "1.0.3",
+      "from": "abab@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz"
+    },
+    "abbrev": {
+      "version": "1.0.9",
+      "from": "abbrev@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+    },
     "accepts": {
       "version": "1.3.3",
       "from": "accepts@>=1.3.3 <1.4.0",
@@ -21,6 +31,18 @@
       "version": "3.3.0",
       "from": "acorn@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "from": "acorn-globals@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@^2.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        }
+      }
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -57,10 +79,20 @@
       "from": "ansi-styles@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
+    "ansicolors": {
+      "version": "0.2.1",
+      "from": "ansicolors@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+    },
     "anymatch": {
       "version": "1.3.0",
       "from": "anymatch@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
+    },
+    "append-transform": {
+      "version": "0.3.0",
+      "from": "append-transform@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz"
     },
     "archive-type": {
       "version": "3.2.0",
@@ -86,6 +118,11 @@
       "version": "1.0.0",
       "from": "array-differ@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "from": "array-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
     },
     "array-find-index": {
       "version": "1.0.1",
@@ -330,6 +367,11 @@
       "from": "babel-helpers@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz"
     },
+    "babel-jest": {
+      "version": "16.0.0",
+      "from": "babel-jest@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-16.0.0.tgz"
+    },
     "babel-loader": {
       "version": "6.2.5",
       "from": "babel-loader@6.2.5",
@@ -344,6 +386,16 @@
       "version": "6.8.0",
       "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
+    },
+    "babel-plugin-istanbul": {
+      "version": "2.0.1",
+      "from": "babel-plugin-istanbul@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.1.tgz"
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "16.0.0",
+      "from": "babel-plugin-jest-hoist@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-16.0.0.tgz"
     },
     "babel-plugin-react-pure-components": {
       "version": "2.2.2",
@@ -735,6 +787,11 @@
         }
       }
     },
+    "babel-preset-jest": {
+      "version": "16.0.0",
+      "from": "babel-preset-jest@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-16.0.0.tgz"
+    },
     "babel-preset-react": {
       "version": "6.11.1",
       "from": "babel-preset-react@6.11.1",
@@ -967,6 +1024,11 @@
       "from": "braces@>=1.8.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
     },
+    "browser-resolve": {
+      "version": "1.11.2",
+      "from": "browser-resolve@>=1.11.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
+    },
     "browserify-zlib": {
       "version": "0.1.4",
       "from": "browserify-zlib@>=0.1.4 <0.2.0",
@@ -1061,6 +1123,11 @@
       "from": "capture-stack-trace@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
     },
+    "cardinal": {
+      "version": "1.0.0",
+      "from": "cardinal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz"
+    },
     "caseless": {
       "version": "0.9.0",
       "from": "caseless@>=0.9.0 <0.10.0",
@@ -1112,6 +1179,23 @@
       "version": "1.0.2",
       "from": "cli-cursor@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "from": "cli-table@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "from": "colors@1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+        }
+      }
+    },
+    "cli-usage": {
+      "version": "0.1.4",
+      "from": "cli-usage@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz"
     },
     "cli-width": {
       "version": "2.1.0",
@@ -1344,6 +1428,16 @@
       "from": "csso@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.0.0.tgz"
     },
+    "cssom": {
+      "version": "0.3.1",
+      "from": "cssom@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz"
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "from": "cssstyle@>=0.2.36 <0.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz"
+    },
     "ctype": {
       "version": "0.5.3",
       "from": "ctype@0.5.3",
@@ -1541,6 +1635,11 @@
         }
       }
     },
+    "diff": {
+      "version": "3.0.0",
+      "from": "diff@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.0.0.tgz"
+    },
     "doctrine": {
       "version": "1.2.2",
       "from": "doctrine@>=1.2.2 <2.0.0",
@@ -1701,6 +1800,23 @@
       "version": "1.0.5",
       "from": "escape-string-regexp@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "from": "escodegen@>=1.8.0 <1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "from": "source-map@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+        }
+      }
     },
     "escope": {
       "version": "3.6.0",
@@ -1961,6 +2077,23 @@
       "version": "1.2.1",
       "from": "filenamify@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz"
+    },
+    "fileset": {
+      "version": "0.2.1",
+      "from": "fileset@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+        }
+      }
     },
     "fill-range": {
       "version": "2.2.3",
@@ -2693,6 +2826,11 @@
       "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
+    },
     "get-proxy": {
       "version": "1.1.0",
       "from": "get-proxy@>=1.0.1 <2.0.0",
@@ -2802,6 +2940,11 @@
       "from": "graphql-relay@0.4.3",
       "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.4.3.tgz"
     },
+    "growly": {
+      "version": "1.3.0",
+      "from": "growly@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz"
+    },
     "gulp-decompress": {
       "version": "1.2.0",
       "from": "gulp-decompress@>=1.2.0 <2.0.0",
@@ -2860,6 +3003,23 @@
       "version": "1.0.0",
       "from": "gulplog@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
+    },
+    "handlebars": {
+      "version": "4.0.5",
+      "from": "handlebars@>=4.0.3 <5.0.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@^1.4.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.4 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
     },
     "har-validator": {
       "version": "1.8.0",
@@ -3099,6 +3259,11 @@
       "from": "invariant@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
     },
+    "invert-kv": {
+      "version": "1.0.0",
+      "from": "invert-kv@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+    },
     "ip-regex": {
       "version": "1.0.3",
       "from": "ip-regex@>=1.0.1 <2.0.0",
@@ -3148,6 +3313,11 @@
       "version": "1.0.0",
       "from": "is-bzip2@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+    },
+    "is-ci": {
+      "version": "1.0.9",
+      "from": "is-ci@>=1.0.9 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.9.tgz"
     },
     "is-dotfile": {
       "version": "1.0.2",
@@ -3354,10 +3524,261 @@
       "from": "isstream@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
+    "istanbul": {
+      "version": "0.4.5",
+      "from": "istanbul@>=0.4.5 <0.5.0",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@1.x",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@^5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@^3.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        }
+      }
+    },
+    "istanbul-api": {
+      "version": "1.0.0-aplha.10",
+      "from": "istanbul-api@>=1.0.0-aplha.10 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.0.0-aplha.10.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        }
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "1.0.0",
+      "from": "istanbul-lib-coverage@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz"
+    },
+    "istanbul-lib-hook": {
+      "version": "1.0.0-alpha.4",
+      "from": "istanbul-lib-hook@>=1.0.0-alpha <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.4.tgz"
+    },
+    "istanbul-lib-instrument": {
+      "version": "1.1.3",
+      "from": "istanbul-lib-instrument@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.3.tgz"
+    },
+    "istanbul-lib-report": {
+      "version": "1.0.0-alpha.3",
+      "from": "istanbul-lib-report@>=1.0.0-alpha <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@^1.4.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@>=3.1.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "1.0.2",
+      "from": "istanbul-lib-source-maps@>=1.0.0-alpha <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.2.tgz"
+    },
+    "istanbul-reports": {
+      "version": "1.0.0-alpha.8",
+      "from": "istanbul-reports@>=1.0.0-alpha <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0-alpha.8.tgz"
+    },
     "iterall": {
       "version": "1.0.2",
       "from": "iterall@1.0.2",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.0.2.tgz"
+    },
+    "jasmine-check": {
+      "version": "0.1.5",
+      "from": "jasmine-check@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jasmine-check/-/jasmine-check-0.1.5.tgz"
+    },
+    "jest": {
+      "version": "16.0.0",
+      "from": "jest@latest",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-16.0.0.tgz",
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "from": "callsites@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz"
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "from": "cliui@^3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.9",
+          "from": "graceful-fs@>=4.1.6 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+        },
+        "jest-cli": {
+          "version": "16.0.0",
+          "from": "jest-cli@>=16.0.0 <17.0.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-16.0.0.tgz"
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "from": "lodash.assign@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "from": "window-size@^0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+        },
+        "yargs": {
+          "version": "5.0.0",
+          "from": "yargs@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz"
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "16.0.0",
+      "from": "jest-changed-files@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-16.0.0.tgz"
+    },
+    "jest-config": {
+      "version": "16.0.0",
+      "from": "jest-config@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-16.0.0.tgz"
+    },
+    "jest-diff": {
+      "version": "16.0.0",
+      "from": "jest-diff@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-16.0.0.tgz"
+    },
+    "jest-environment-jsdom": {
+      "version": "16.0.0",
+      "from": "jest-environment-jsdom@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-16.0.0.tgz"
+    },
+    "jest-environment-node": {
+      "version": "16.0.0",
+      "from": "jest-environment-node@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-16.0.0.tgz"
+    },
+    "jest-file-exists": {
+      "version": "15.0.0",
+      "from": "jest-file-exists@>=15.0.0 <16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-15.0.0.tgz"
+    },
+    "jest-haste-map": {
+      "version": "16.0.0",
+      "from": "jest-haste-map@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-16.0.0.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.9",
+          "from": "graceful-fs@^4.1.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+        }
+      }
+    },
+    "jest-jasmine2": {
+      "version": "16.0.0",
+      "from": "jest-jasmine2@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-16.0.0.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.9",
+          "from": "graceful-fs@^4.1.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+        }
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "16.0.0",
+      "from": "jest-matcher-utils@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-16.0.0.tgz"
+    },
+    "jest-matchers": {
+      "version": "16.0.0",
+      "from": "jest-matchers@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-16.0.0.tgz"
+    },
+    "jest-mock": {
+      "version": "16.0.0",
+      "from": "jest-mock@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-16.0.0.tgz"
+    },
+    "jest-resolve": {
+      "version": "16.0.0",
+      "from": "jest-resolve@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-16.0.0.tgz"
+    },
+    "jest-resolve-dependencies": {
+      "version": "16.0.0",
+      "from": "jest-resolve-dependencies@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-16.0.0.tgz"
+    },
+    "jest-runtime": {
+      "version": "16.0.0",
+      "from": "jest-runtime@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-16.0.0.tgz",
+      "dependencies": {
+        "cliui": {
+          "version": "3.2.0",
+          "from": "cliui@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.9",
+          "from": "graceful-fs@^4.1.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "from": "lodash.assign@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "from": "window-size@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+        },
+        "yargs": {
+          "version": "5.0.0",
+          "from": "yargs@^5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz"
+        }
+      }
+    },
+    "jest-snapshot": {
+      "version": "16.0.0",
+      "from": "jest-snapshot@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-16.0.0.tgz"
+    },
+    "jest-util": {
+      "version": "16.0.0",
+      "from": "jest-util@>=16.0.0 <17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-16.0.0.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.9",
+          "from": "graceful-fs@^4.1.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+        }
+      }
     },
     "jodid25519": {
       "version": "1.0.2",
@@ -3388,6 +3809,18 @@
       "version": "0.1.0",
       "from": "jsbn@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+    },
+    "jsdom": {
+      "version": "9.6.0",
+      "from": "jsdom@>=9.5.0 <10.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.6.0.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        }
+      }
     },
     "jsesc": {
       "version": "0.5.0",
@@ -3619,6 +4052,11 @@
       "from": "lazystream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
     },
+    "lcid": {
+      "version": "1.0.0",
+      "from": "lcid@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+    },
     "levn": {
       "version": "0.3.0",
       "from": "levn@>=0.3.0 <0.4.0",
@@ -3679,6 +4117,11 @@
       "version": "3.2.0",
       "from": "lodash._baseassign@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -3759,6 +4202,11 @@
       "version": "3.0.1",
       "from": "lodash.camelcase@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz"
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2",
+      "from": "lodash.clonedeep@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz"
     },
     "lodash.deburr": {
       "version": "3.2.0",
@@ -3952,6 +4400,23 @@
       "from": "map-obj@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
+    "marked": {
+      "version": "0.3.6",
+      "from": "marked@>=0.3.6 <0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz"
+    },
+    "marked-terminal": {
+      "version": "1.6.2",
+      "from": "marked-terminal@>=1.6.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.6.2.tgz",
+      "dependencies": {
+        "lodash.assign": {
+          "version": "4.2.0",
+          "from": "lodash.assign@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+        }
+      }
+    },
     "math-expression-evaluator": {
       "version": "1.2.14",
       "from": "math-expression-evaluator@>=1.2.14 <2.0.0",
@@ -4049,6 +4514,11 @@
       "from": "ms@0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
+    "multimatch": {
+      "version": "2.1.0",
+      "from": "multimatch@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz"
+    },
     "multipipe": {
       "version": "0.1.2",
       "from": "multipipe@>=0.1.2 <0.2.0",
@@ -4101,6 +4571,11 @@
       "from": "netrc@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz"
     },
+    "node-emoji": {
+      "version": "1.4.1",
+      "from": "node-emoji@>=1.3.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.1.tgz"
+    },
     "node-fetch": {
       "version": "1.6.1",
       "from": "node-fetch@>=1.0.1 <2.0.0",
@@ -4133,6 +4608,18 @@
         }
       }
     },
+    "node-notifier": {
+      "version": "4.6.1",
+      "from": "node-notifier@>=4.6.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        }
+      }
+    },
     "node-status-codes": {
       "version": "1.0.0",
       "from": "node-status-codes@>=1.0.0 <2.0.0",
@@ -4152,6 +4639,11 @@
       "version": "1.2.3",
       "from": "node.flow@1.2.3",
       "resolved": "https://registry.npmjs.org/node.flow/-/node.flow-1.2.3.tgz"
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "from": "nopt@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.5",
@@ -4187,6 +4679,11 @@
       "version": "1.0.0",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+    },
+    "nwmatcher": {
+      "version": "1.3.8",
+      "from": "nwmatcher@>=1.3.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.8.tgz"
     },
     "oauth-sign": {
       "version": "0.6.0",
@@ -4292,6 +4789,11 @@
       "from": "os-homedir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
     },
+    "os-locale": {
+      "version": "1.4.0",
+      "from": "os-locale@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+    },
     "os-tmpdir": {
       "version": "1.0.1",
       "from": "os-tmpdir@>=1.0.1 <2.0.0",
@@ -4339,6 +4841,11 @@
       "from": "parse-json@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
+    "parse5": {
+      "version": "1.5.1",
+      "from": "parse5@>=1.5.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
+    },
     "parseurl": {
       "version": "1.3.1",
       "from": "parseurl@>=1.3.1 <1.4.0",
@@ -4368,6 +4875,11 @@
       "version": "1.0.0",
       "from": "path-key@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz"
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "from": "path-parse@>=1.0.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
     },
     "path-root": {
       "version": "0.1.1",
@@ -4885,6 +5397,11 @@
       "from": "preserve@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
+    "pretty-format": {
+      "version": "4.2.1",
+      "from": "pretty-format@>=4.2.1 <4.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.2.1.tgz"
+    },
     "private": {
       "version": "0.1.6",
       "from": "private@>=0.1.6 <0.2.0",
@@ -5173,6 +5690,11 @@
       "from": "redent@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
+    "redeyed": {
+      "version": "1.0.0",
+      "from": "redeyed@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.0.tgz"
+    },
     "reduce-css-calc": {
       "version": "1.2.4",
       "from": "reduce-css-calc@>=1.2.0 <2.0.0",
@@ -5333,6 +5855,16 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
         }
       }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "from": "require-directory@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
     },
     "require-uncached": {
       "version": "1.0.2",
@@ -5502,6 +6034,11 @@
       "from": "serve-static@>=1.11.1 <1.12.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "from": "set-blocking@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "from": "set-immediate-shim@>=1.0.0 <2.0.0",
@@ -5526,6 +6063,11 @@
       "version": "0.6.1",
       "from": "shelljs@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz"
+    },
+    "shellwords": {
+      "version": "0.1.0",
+      "from": "shellwords@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz"
     },
     "signal-exit": {
       "version": "3.0.0",
@@ -5712,6 +6254,11 @@
       "from": "string-width@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
     },
+    "string.prototype.codepointat": {
+      "version": "0.2.0",
+      "from": "string.prototype.codepointat@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz"
+    },
     "stringstream": {
       "version": "0.0.5",
       "from": "stringstream@>=0.0.4 <0.1.0",
@@ -5791,6 +6338,11 @@
       "from": "svgo@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz"
     },
+    "symbol-tree": {
+      "version": "3.1.4",
+      "from": "symbol-tree@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz"
+    },
     "systemjs": {
       "version": "0.19.36",
       "from": "systemjs@0.19.36",
@@ -5831,10 +6383,25 @@
       "from": "tempfile@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz"
     },
+    "test-exclude": {
+      "version": "2.1.3",
+      "from": "test-exclude@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.3.tgz"
+    },
+    "testcheck": {
+      "version": "0.1.4",
+      "from": "testcheck@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/testcheck/-/testcheck-0.1.4.tgz"
+    },
     "text-table": {
       "version": "0.2.0",
       "from": "text-table@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+    },
+    "throat": {
+      "version": "3.0.0",
+      "from": "throat@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-3.0.0.tgz"
     },
     "through": {
       "version": "2.3.8",
@@ -5911,6 +6478,11 @@
       "version": "2.3.1",
       "from": "tough-cookie@>=0.12.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "from": "tr46@>=0.0.3 <0.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
     },
     "traceur": {
       "version": "0.0.105",
@@ -6192,6 +6764,11 @@
       "from": "watchpack@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz"
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "from": "webidl-conversions@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+    },
     "webpack": {
       "version": "1.13.2",
       "from": "webpack@1.13.2",
@@ -6277,6 +6854,11 @@
       "from": "whatwg-fetch@1.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz"
     },
+    "whatwg-url": {
+      "version": "3.0.0",
+      "from": "whatwg-url@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.0.0.tgz"
+    },
     "when": {
       "version": "3.7.7",
       "from": "when@>=3.7.5 <4.0.0",
@@ -6292,6 +6874,11 @@
       "from": "which@>=1.2.8 <2.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
     },
+    "which-module": {
+      "version": "1.0.0",
+      "from": "which-module@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+    },
     "window-size": {
       "version": "0.1.0",
       "from": "window-size@0.1.0",
@@ -6301,6 +6888,16 @@
       "version": "1.0.0",
       "from": "wordwrap@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+    },
+    "worker-farm": {
+      "version": "1.3.1",
+      "from": "worker-farm@>=1.3.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz"
+    },
+    "wrap-ansi": {
+      "version": "2.0.0",
+      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
     },
     "wrap-fn": {
       "version": "0.1.5",
@@ -6317,6 +6914,11 @@
       "from": "write@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
     },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "from": "xml-name-validator@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+    },
     "xmlhttprequest": {
       "version": "1.8.0",
       "from": "xmlhttprequest@>=1.8.0 <2.0.0",
@@ -6332,6 +6934,11 @@
       "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
+    "y18n": {
+      "version": "3.2.1",
+      "from": "y18n@>=3.2.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+    },
     "yallist": {
       "version": "2.0.0",
       "from": "yallist@>=2.0.0 <3.0.0",
@@ -6341,6 +6948,23 @@
       "version": "3.10.0",
       "from": "yargs@>=3.10.0 <3.11.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+    },
+    "yargs-parser": {
+      "version": "3.2.0",
+      "from": "yargs-parser@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "from": "lodash.assign@^4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+        }
+      }
     },
     "yauzl": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "env": "env",
     "start": "NODE_ENV=development webpack-dev-server --config webpack/config.js --progress --colors --cache --inline --hot --port 4890",
+    "test": "jest",
     "lint": "eslint .",
     "lint-and-fix": "eslint --fix .",
     "build": "NODE_ENV=development webpack --config webpack/config.js --progress --bail",
@@ -40,6 +41,7 @@
     "file-loader": "^0.9.0",
     "image-webpack-loader": "^2.0.0",
     "imports-loader": "^0.6.5",
+    "jest": "^16.0.0",
     "postcss": "^5.1.2",
     "postcss-browser-reporter": "^0.5.0",
     "postcss-cssnext": "^2.7.0",


### PR DESCRIPTION
This brings the my builds dropdown and build tooltip into line with each other.

Both now have a semi-bold first-line of commit message displayed, as well as the shortened commit-ish, and use consistent colours and sizes.

<img width="277" alt="screen shot 2016-10-03 at 4 09 28 pm" src="https://cloud.githubusercontent.com/assets/282113/19028104/d8b7b038-8983-11e6-9760-e3694cf69d2b.png">

<img width="250" alt="screen shot 2016-10-03 at 4 10 27 pm" src="https://cloud.githubusercontent.com/assets/282113/19028106/eae63216-8983-11e6-836a-2f9d979df512.png">

This branch also;

- fixes some ESLint warnings
- breaks out some repeated commit metadata handling into a shared function library