### PR TITLE
Replace unicode down triangles with real icons

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -83,9 +83,7 @@ class Navigation extends React.Component {
                 <span className="truncate" style={{ maxWidth: "10em" }}>
                   {this._organizationSelectorLabel()}
                 </span>
-                <span className="ml1">
-                  &#9662;
-                </span>
+                <Icon icon="down-triangle" style={{ width: 7, height: 7, marginLeft: '.5em' }} />
               </DropdownButton>
               {this._organizationsList()}
             </Dropdown>
@@ -102,10 +100,10 @@ class Navigation extends React.Component {
               <DropdownButton className={classNames({ "lime": this.state.showingUserDropdown })}
                 style={{ paddingRight: 0 }}
               >
-                <UserAvatar user={this.props.viewer.user} className="flex-none flex items-center mr1" style={{ width: 26, height: 26 }} />
-                <span className="flex items-center xs-hide"><span className="truncate" style={{ maxWidth: "9em" }} data-current-user-name={true}>{this.props.viewer.user.name}</span></span>
-                <span className="ml1 flex items-center">
-                  &#9662;
+                <UserAvatar user={this.props.viewer.user} className="flex-none flex items-center" style={{ width: 26, height: 26 }} />
+                <span className="flex items-center xs-hide ml1"><span className="truncate" style={{ maxWidth: "9em" }} data-current-user-name={true}>{this.props.viewer.user.name}</span></span>
+                <span className="flex items-center">
+                  <Icon icon="down-triangle" style={{ width: 7, height: 7, marginLeft: '.5em' }} />
                 </span>
               </DropdownButton>
 

--- a/app/components/organization/Teams.js
+++ b/app/components/organization/Teams.js
@@ -4,6 +4,7 @@ import Relay from 'react-relay';
 import Dropdown from '../shared/Dropdown';
 import Chooser from '../shared/Chooser';
 import Emojify from '../shared/Emojify';
+import Icon from '../shared/Icon';
 
 class Teams extends React.Component {
   static propTypes = {
@@ -15,9 +16,13 @@ class Teams extends React.Component {
   render() {
     return (
       <Dropdown align="center" width={300} ref={(c) => this.dropdownNode = c}>
-        <button className="h4 p0 m0 light dark-gray inline-block btn flex" style={{ marginTop: 3, fontSize: 16 }}>
-          <span className="flex items-center"><span className="truncate">{this.renderLabel()}</span></span>
-          <span className="ml2 flex items-center">&#9662;</span>
+        <button className="h4 p0 m0 light dark-gray inline-block btn" style={{ marginTop: 3, fontSize: 16 }}>
+          <div className="flex">
+            <span className="flex items-center"><span className="truncate">{this.renderLabel()}</span></span>
+            <span className="flex items-center">
+              <Icon icon="down-triangle" style={{ width: 8, height: 8, marginLeft: '.5em' }} />
+            </span>
+          </div>
         </button>
 
         <Chooser selected={null} onSelect={this.handleDropdownSelect}>

--- a/app/components/shared/Icon/down-triangle.js
+++ b/app/components/shared/Icon/down-triangle.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default (
+  <g transform="translate(0,5)">
+    <polygon points="0,0 20,0 10,15" fill="currentColor" />
+  </g>
+);

--- a/app/components/shared/Icon/index.js
+++ b/app/components/shared/Icon/index.js
@@ -35,6 +35,8 @@ const pathNodes = (icon) => {
       return require("./github").default;
     case 'twitter':
       return require("./twitter").default;
+    case 'down-triangle':
+      return require("./down-triangle").default;
     case 'chevron-right':
       return require("./chevron-right").default;
     case 'teams':


### PR DESCRIPTION
I went to fix this Firefox bug:

<img width="291" alt="firefox-before" src="https://cloud.githubusercontent.com/assets/153/19101705/2bb6c66e-8b16-11e6-82db-6d1274b4a6bc.png">

and then I accidentally fixed all the dropdown triangles to be nicer than unicode:

<img width="297" alt="and-then" src="https://cloud.githubusercontent.com/assets/153/19101707/3a43a878-8b16-11e6-974f-e460283a2e35.png">

They also look nice on mobile now too:

![mobile-triangles](https://cloud.githubusercontent.com/assets/153/19101888/6a6bd646-8b17-11e6-9d9e-8c527a5f18ab.png)
