### PR TITLE
Finished -> Passed/Failed

### DIFF
--- a/app/lib/__snapshots__/builds.spec.js.snap
+++ b/app/lib/__snapshots__/builds.spec.js.snap
@@ -21,7 +21,7 @@ Object {
 
 exports[`buildStatus returns correct build status for the \`failed\` state 1`] = `
 Object {
-  "prefix": "Finished",
+  "prefix": "Failed",
   "timeValue": 2016-10-05T04:57:47.000Z,
 }
 `;
@@ -35,7 +35,7 @@ Object {
 
 exports[`buildStatus returns correct build status for the \`passed\` state 1`] = `
 Object {
-  "prefix": "Finished",
+  "prefix": "Passed",
   "timeValue": 2016-10-05T04:57:47.000Z,
 }
 `;

--- a/app/lib/builds.js
+++ b/app/lib/builds.js
@@ -52,9 +52,14 @@ export function buildStatus(build) {
       prefix: 'Scheduled',
       timeValue: createdAt
     };
-  } else if (state === 'failed' || state === 'passed') {
+  } else if (state === 'failed') {
     return {
-      prefix: 'Finished',
+      prefix: 'Failed',
+      timeValue: finishedAt
+    };
+  } else if (state === 'passed') {
+    return {
+      prefix: 'Passed',
       timeValue: finishedAt
     };
   } else if (state === 'blocked') {


### PR DESCRIPTION
This changes the tooltip text from:

![pasted image at 2016_10_17 12_05 pm](https://cloud.githubusercontent.com/assets/153/19465559/d654d9d2-9550-11e6-91a0-a2a8145a0e7e.png)

to "Failed Tuesday at 2:33 PM"

Which is important because at the moment, colour is the only way to differentiate the builds in the build graph… there's no icon or words to tell people what the difference between passed and failed graphs are.