### PR TITLE
Fix graph calculations

### DIFF
--- a/app/components/organization/Pipeline/bar.js
+++ b/app/components/organization/Pipeline/bar.js
@@ -11,7 +11,9 @@ export default class Bar extends React.Component {
     color: React.PropTypes.string.isRequired,
     hoverColor: React.PropTypes.string.isRequired,
     duration: React.PropTypes.number,
-    maximumDuration: React.PropTypes.number,
+    graph: React.PropTypes.shape({
+      maximumDuration: React.PropTypes.number
+    }).isRequired,
     left: React.PropTypes.number.isRequired,
     build: React.PropTypes.object,
     showFullGraph: React.PropTypes.bool.isRequired
@@ -40,7 +42,7 @@ export default class Bar extends React.Component {
   calculateSizes() {
     // Calcualte what percentage this bar is in relation to the longest
     // running build
-    let height = (this.props.duration / this.props.maximumDuration);
+    let height = (this.props.duration / this.props.graph.maximumDuration);
     let transform = 'none';
 
     // See if the height is less than our minimum. If it is, set a hard pixel

--- a/app/components/organization/Pipeline/graph.js
+++ b/app/components/organization/Pipeline/graph.js
@@ -85,7 +85,13 @@ class Graph extends React.Component {
 
   renderBars() {
     const bars = [];
-    let maximumDuration = 1; // 1 to avoid a `0/0` when we calculate percentages
+
+    // `maximumDuration` is wrapped in an object so it's passed by
+    // reference, which means all bars get the final, correct value
+    // despite the generating loop only occuring once
+    const graphProps = {
+      maximumDuration: 1 // starts as 1 to avoid a `0/0` when we calculate percentages
+    };
 
     for (let buildIndex = 0; buildIndex < MAXIMUM_NUMBER_OF_BUILDS; buildIndex++) {
       const index = MAXIMUM_NUMBER_OF_BUILDS - buildIndex - 1;
@@ -95,8 +101,8 @@ class Graph extends React.Component {
         const { from, to } = buildTime(buildEdge.node);
         const duration = moment(to).diff(moment(from));
 
-        if (duration > maximumDuration) {
-          maximumDuration = duration;
+        if (duration > graphProps.maximumDuration) {
+          graphProps.maximumDuration = duration;
         }
 
         bars[index] = (
@@ -109,7 +115,7 @@ class Graph extends React.Component {
             build={buildEdge.node}
             left={index * BAR_WIDTH_WITH_SEPERATOR}
             width={BAR_WIDTH_WITH_SEPERATOR}
-            maximumDuration={maximumDuration}
+            graph={graphProps}
             showFullGraph={this.state.showFullGraph}
           />
         );
@@ -122,7 +128,7 @@ class Graph extends React.Component {
             duration={0}
             left={index * BAR_WIDTH_WITH_SEPERATOR}
             width={BAR_WIDTH_WITH_SEPERATOR}
-            maximumDuration={maximumDuration}
+            graph={graphProps}
             showFullGraph={this.state.showFullGraph}
           />
         );


### PR DESCRIPTION
It turned out the bug in the graph rendering was actually nothing to do with the build _state_ at all, but that newer, quick build graphs were never shrunk by the longer build times following them!

Before:
<img width="252" alt="screen shot 2016-10-24 at 11 00 20 am" src="https://cloud.githubusercontent.com/assets/282113/19632452/27013dd0-99d9-11e6-8344-068fff9f55f7.png">

After:
<img width="257" alt="screen shot 2016-10-24 at 10 58 20 am" src="https://cloud.githubusercontent.com/assets/282113/19632453/27461b1c-99d9-11e6-95ea-2ee0d699c7c7.png">
