### PR TITLE
More robust relative date handling

### DIFF
--- a/app/components/icons/Favorite.js
+++ b/app/components/icons/Favorite.js
@@ -10,10 +10,18 @@ class Favorite extends React.Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.favorite != nextProps.favorite && this.state.hover) {
+    if (this.props.favorite !== nextProps.favorite && this.state.hover) {
       this.setState({ hover: false });
     }
   }
+
+  handleMouseOver = () => {
+    this.setState({ hover: true });
+  };
+
+  handleMouseOut = () => {
+    this.setState({ hover: false });
+  };
 
   render() {
     return (
@@ -29,14 +37,6 @@ class Favorite extends React.Component {
       </svg>
     );
   }
-
-  handleMouseOver = () => {
-    this.setState({ hover: true });
-  };
-
-  handleMouseOut = () => {
-    this.setState({ hover: false });
-  };
 }
 
 export default Favorite;

--- a/app/lib/__snapshots__/builds.spec.js.snap
+++ b/app/lib/__snapshots__/builds.spec.js.snap
@@ -82,7 +82,18 @@ Object {
 }
 `;
 
-exports[`buildTime returns correct time properties for the \`canceled\` state 2`] = `Object {}`;
+exports[`buildTime returns correct time properties for the \`canceled\` state 2`] = `
+Object {
+  "from": undefined,
+}
+`;
+
+exports[`buildTime returns correct time properties for the \`canceled\` state 3`] = `
+Object {
+  "from": 2016-10-05T05:14:26.920Z,
+  "to": 2016-10-05T04:57:47.000Z,
+}
+`;
 
 exports[`buildTime returns correct time properties for the \`canceling\` state 1`] = `
 Object {

--- a/app/lib/__snapshots__/builds.spec.js.snap
+++ b/app/lib/__snapshots__/builds.spec.js.snap
@@ -75,6 +75,19 @@ Object {
 }
 `;
 
+exports[`buildTime returns correct time properties for the \`blocked\` state 2`] = `
+Object {
+  "from": undefined,
+}
+`;
+
+exports[`buildTime returns correct time properties for the \`blocked\` state 3`] = `
+Object {
+  "from": 2016-10-05T05:14:26.920Z,
+  "to": 2016-10-05T04:57:47.000Z,
+}
+`;
+
 exports[`buildTime returns correct time properties for the \`canceled\` state 1`] = `
 Object {
   "from": 2016-10-05T04:57:46.920Z,

--- a/app/lib/__snapshots__/date.spec.js.snap
+++ b/app/lib/__snapshots__/date.spec.js.snap
@@ -14,6 +14,14 @@ exports[`getDurationString correctly handles \`full\` dates 7`] = `"1 week, 13 d
 
 exports[`getDurationString correctly handles \`full\` dates 8`] = `"9 weeks, 2 days, 20 hours"`;
 
+exports[`getDurationString correctly handles \`full\` dates 9`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates 10`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates 11`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates 12`] = `"0 seconds"`;
+
 exports[`getDurationString correctly handles \`micro\` dates 1`] = `"0s"`;
 
 exports[`getDurationString correctly handles \`micro\` dates 2`] = `"5s"`;
@@ -29,6 +37,14 @@ exports[`getDurationString correctly handles \`micro\` dates 6`] = `"1d"`;
 exports[`getDurationString correctly handles \`micro\` dates 7`] = `"3w"`;
 
 exports[`getDurationString correctly handles \`micro\` dates 8`] = `"9w"`;
+
+exports[`getDurationString correctly handles \`micro\` dates 9`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates 10`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates 11`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates 12`] = `"0s"`;
 
 exports[`getDurationString correctly handles \`short\` dates 1`] = `"0s"`;
 
@@ -46,11 +62,21 @@ exports[`getDurationString correctly handles \`short\` dates 7`] = `"1w 14d"`;
 
 exports[`getDurationString correctly handles \`short\` dates 8`] = `"9w 3d"`;
 
+exports[`getDurationString correctly handles \`short\` dates 9`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates 10`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates 11`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates 12`] = `"0s"`;
+
 exports[`getDurationString defaults to full dates 1`] = `"5 seconds"`;
 
 exports[`getDurationString falls back to \`now\` when not supplied a \`to\` value 1`] = `"1 day, 4 hours, 30 minutes"`;
 
 exports[`getDurationString falls back to \`now\` when not supplied a \`to\` value 2`] = `"1d 5h"`;
+
+exports[`getDurationString falls back to \`now\` when not supplied a \`to\` value 3`] = `"0s"`;
 
 exports[`getDurationString formats are supplied as an array 1`] = `3`;
 

