### PR TITLE
Isolate BuildState icon SVG element references

### DIFF
--- a/app/components/icons/BuildState.js
+++ b/app/components/icons/BuildState.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import shallowCompare from 'react-addons-shallow-compare';
+import { v4 as uuid } from 'uuid';
 
 const SIZE_DEFINITIONS = {
   regular: {
@@ -50,6 +51,16 @@ class BuildState extends React.Component {
     size: 'regular'
   };
 
+  state = {
+    uuid: ''
+  };
+
+  componentWillMount() {
+    this.setState({
+      uuid: uuid()
+    });
+  }
+
   shouldComponentUpdate(nextProps, nextState) {
     return shallowCompare(this, nextProps, nextState);
   }
@@ -59,17 +70,18 @@ class BuildState extends React.Component {
     const strokeWidth = sizeDefinition.strokeWidth || 2;
     const size = sizeDefinition.size || 32;
 
-    const circleId = parseInt(Math.random().toString(10).replace('.', ''), 10).toString(36);
+    const outerCircleId = `BuildState_${this.state.uuid}_circle`;
+    const strokeClipPathId = `BuildState_${this.state.uuid}_strokeClipPath`;
 
     return (
       <svg width={size} height={size} viewBox="0 0 32 32" className={this.props.className}>
         <defs>
-          <circle id={`circle_${circleId}`} fill="none" cx="16" cy="16" r="15" stroke={STATE_DEFINITIONS[this.props.state].strokeColor} strokeWidth={strokeWidth * 2} />
-          <clipPath id={`circleClip_${circleId}`}>
-            <use xlinkHref={`#circle_${circleId}`}/>
+          <circle id={outerCircleId} fill="none" cx="16" cy="16" r="15" stroke={STATE_DEFINITIONS[this.props.state].strokeColor} strokeWidth={strokeWidth * 2} />
+          <clipPath id={strokeClipPathId}>
+            <use xlinkHref={`#${outerCircleId}`}/>
           </clipPath>
         </defs>
-        <use xlinkHref={`#circle_${circleId}`} clipPath={`url(#circleClip_${circleId})`} />
+        <use xlinkHref={`#${outerCircleId}`} clipPath={`url(#${strokeClipPathId})`} />
         {this.renderPaths(strokeWidth)}
       </svg>
     );
@@ -88,6 +100,8 @@ class BuildState extends React.Component {
         [STATE_DEFINITIONS[this.props.state] && STATE_DEFINITIONS[this.props.state].animation]: this.props.state && STATE_DEFINITIONS[this.props.state] && STATE_DEFINITIONS[this.props.state].animation
       })
     };
+
+    const maskId = `BuildState_${this.state.uuid}_mask`;
 
     switch (this.props.state) {
       case 'failed':
@@ -121,11 +135,11 @@ class BuildState extends React.Component {
         return (
           <g>
             <defs>
-              <mask id="a" x="9" y="9" width="14" height="14" maskUnits="userSpaceOnUse">
+              <mask id={maskId} x="9" y="9" width="14" height="14" maskUnits="userSpaceOnUse">
                 <polygon points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16" fill="#fff" {...applyAnimation}/>
               </mask>
             </defs>
-            <g mask="url(#a)">
+            <g mask={`url(#${maskId})`}>
               <path d="M16,22a6,6,0,1,0-6-6A6,6,0,0,0,16,22Z" {...applyStroke} />
             </g>
           </g>

--- a/app/components/icons/BuildState.spec.js
+++ b/app/components/icons/BuildState.spec.js
@@ -1,0 +1,57 @@
+/* global describe, it, expect */
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+const SIZES = [
+  'regular',
+  'small'
+];
+
+const BUILD_STATES = [
+  'pending',
+  'scheduled',
+  'running',
+  'passed',
+  'blocked',
+  'failed',
+  'canceled'
+];
+
+describe('BuildState', () => {
+  jest.mock('uuid', () => ({ v4: () => 'NORMALLY-UUID-GOES-HERE-BUTNEVERMIND' }));
+
+  const BuildState = require('./BuildState').default;
+
+  SIZES.forEach((size) => {
+    describe(`where size="${size}"`, () => {
+      BUILD_STATES.forEach((state) => {
+        it(`renders correctly for build state \`${state}\``, () => {
+          const component = ReactTestRenderer.create(
+            <BuildState state={state} size={size} />
+          );
+
+          const tree = component.toJSON();
+          expect(tree).toMatchSnapshot();
+        });
+      });
+    });
+  });
+
+  it(`passes through className`, () => {
+    const component = ReactTestRenderer.create(
+      <BuildState state={BUILD_STATES[0]} size={SIZES[0]} className="some-weird-class-name" />
+    );
+
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it(`has default for \`size\``, () => {
+    const component = ReactTestRenderer.create(
+      <BuildState state={BUILD_STATES[0]} />
+    );
+
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/app/components/icons/BuildState.spec.js
+++ b/app/components/icons/BuildState.spec.js
@@ -1,4 +1,4 @@
-/* global describe, it, expect */
+/* global describe, it, expect, jest */
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 

--- a/app/components/icons/__snapshots__/BuildState.spec.js.snap
+++ b/app/components/icons/__snapshots__/BuildState.spec.js.snap
@@ -1,0 +1,629 @@
+exports[`BuildState has default for \`size\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#cdcccc"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#cdcccc"
+    strokeWidth={2} />
+</svg>
+`;
+
+exports[`BuildState passes through className 1`] = `
+<svg
+  className="some-weird-class-name"
+  height={32}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#cdcccc"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#cdcccc"
+    strokeWidth={2} />
+</svg>
+`;
+
+exports[`BuildState where size="regular" renders correctly for build state \`blocked\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#90c73e"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    fill="none"
+    stroke="#90c73e"
+    strokeWidth={2}>
+    <path
+      d="M13,21V11" />
+    <path
+      d="M19,21V11" />
+  </g>
+</svg>
+`;
+
+exports[`BuildState where size="regular" renders correctly for build state \`canceled\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#F83F23"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    fill="none"
+    stroke="#F83F23"
+    strokeWidth={2}
+    transform="translate(10.000000, 10.000000)">
+    <path
+      d="M0.600275489,0.600275489 L11.3997245,11.3997245" />
+    <path
+      d="M11.3997245,0.600275489 L0.600275489,11.3997245" />
+  </g>
+</svg>
+`;
+
+exports[`BuildState where size="regular" renders correctly for build state \`failed\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#F83F23"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    fill="none"
+    stroke="#F83F23"
+    strokeWidth={2}
+    transform="translate(10.000000, 10.000000)">
+    <path
+      d="M0.600275489,0.600275489 L11.3997245,11.3997245" />
+    <path
+      d="M11.3997245,0.600275489 L0.600275489,11.3997245" />
+  </g>
+</svg>
+`;
+
+exports[`BuildState where size="regular" renders correctly for build state \`passed\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#90c73e"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <polyline
+    fill="none"
+    points="10 17.61 14.38 20.81 21 11.41"
+    stroke="#90c73e"
+    strokeMiterlimit="10"
+    strokeWidth={2} />
+</svg>
+`;
+
+exports[`BuildState where size="regular" renders correctly for build state \`pending\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#cdcccc"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#cdcccc"
+    strokeWidth={2} />
+</svg>
+`;
+
+exports[`BuildState where size="regular" renders correctly for build state \`running\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#fdba12"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+    <mask
+      height="14"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_mask"
+      maskUnits="userSpaceOnUse"
+      width="14"
+      x="9"
+      y="9">
+      <polygon
+        className="animation-spin"
+        fill="#fff"
+        points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
+        style={
+          Object {
+            "transformOrigin": "center",
+          }
+        } />
+    </mask>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    mask="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_mask)">
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      r="6"
+      stroke="#fdba12"
+      strokeWidth={2} />
+  </g>
+</svg>
+`;
+
+exports[`BuildState where size="regular" renders correctly for build state \`scheduled\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#aeaeae"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+    <mask
+      height="14"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_mask"
+      maskUnits="userSpaceOnUse"
+      width="14"
+      x="9"
+      y="9">
+      <polygon
+        className="animation-spin"
+        fill="#fff"
+        points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
+        style={
+          Object {
+            "transformOrigin": "center",
+          }
+        } />
+    </mask>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    mask="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_mask)">
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      r="6"
+      stroke="#aeaeae"
+      strokeWidth={2} />
+  </g>
+</svg>
+`;
+
+exports[`BuildState where size="small" renders correctly for build state \`blocked\` 1`] = `
+<svg
+  className={undefined}
+  height={20}
+  viewBox="0 0 32 32"
+  width={20}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#90c73e"
+      strokeWidth={6} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    fill="none"
+    stroke="#90c73e"
+    strokeWidth={3}>
+    <path
+      d="M13,21V11" />
+    <path
+      d="M19,21V11" />
+  </g>
+</svg>
+`;
+
+exports[`BuildState where size="small" renders correctly for build state \`canceled\` 1`] = `
+<svg
+  className={undefined}
+  height={20}
+  viewBox="0 0 32 32"
+  width={20}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#F83F23"
+      strokeWidth={6} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    fill="none"
+    stroke="#F83F23"
+    strokeWidth={3}
+    transform="translate(10.000000, 10.000000)">
+    <path
+      d="M0.600275489,0.600275489 L11.3997245,11.3997245" />
+    <path
+      d="M11.3997245,0.600275489 L0.600275489,11.3997245" />
+  </g>
+</svg>
+`;
+
+exports[`BuildState where size="small" renders correctly for build state \`failed\` 1`] = `
+<svg
+  className={undefined}
+  height={20}
+  viewBox="0 0 32 32"
+  width={20}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#F83F23"
+      strokeWidth={6} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    fill="none"
+    stroke="#F83F23"
+    strokeWidth={3}
+    transform="translate(10.000000, 10.000000)">
+    <path
+      d="M0.600275489,0.600275489 L11.3997245,11.3997245" />
+    <path
+      d="M11.3997245,0.600275489 L0.600275489,11.3997245" />
+  </g>
+</svg>
+`;
+
+exports[`BuildState where size="small" renders correctly for build state \`passed\` 1`] = `
+<svg
+  className={undefined}
+  height={20}
+  viewBox="0 0 32 32"
+  width={20}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#90c73e"
+      strokeWidth={6} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <polyline
+    fill="none"
+    points="10 17.61 14.38 20.81 21 11.41"
+    stroke="#90c73e"
+    strokeMiterlimit="10"
+    strokeWidth={3} />
+</svg>
+`;
+
+exports[`BuildState where size="small" renders correctly for build state \`pending\` 1`] = `
+<svg
+  className={undefined}
+  height={20}
+  viewBox="0 0 32 32"
+  width={20}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#cdcccc"
+      strokeWidth={6} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#cdcccc"
+    strokeWidth={3} />
+</svg>
+`;
+
+exports[`BuildState where size="small" renders correctly for build state \`running\` 1`] = `
+<svg
+  className={undefined}
+  height={20}
+  viewBox="0 0 32 32"
+  width={20}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#fdba12"
+      strokeWidth={6} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+    <mask
+      height="14"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_mask"
+      maskUnits="userSpaceOnUse"
+      width="14"
+      x="9"
+      y="9">
+      <polygon
+        className="animation-spin"
+        fill="#fff"
+        points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
+        style={
+          Object {
+            "transformOrigin": "center",
+          }
+        } />
+    </mask>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    mask="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_mask)">
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      r="6"
+      stroke="#fdba12"
+      strokeWidth={3} />
+  </g>
+</svg>
+`;
+
+exports[`BuildState where size="small" renders correctly for build state \`scheduled\` 1`] = `
+<svg
+  className={undefined}
+  height={20}
+  viewBox="0 0 32 32"
+  width={20}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#aeaeae"
+      strokeWidth={6} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+    <mask
+      height="14"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_mask"
+      maskUnits="userSpaceOnUse"
+      width="14"
+      x="9"
+      y="9">
+      <polygon
+        className="animation-spin"
+        fill="#fff"
+        points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
+        style={
+          Object {
+            "transformOrigin": "center",
+          }
+        } />
+    </mask>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <g
+    mask="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_mask)">
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      r="6"
+      stroke="#aeaeae"
+      strokeWidth={3} />
+  </g>
+</svg>
+`;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6689,7 +6689,7 @@
     },
     "uuid": {
       "version": "2.0.2",
-      "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
+      "from": "uuid@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
     },
     "vali-date": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6689,7 +6689,7 @@
     },
     "uuid": {
       "version": "2.0.2",
-      "from": "uuid@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
     },
     "vali-date": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-relay": "^0.9.3",
     "react-router": "^2.8.1",
     "react-router-relay": "^0.13.5",
-    "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
+    "uuid": "^2.0.2",
     "webpack-dev-server": "^1.16.1",
     "whatwg-fetch": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "react-relay": "^0.9.3",
     "react-router": "^2.8.1",
     "react-router-relay": "^0.13.5",
+    "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
     "webpack-dev-server": "^1.16.1",
     "whatwg-fetch": "^1.0.0"
   },


### PR DESCRIPTION
Switching to UUID should prevent collisions, and mixed up states. There is probably a better approach to this, however.