### PR TITLE
Make buildTimer fall back to scheduledAt

### DIFF
--- a/app/lib/__snapshots__/builds.spec.js.snap
+++ b/app/lib/__snapshots__/builds.spec.js.snap
@@ -77,14 +77,14 @@ Object {
 
 exports[`buildTime returns correct time properties for the \`blocked\` state 2`] = `
 Object {
-  "from": undefined,
+  "from": 2016-10-05T05:14:26.920Z,
+  "to": 2016-10-05T04:57:47.000Z,
 }
 `;
 
 exports[`buildTime returns correct time properties for the \`blocked\` state 3`] = `
 Object {
-  "from": 2016-10-05T05:14:26.920Z,
-  "to": 2016-10-05T04:57:47.000Z,
+  "from": undefined,
 }
 `;
 
@@ -97,20 +97,26 @@ Object {
 
 exports[`buildTime returns correct time properties for the \`canceled\` state 2`] = `
 Object {
-  "from": undefined,
+  "from": 2016-10-05T05:14:26.920Z,
+  "to": 2016-10-05T04:57:47.000Z,
 }
 `;
 
 exports[`buildTime returns correct time properties for the \`canceled\` state 3`] = `
 Object {
-  "from": 2016-10-05T05:14:26.920Z,
-  "to": 2016-10-05T04:57:47.000Z,
+  "from": undefined,
 }
 `;
 
 exports[`buildTime returns correct time properties for the \`canceling\` state 1`] = `
 Object {
   "from": 2016-10-05T04:57:46.920Z,
+}
+`;
+
+exports[`buildTime returns correct time properties for the \`canceling\` state 2`] = `
+Object {
+  "from": 2016-10-05T05:14:26.920Z,
 }
 `;
 
@@ -121,11 +127,27 @@ Object {
 }
 `;
 
+exports[`buildTime returns correct time properties for the \`failed\` state 2`] = `
+Object {
+  "from": 2016-10-05T05:14:26.920Z,
+  "to": 2016-10-05T04:57:47.000Z,
+}
+`;
+
 exports[`buildTime returns correct time properties for the \`not_run\` state 1`] = `Object {}`;
+
+exports[`buildTime returns correct time properties for the \`not_run\` state 2`] = `Object {}`;
 
 exports[`buildTime returns correct time properties for the \`passed\` state 1`] = `
 Object {
   "from": 2016-10-05T04:57:46.920Z,
+  "to": 2016-10-05T04:57:47.000Z,
+}
+`;
+
+exports[`buildTime returns correct time properties for the \`passed\` state 2`] = `
+Object {
+  "from": 2016-10-05T05:14:26.920Z,
   "to": 2016-10-05T04:57:47.000Z,
 }
 `;
@@ -136,7 +158,19 @@ Object {
 }
 `;
 
+exports[`buildTime returns correct time properties for the \`running\` state 2`] = `
+Object {
+  "from": 2016-10-05T05:14:26.920Z,
+}
+`;
+
 exports[`buildTime returns correct time properties for the \`scheduled\` state 1`] = `
+Object {
+  "from": 2016-10-05T05:14:26.920Z,
+}
+`;
+
+exports[`buildTime returns correct time properties for the \`scheduled\` state 2`] = `
 Object {
   "from": 2016-10-05T05:14:26.920Z,
 }
@@ -144,8 +178,16 @@ Object {
 
 exports[`buildTime returns correct time properties for the \`skipped\` state 1`] = `Object {}`;
 
+exports[`buildTime returns correct time properties for the \`skipped\` state 2`] = `Object {}`;
+
 exports[`buildTime returns correct time properties for the \`started\` state 1`] = `
 Object {
   "from": 2016-10-05T04:57:46.920Z,
+}
+`;
+
+exports[`buildTime returns correct time properties for the \`started\` state 2`] = `
+Object {
+  "from": 2016-10-05T05:14:26.920Z,
 }
 `;

--- a/app/lib/builds.js
+++ b/app/lib/builds.js
@@ -8,9 +8,6 @@ export function buildTime(build) {
     case 'passed':
     case 'running':
     case 'started':
-      buildTime.from = startedAt;
-      break;
-
     case 'blocked':
     case 'canceled':
       buildTime.from = startedAt || scheduledAt;

--- a/app/lib/builds.spec.js
+++ b/app/lib/builds.spec.js
@@ -25,16 +25,16 @@ describe('buildTime', () => {
         scheduledAt: new Date(1475644466920)
       })).toMatchSnapshot();
 
+      expect(buildTime({
+        state,
+        scheduledAt: new Date(1475644466920),
+        canceledAt: new Date(1475643467000),
+        finishedAt: new Date(1475643467000)
+      })).toMatchSnapshot();
+
       if (['canceled', 'blocked'].indexOf(state) !== -1) {
         expect(buildTime({
           state,
-          canceledAt: new Date(1475643467000),
-          finishedAt: new Date(1475643467000)
-        })).toMatchSnapshot();
-
-        expect(buildTime({
-          state,
-          scheduledAt: new Date(1475644466920),
           canceledAt: new Date(1475643467000),
           finishedAt: new Date(1475643467000)
         })).toMatchSnapshot();


### PR DESCRIPTION
Certain builds which can enter a finished state do not have a `startedAt`, but do have a `scheduledAt`. This takes that value for the start time, which fixes graphing of those times!