### PR TITLE
Defer data loading on Agents Page

### DIFF
--- a/app/components/agent/Index/agentTokens.js
+++ b/app/components/agent/Index/agentTokens.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Relay from 'react-relay';
-import classNames from 'classnames';
 
 import Panel from '../../shared/Panel';
 import Spinner from '../../shared/Spinner';
@@ -33,14 +32,14 @@ class AgentTokens extends React.Component {
   }
 
   renderBody() {
-    if(this.props.organization.agentTokens) {
+    if (this.props.organization.agentTokens) {
       return this.props.organization.agentTokens.edges.map((edge) => this.renderRow(edge.node));
     } else {
       return (
         <Panel.Section className="center">
           <Spinner />
         </Panel.Section>
-      )
+      );
     }
   }
 
@@ -52,7 +51,7 @@ class AgentTokens extends React.Component {
           <code className="red monospace" style={{ wordWrap: "break-word" }}>{token.token}</code>
         </RevealButton>
       </Panel.Row>
-    )
+    );
   }
 }
 

--- a/app/components/agent/Index/agentTokens.js
+++ b/app/components/agent/Index/agentTokens.js
@@ -64,16 +64,13 @@ export default Relay.createContainer(AgentTokens, {
   fragments: {
     organization: () => Relay.QL`
       fragment on Organization {
-        agentTokens(first: 500, revoked: false) @include(if: $isMounted) {
+        agentTokens(first: 50, revoked: false) @include(if: $isMounted) {
           edges {
             node {
               id
               description
               token
             }
-          }
-          pageInfo {
-            hasNextPage
           }
         }
       }

--- a/app/components/agent/Index/agentTokens.js
+++ b/app/components/agent/Index/agentTokens.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import Relay from 'react-relay';
+import classNames from 'classnames';
+
+import Panel from '../../shared/Panel';
+import Spinner from '../../shared/Spinner';
+import RevealButton from '../../shared/RevealButton';
+
+class AgentTokens extends React.Component {
+  static propTypes = {
+    organization: React.PropTypes.shape({
+      agentTokens: React.PropTypes.shape({
+        edges: React.PropTypes.array.isRequired
+      })
+    }).isRequired,
+    relay: React.PropTypes.object.isRequired
+  };
+
+  componentDidMount() {
+    this.props.relay.setVariables({ isMounted: true });
+  }
+
+  render() {
+    return (
+      <Panel>
+        <Panel.Header>Agent Token</Panel.Header>
+        <Panel.Section>
+          <span>Your Buildkite agent token is used to configure and start new Buildkite agents.</span>
+        </Panel.Section>
+        {this.renderBody()}
+      </Panel>
+    );
+  }
+
+  renderBody() {
+    if(this.props.organization.agentTokens) {
+      return this.props.organization.agentTokens.edges.map((edge) => this.renderRow(edge.node));
+    } else {
+      return (
+        <Panel.Section className="center">
+          <Spinner />
+        </Panel.Section>
+      )
+    }
+  }
+
+  renderRow(token) {
+    return (
+      <Panel.Row key={token.id}>
+        <small className="dark-gray mb1 block">{token.description}</small>
+        <RevealButton caption="Reveal Agent Token">
+          <code className="red monospace" style={{ wordWrap: "break-word" }}>{token.token}</code>
+        </RevealButton>
+      </Panel.Row>
+    )
+  }
+}
+
+export default Relay.createContainer(AgentTokens, {
+  initialVariables: {
+    isMounted: false
+  },
+
+  fragments: {
+    organization: () => Relay.QL`
+      fragment on Organization {
+        agentTokens(first: 500, revoked: false) @include(if: $isMounted) {
+          edges {
+            node {
+              id
+              description
+              token
+            }
+          }
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    `
+  }
+});

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -1,0 +1,124 @@
+import React from 'react';
+import Relay from 'react-relay';
+
+import Panel from '../../shared/Panel';
+import Button from '../../shared/Button';
+import Spinner from '../../shared/Spinner';
+
+import AgentRow from './row';
+
+const AGENT_LIST_REFRESH_INTERVAL = 10 * 1000;
+const PAGE_SIZE = 20;
+
+class Agents extends React.Component {
+  static propTypes = {
+    organization: React.PropTypes.shape({
+      agents: React.PropTypes.shape({
+        pageInfo: React.PropTypes.shape({
+          hasNextPage: React.PropTypes.bool.isRequired
+        }).isRequired,
+        edges: React.PropTypes.array.isRequired
+      })
+    }).isRequired,
+    relay: React.PropTypes.object.isRequired
+  };
+
+  componentDidMount() {
+    this._agentListRefreshInterval = setInterval(this.fetchUpdatedData, AGENT_LIST_REFRESH_INTERVAL);
+    this.props.relay.setVariables({ isMounted: true });
+  }
+
+  componentWillUnmount() {
+    clearInterval(this._agentListRefreshInterval);
+  }
+
+  fetchUpdatedData = () => {
+    this.props.relay.forceFetch(true);
+  };
+
+  render() {
+    return (
+      <Panel>
+        <Panel.Header>Agents {this.renderHeaderInformation()}</Panel.Header>
+        {this.renderRows()}
+        {this.renderLoadMoreButton()}
+      </Panel>
+    )
+  }
+
+  renderHeaderInformation() {
+    if(this.props.organization.agents) {
+      return (
+        <span>(Showing {this.props.organization.agents.edges.length} of {this.props.organization.agents.count})</span>
+      )
+    }
+  }
+
+  renderRows() {
+    let agents = this.props.organization.agents;
+
+    if(agents) {
+      if (agents.edges.length > 0) {
+        return agents.edges.map((edge) => <AgentRow key={edge.node.id} agent={edge.node} />);
+      } else {
+        return <Panel.Section className="dark-gray">No agents connected</Panel.Section>;
+      }
+    } else {
+      return (
+        <Panel.Section className="center">
+          <Spinner />
+        </Panel.Section>
+      )
+    }
+  }
+
+  renderLoadMoreButton() {
+    if(this.props.organization.agents) {
+      if (this.props.organization.agents.pageInfo.hasNextPage) {
+        return (
+          <Panel.Footer>
+            <Button outline={true} theme={"default"} onClick={this.handleLoadMoreAgentsClick}>Load {PAGE_SIZE} more agents...</Button>
+          </Panel.Footer>
+        );
+      } else {
+        return (
+          <Panel.Footer>
+            <small className="dark-gray">No more to load</small>
+          </Panel.Footer>
+        );
+      }
+    }
+  }
+
+  handleLoadMoreAgentsClick = () => {
+    this.props.relay.setVariables({
+      pageSize: this.props.relay.variables.pageSize + PAGE_SIZE
+    });
+  };
+}
+
+export default Relay.createContainer(Agents, {
+  initialVariables: {
+    isMounted: false,
+    pageSize: PAGE_SIZE
+  },
+
+  fragments: {
+    organization: () => Relay.QL`
+      fragment on Organization {
+        agents(first: $pageSize) @include(if: $isMounted) {
+          count
+          edges {
+            node {
+              id
+              ${AgentRow.getFragment('agent')}
+            }
+          }
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    `
+  }
+});

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -78,7 +78,7 @@ class Agents extends React.Component {
       if (this.props.organization.agents.pageInfo.hasNextPage) {
         return (
           <Panel.Footer>
-            <Button outline={true} theme={"default"} onClick={this.handleLoadMoreAgentsClick}>Load {PAGE_SIZE} more agents...</Button>
+            <Button outline={true} theme={"default"} onClick={this.handleLoadMoreAgentsClick}>Load {PAGE_SIZE} more agents…</Button>
           </Panel.Footer>
         );
       } else {

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -14,6 +14,7 @@ class Agents extends React.Component {
   static propTypes = {
     organization: React.PropTypes.shape({
       agents: React.PropTypes.shape({
+        count: React.PropTypes.number.isRequired,
         pageInfo: React.PropTypes.shape({
           hasNextPage: React.PropTypes.bool.isRequired
         }).isRequired,
@@ -43,21 +44,21 @@ class Agents extends React.Component {
         {this.renderRows()}
         {this.renderLoadMoreButton()}
       </Panel>
-    )
+    );
   }
 
   renderHeaderInformation() {
-    if(this.props.organization.agents) {
+    if (this.props.organization.agents) {
       return (
         <span>(Showing {this.props.organization.agents.edges.length} of {this.props.organization.agents.count})</span>
-      )
+      );
     }
   }
 
   renderRows() {
-    let agents = this.props.organization.agents;
+    const agents = this.props.organization.agents;
 
-    if(agents) {
+    if (agents) {
       if (agents.edges.length > 0) {
         return agents.edges.map((edge) => <AgentRow key={edge.node.id} agent={edge.node} />);
       } else {
@@ -68,12 +69,12 @@ class Agents extends React.Component {
         <Panel.Section className="center">
           <Spinner />
         </Panel.Section>
-      )
+      );
     }
   }
 
   renderLoadMoreButton() {
-    if(this.props.organization.agents) {
+    if (this.props.organization.agents) {
       if (this.props.organization.agents.pageInfo.hasNextPage) {
         return (
           <Panel.Footer>

--- a/app/components/agent/Index/index.js
+++ b/app/components/agent/Index/index.js
@@ -16,8 +16,7 @@ class AgentIndex extends React.Component {
           allowed: React.PropTypes.bool.isRequired
         }).isRequired
       }).isRequired
-    }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    }).isRequired
   };
 
   render() {
@@ -47,7 +46,7 @@ class AgentIndex extends React.Component {
     } else {
       return (
         <Agents organization={this.props.organization} />
-      )
+      );
     }
   }
 }

--- a/app/components/agent/Index/index.js
+++ b/app/components/agent/Index/index.js
@@ -1,29 +1,16 @@
 import React from 'react';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
-import classNames from 'classnames';
 
-import AgentRow from './row';
-import AgentTokens from './agentTokens';
-
-import Panel from '../../shared/Panel';
 import PageWithContainer from '../../shared/PageWithContainer';
-import Button from '../../shared/Button';
 
-const AGENT_LIST_REFRESH_INTERVAL = 10 * 1000;
-const PAGE_SIZE = 20;
+import Agents from './agents';
+import AgentTokens from './agentTokens';
 
 class AgentIndex extends React.Component {
   static propTypes = {
     organization: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
-      agents: React.PropTypes.shape({
-        pageInfo: React.PropTypes.shape({
-          hasNextPage: React.PropTypes.bool.isRequired
-        }).isRequired,
-        count: React.PropTypes.number.isRequired,
-        edges: React.PropTypes.array.isRequired
-      }).isRequired,
       permissions: React.PropTypes.shape({
         agentTokenView: React.PropTypes.shape({
           allowed: React.PropTypes.bool.isRequired
@@ -33,101 +20,48 @@ class AgentIndex extends React.Component {
     relay: React.PropTypes.object.isRequired
   };
 
-  componentDidMount() {
-    this._agentListRefreshInterval = setInterval(this.fetchUpdatedData, AGENT_LIST_REFRESH_INTERVAL);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this._agentListRefreshInterval);
-  }
-
-  fetchUpdatedData = () => {
-    this.props.relay.forceFetch(true);
-  };
-
   render() {
-    const tokenViewAllowed = this.props.organization.permissions.agentTokenView.allowed;
-
-    let loadMoreButton;
-    if (this.props.organization.agents.pageInfo.hasNextPage) {
-      loadMoreButton =
-        <Button outline={true} theme={"default"} onClick={this.handleLoadMoreAgentsClick}>Load {PAGE_SIZE} more agents...</Button>;
-    } else {
-      loadMoreButton = <small className="dark-gray">No more to load</small>;
-    }
-
-    let pageContent = (
-      <Panel>
-        <Panel.Header>Agents (Showing {this.props.organization.agents.edges.length} of {this.props.organization.agents.count})</Panel.Header>
-        {this.renderAgentList(this.props.organization.agents)}
-        <Panel.Footer>
-          {loadMoreButton}
-        </Panel.Footer>
-      </Panel>
+    return (
+      <DocumentTitle title={`Agents · ${this.props.organization.name}`}>
+        <PageWithContainer>
+          {this.renderContent()}
+        </PageWithContainer>
+      </DocumentTitle>
     );
+  }
 
-    if (tokenViewAllowed) {
-      pageContent = (
+  renderContent() {
+    // Switches between showing just the agents, or the agents along with
+    // registration tokens.
+    if (this.props.organization.permissions.agentTokenView.allowed) {
+      return (
         <div className="clearfix mxn3">
           <div className="sm-col sm-col-8 px3">
-            {pageContent}
+            <Agents organization={this.props.organization} />
           </div>
           <div className="sm-col sm-col-4 px3">
             <AgentTokens organization={this.props.organization} />
           </div>
         </div>
       );
-    }
-
-    return (
-      <DocumentTitle title={`Agents · ${this.props.organization.name}`}>
-        <PageWithContainer>
-          {pageContent}
-        </PageWithContainer>
-      </DocumentTitle>
-    );
-  }
-
-  renderAgentList(agents) {
-    if (agents.edges.length > 0) {
-      return agents.edges.map((edge) => <AgentRow key={edge.node.id} agent={edge.node} />);
     } else {
-      return <Panel.Section className="dark-gray">No agents connected</Panel.Section>;
+      return (
+        <Agents organization={this.props.organization} />
+      )
     }
   }
-
-  handleLoadMoreAgentsClick = () => {
-    this.props.relay.setVariables({
-      pageSize: this.props.relay.variables.pageSize + PAGE_SIZE
-    });
-  };
 }
 
 export default Relay.createContainer(AgentIndex, {
-  initialVariables: {
-    pageSize: PAGE_SIZE
-  },
-
   fragments: {
     organization: () => Relay.QL`
       fragment on Organization {
         ${AgentTokens.getFragment('organization')}
+        ${Agents.getFragment('organization')}
         name
         permissions {
           agentTokenView {
             allowed
-          }
-        }
-        agents(first: $pageSize) {
-          count
-          edges {
-            node {
-              id
-              ${AgentRow.getFragment('agent')}
-            }
-          }
-          pageInfo {
-            hasNextPage
           }
         }
       }

--- a/app/components/agent/Index/index.js
+++ b/app/components/agent/Index/index.js
@@ -4,10 +4,10 @@ import DocumentTitle from 'react-document-title';
 import classNames from 'classnames';
 
 import AgentRow from './row';
+import AgentTokens from './agentTokens';
 
 import Panel from '../../shared/Panel';
 import PageWithContainer from '../../shared/PageWithContainer';
-import RevealButton from '../../shared/RevealButton';
 import Button from '../../shared/Button';
 
 const AGENT_LIST_REFRESH_INTERVAL = 10 * 1000;
@@ -28,9 +28,6 @@ class AgentIndex extends React.Component {
         agentTokenView: React.PropTypes.shape({
           allowed: React.PropTypes.bool.isRequired
         }).isRequired
-      }).isRequired,
-      agentTokens: React.PropTypes.shape({
-        edges: React.PropTypes.array.isRequired
       }).isRequired
     }).isRequired,
     relay: React.PropTypes.object.isRequired
@@ -50,7 +47,6 @@ class AgentIndex extends React.Component {
 
   render() {
     const tokenViewAllowed = this.props.organization.permissions.agentTokenView.allowed;
-    const agentTokens = this.props.organization.agentTokens.edges;
 
     let loadMoreButton;
     if (this.props.organization.agents.pageInfo.hasNextPage) {
@@ -70,37 +66,14 @@ class AgentIndex extends React.Component {
       </Panel>
     );
 
-    if (tokenViewAllowed && agentTokens.length) {
+    if (tokenViewAllowed) {
       pageContent = (
         <div className="clearfix mxn3">
           <div className="sm-col sm-col-8 px3">
             {pageContent}
           </div>
           <div className="sm-col sm-col-4 px3">
-            <Panel>
-              <Panel.Header>Agent Token</Panel.Header>
-              <Panel.Row>
-                <p className={classNames("black", { [agentTokens.length === 1 ? 'mt0' : 'm0']: true })}>Your Buildkite agent token is used to configure and start new Buildkite agents.</p>
-                {agentTokens.length === 1 &&
-                  <RevealButton caption="Reveal Agent Token">
-                    <code className="red monospace" style={{ wordWrap: "break-word" }}>{agentTokens[0].node.token}</code>
-                  </RevealButton>
-                }
-              </Panel.Row>
-              {agentTokens.length > 1 &&
-                <Panel.Row>
-                  {agentTokens.map((token, index, array) => (
-                    <div key={index}>
-                      <small className="dark-gray mb1 block">{token.node.description}</small>
-                      <RevealButton caption="Reveal Agent Token">
-                        <code className="red monospace" style={{ wordWrap: "break-word" }}>{token.node.token}</code>
-                      </RevealButton>
-                      {index !== array.length - 1 && <hr className="bg-gray mx-auto max-width-1 border-none height-0 my3" style={{ height: 1 }} />}
-                    </div>
-                  ))}
-                </Panel.Row>
-              }
-            </Panel>
+            <AgentTokens organization={this.props.organization} />
           </div>
         </div>
       );
@@ -138,6 +111,7 @@ export default Relay.createContainer(AgentIndex, {
   fragments: {
     organization: () => Relay.QL`
       fragment on Organization {
+        ${AgentTokens.getFragment('organization')}
         name
         permissions {
           agentTokenView {
@@ -154,14 +128,6 @@ export default Relay.createContainer(AgentIndex, {
           }
           pageInfo {
             hasNextPage
-          }
-        }
-        agentTokens(first: 500, revoked:false) {
-          edges {
-            node {
-              description
-              token
-            }
           }
         }
       }

--- a/app/components/agent/Index/index.js
+++ b/app/components/agent/Index/index.js
@@ -3,12 +3,12 @@ import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 import classNames from 'classnames';
 
-import AgentRow from './Row';
+import AgentRow from './row';
 
-import Panel from '../shared/Panel';
-import PageWithContainer from '../shared/PageWithContainer';
-import RevealButton from '../shared/RevealButton';
-import Button from '../shared/Button';
+import Panel from '../../shared/Panel';
+import PageWithContainer from '../../shared/PageWithContainer';
+import RevealButton from '../../shared/RevealButton';
+import Button from '../../shared/Button';
 
 const AGENT_LIST_REFRESH_INTERVAL = 10 * 1000;
 const PAGE_SIZE = 20;

--- a/app/components/agent/Index/row.js
+++ b/app/components/agent/Index/row.js
@@ -3,7 +3,7 @@ import Relay from 'react-relay';
 import { Link } from 'react-router';
 import classNames from 'classnames';
 
-import Panel from '../shared/Panel';
+import Panel from '../../shared/Panel';
 
 class AgentRow extends React.Component {
   static propTypes = {


### PR DESCRIPTION
This change will defer the loading of the agents and the tokens until the main page has mounted. They show a spinner until the data is available. This stops the page from blocking until all the data is available - which is a bit nicer on the eyes.

I also rearranged the code a little bit and split things out into seperate components.