### PR TITLE
This is a tiny optimisation of the pipeline render

### DIFF
--- a/app/components/organization/Pipeline/graph.js
+++ b/app/components/organization/Pipeline/graph.js
@@ -88,6 +88,7 @@ class Graph extends React.Component {
     let maximumDuration = 1; // 1 to avoid a `0/0` when we calculate percentages
 
     for (let buildIndex = 0; buildIndex < MAXIMUM_NUMBER_OF_BUILDS; buildIndex++) {
+      const index = MAXIMUM_NUMBER_OF_BUILDS - buildIndex - 1;
       const buildEdge = this.props.pipeline.builds.edges[buildIndex];
 
       if (buildEdge) {
@@ -98,32 +99,37 @@ class Graph extends React.Component {
           maximumDuration = duration;
         }
 
-        bars[MAXIMUM_NUMBER_OF_BUILDS - buildIndex - 1] = {
-          color: this.colorForBuild(buildEdge.node),
-          hoverColor: this.hoverColorForBuild(buildEdge.node),
-          duration,
-          href: buildEdge.node.url,
-          build: buildEdge.node
-        };
+        bars[index] = (
+          <Bar
+            key={index}
+            color={this.colorForBuild(buildEdge.node)}
+            hoverColor={this.hoverColorForBuild(buildEdge.node)}
+            duration={duration}
+            href={buildEdge.node.url}
+            build={buildEdge.node}
+            left={index * BAR_WIDTH_WITH_SEPERATOR}
+            width={BAR_WIDTH_WITH_SEPERATOR}
+            maximumDuration={maximumDuration}
+            showFullGraph={this.state.showFullGraph}
+          />
+        );
       } else {
-        bars[MAXIMUM_NUMBER_OF_BUILDS - buildIndex - 1] = {
-          color: PENDING_COLOR,
-          hoverColor: PENDING_COLOR_HOVER,
-          duration: 0
-        };
+        bars[index] = (
+          <Bar
+            key={index}
+            color={PENDING_COLOR}
+            hoverColor={PENDING_COLOR_HOVER}
+            duration={0}
+            left={index * BAR_WIDTH_WITH_SEPERATOR}
+            width={BAR_WIDTH_WITH_SEPERATOR}
+            maximumDuration={maximumDuration}
+            showFullGraph={this.state.showFullGraph}
+          />
+        );
       }
     }
 
-    return bars.map((bar, index) => (
-      <Bar
-        key={index}
-        {...bar}
-        left={index * BAR_WIDTH_WITH_SEPERATOR}
-        width={BAR_WIDTH_WITH_SEPERATOR}
-        maximumDuration={maximumDuration}
-        showFullGraph={this.state.showFullGraph}
-      />
-    ));
+    return bars;
   }
 
   colorForBuild(build) {

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -90,35 +90,27 @@ class OrganizationPipelines extends React.Component {
     const favorited = [];
     const remainder = [];
     for (const edge of this.props.organization.pipelines.edges) {
+      // Put the favorites in the own section
       if (edge.node.favorite) {
-        favorited.push(edge.node);
+        favorited.push(<Pipeline key={edge.node.id} pipeline={edge.node} includeGraphData={this.props.relay.variables.includeGraphData} />);
       } else {
-        remainder.push(edge.node);
+        remainder.push(<Pipeline key={edge.node.id} pipeline={edge.node} includeGraphData={this.props.relay.variables.includeGraphData} />);
       }
     }
 
-    const nodes = [];
-
-    // Put the favorites in the own section with a divider
-    if (favorited.length > 0) {
-      for (const pipeline of favorited) {
-        nodes.push(
-          <Pipeline key={pipeline.id} pipeline={pipeline} includeGraphData={this.props.relay.variables.includeGraphData} />
-        );
-      }
-
-      if (remainder.length > 0) {
-        nodes.push(
-          <hr key="seperator" className="my4 bg-gray mx-auto max-width-1 border-none height-0" style={{ height: 1 }} />
-        );
-      }
+    if (favorited.length > 0 && remainder.length > 0) {
+      return favorited.concat(
+        [<hr key="seperator" className="my4 bg-gray mx-auto max-width-1 border-none height-0" style={{ height: 1 }} />],
+        remainder
+      );
+    } else if (favorited.length > 0) {
+      return favorited;
+    } else if (remainder.length > 0) {
+      return remainder;
     }
 
-    for (const pipeline of remainder) {
-      nodes.push(<Pipeline key={pipeline.id} pipeline={pipeline} includeGraphData={this.props.relay.variables.includeGraphData} />);
-    }
-
-    return nodes;
+    // Just in case
+    return [];
   }
 }
 


### PR DESCRIPTION
This avoids the triple-loop method we currently use, which should make a future version (insert sparkle emoji here✨) able to either paginate, or render the first N graphs before rendering the rest.

This was part of more perf investigation after shipping #95