### PR TITLE
Fix overflow issue with long build names that don't have spaces

### DIFF
--- a/app/components/organization/Pipeline/build-tooltip.js
+++ b/app/components/organization/Pipeline/build-tooltip.js
@@ -45,8 +45,10 @@ class BuildTooltip extends React.Component {
                 <UserAvatar user={this.props.build.createdBy} className="block fit" />
                 <small className="dark-gray"><Duration.Micro {...buildTime(this.props.build)} /></small>
               </Media.Image>
-              <Media.Description className="line-height-2">
-                <span className="block line-height-3"><Emojify className="semi-bold" text={shortMessage(this.props.build.message)} /> <span className="dark-gray">{shortCommit(this.props.build.commit)}</span></span>
+              <Media.Description className="flex-auto line-height-2">
+                <span className="block line-height-3 overflow-hidden overflow-ellipsis">
+                  <Emojify className="semi-bold" text={shortMessage(this.props.build.message)} /> <span className="dark-gray">{shortCommit(this.props.build.commit)}</span>
+                </span>
                 <small className="dark-gray"><BuildStatusDescription build={this.props.build} updateFrequency={0} /></small>
               </Media.Description>
             </Media>

--- a/app/components/user/BuildsDropdown/build.js
+++ b/app/components/user/BuildsDropdown/build.js
@@ -39,7 +39,7 @@ class BuildsDropdownBuild extends React.Component {
             <small><Duration.Micro className="dark-gray" {...buildTime(this.props.build)} /></small>
           </div>
           <div className="flex-auto line-height-2">
-            <span className="line-height-3 block text-overflow-ellipsis">
+            <span className="block line-height-3 overflow-hidden overflow-ellipsis">
               <Emojify className={messageClassName} text={shortMessage(this.props.build.message)} /> {shortCommit(this.props.build.commit)}
             </span>
             <small className="block">{this.props.build.organization.name} / {this.props.build.pipeline.name}</small>

--- a/app/components/user/BuildsDropdown/build.js
+++ b/app/components/user/BuildsDropdown/build.js
@@ -39,7 +39,7 @@ class BuildsDropdownBuild extends React.Component {
             <small><Duration.Micro className="dark-gray" {...buildTime(this.props.build)} /></small>
           </div>
           <div className="flex-auto line-height-2">
-            <span className="line-height-3 block">
+            <span className="line-height-3 block text-overflow-ellipsis">
               <Emojify className={messageClassName} text={shortMessage(this.props.build.message)} /> {shortCommit(this.props.build.commit)}
             </span>
             <small className="block">{this.props.build.organization.name} / {this.props.build.pipeline.name}</small>

--- a/app/css/text.css
+++ b/app/css/text.css
@@ -6,8 +6,7 @@
   border-bottom: 1px dashed currentColor;
 }
 
-.text-overflow-ellipsis {
-  overflow: hidden;
+.overflow-ellipsis {
   text-overflow: ellipsis;
 }
 

--- a/app/css/text.css
+++ b/app/css/text.css
@@ -6,6 +6,11 @@
   border-bottom: 1px dashed currentColor;
 }
 
+.text-overflow-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 @media (--breakpoint-sm) {
   .sm-right-align { text-align: right !important }
 }


### PR DESCRIPTION
BEFORE 
<img width="438" alt="screen shot 2016-10-05 at 7 38 21 am" src="https://cloud.githubusercontent.com/assets/145505/19111837/a9b2967a-8acf-11e6-9d81-b71aed605fa7.png">

AFTER
<img width="434" alt="screen shot 2016-10-05 at 7 38 31 am" src="https://cloud.githubusercontent.com/assets/145505/19111840/abc7802e-8acf-11e6-984d-3dd063782835.png">