--- a/app/lib/builds.js
+++ b/app/lib/builds.js
@@ -22,9 +22,16 @@ export function buildTime(build) {
   }
 
   switch (state) {
-    case 'blocked':
     case 'failed':
     case 'passed':
+      buildTime.to = finishedAt;
+      break;
+
+    case 'blocked':
+      if (!buildTime.from) {
+        break;
+      }
+
       buildTime.to = finishedAt;
       break;
 

--- a/app/lib/builds.js
+++ b/app/lib/builds.js
@@ -3,18 +3,17 @@ export function buildTime(build) {
   const buildTime = {};
 
   switch (state) {
-    case 'blocked':
-    case 'canceled':
     case 'canceling':
     case 'failed':
     case 'passed':
     case 'running':
     case 'started':
-      if (state === 'canceled' && !startedAt) {
-        break;
-      }
-
       buildTime.from = startedAt;
+      break;
+
+    case 'blocked':
+    case 'canceled':
+      buildTime.from = startedAt || scheduledAt;
       break;
 
     case 'scheduled':
@@ -30,7 +29,7 @@ export function buildTime(build) {
       break;
 
     case 'canceled':
-      if (!startedAt) {
+      if (!buildTime.from) {
         break;
       }
 

--- a/app/lib/builds.spec.js
+++ b/app/lib/builds.spec.js
@@ -28,7 +28,15 @@ describe('buildTime', () => {
       if (state === 'canceled') {
         expect(buildTime({
           state,
-          canceledAt: new Date(1475643467000)
+          canceledAt: new Date(1475643467000),
+          finishedAt: new Date(1475643467000)
+        })).toMatchSnapshot();
+
+        expect(buildTime({
+          state,
+          scheduledAt: new Date(1475644466920),
+          canceledAt: new Date(1475643467000),
+          finishedAt: new Date(1475643467000)
         })).toMatchSnapshot();
       }
     });

--- a/app/lib/builds.spec.js
+++ b/app/lib/builds.spec.js
@@ -25,7 +25,7 @@ describe('buildTime', () => {
         scheduledAt: new Date(1475644466920)
       })).toMatchSnapshot();
 
-      if (state === 'canceled') {
+      if (['canceled', 'blocked'].indexOf(state) !== -1) {
         expect(buildTime({
           state,
           canceledAt: new Date(1475643467000),

--- a/app/lib/date.js
+++ b/app/lib/date.js
@@ -49,6 +49,9 @@ export function getDurationString(from, to = moment(), format = 'full') {
       amount = duration.get(label);
     }
 
+    // disallow negative values
+    amount = Math.max(amount, 0);
+
     // the last label is always supplied, even if it's 0
     if (amount > 0 || index === labels.length - 1) {
       times.push({ amount, label });

--- a/app/lib/date.spec.js
+++ b/app/lib/date.spec.js
@@ -10,7 +10,11 @@ const DATE_FIXTURES = [
   { from: "2016-05-07T09:00:00.000+10:00", to: "2016-05-07T13:59:03.000+10:00" },
   { from: "2016-05-07T09:00:00.000+10:00", to: "2016-05-08T16:03:21.000+10:00" },
   { from: "2016-05-07T09:00:00.000+10:00", to: "2016-05-21T01:22:12.000+10:00" },
-  { from: "2016-05-07T09:00:00.000+10:00", to: "2016-07-10T04:34:17.000+10:00" }
+  { from: "2016-05-07T09:00:00.000+10:00", to: "2016-07-10T04:34:17.000+10:00" },
+  { from: undefined, to: undefined },
+  { from: undefined, to: "2016-10-06T08:10:25.000+10:00" },
+  { from: undefined, to: "2016-10-06T08:09:55.000+10:00" },
+  { from: undefined, to: "2016-10-06T08:09:25.000+10:00" }
 ];
 
 describe('getDurationString', () => {
@@ -37,6 +41,7 @@ describe('getDurationString', () => {
     MockDate.set("2016-10-06T08:10:25.000+10:00");
     expect(getDurationString("2016-10-05T03:40:02.000+10:00")).toMatchSnapshot();
     expect(getDurationString("2016-10-05T03:40:02.000+10:00", undefined, "short")).toMatchSnapshot();
+    expect(getDurationString(undefined, undefined, "short")).toMatchSnapshot();
     MockDate.reset();
   });
 


### PR DESCRIPTION
- disallows negative time spans (note: this means `from` *must* be before `to`; this might need revision in future?)
- falls back to `scheduledAt` for `blocked` or `canceled` builds without `startedAt`
- adds specs around these edge cases