### PR TITLE
Hide username on mid-sized screens

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -119,7 +119,7 @@ class Navigation extends React.Component {
   renderTopOrganizationMenu() {
     if (this.props.organization) {
       return (
-        <span className="flex xs-hide">
+        <span className="flex xs-hide sm-hide md-hide">
           {this.renderOrganizationMenu()}
         </span>
       );
@@ -129,7 +129,7 @@ class Navigation extends React.Component {
   renderBottomOrganizationMenu() {
     if (this.props.organization) {
       return (
-        <div className="border-top border-gray sm-hide md-hide lg-hide">
+        <div className="border-top border-gray lg-hide">
           <div className="container flex flex-stretch" style={{ height: 45 }}>
             {this.renderOrganizationMenu({ paddingLeft: 0 })}
           </div>
@@ -161,9 +161,11 @@ class Navigation extends React.Component {
       <Dropdown align="center" width={250} className="flex" onToggle={this.handleBuildsDropdownToggle}>
         <DropdownButton className={classNames("py0", { "lime": this.state.showingBuildsDropdown })}>
           {'My Builds '}
-          <ReactCSSTransitionGroup transitionName="transition-appear-pop" transitionEnterTimeout={200} transitionLeaveTimeout={200}>
-            {badge}
-          </ReactCSSTransitionGroup>
+          <div className="xs-hide">
+            <ReactCSSTransitionGroup transitionName="transition-appear-pop" transitionEnterTimeout={200} transitionLeaveTimeout={200}>
+              {badge}
+            </ReactCSSTransitionGroup>
+          </div>
           <Icon icon="down-triangle" style={{ width: 7, height: 7, marginLeft: '.5em' }} />
         </DropdownButton>
         <BuildsDropdown viewer={this.props.viewer} />
@@ -276,7 +278,7 @@ class Navigation extends React.Component {
                   paddingRight: 20
                 }}
               >
-                <span className="truncate" style={{ maxWidth: "10em" }}>
+                <span className="truncate" style={{ maxWidth: "7em" }}>
                   {this.props.organization ? this.props.organization.name : 'Organizations'}
                 </span>
                 <Icon icon="down-triangle" style={{ width: 7, height: 7, marginLeft: '.5em' }} />
@@ -297,7 +299,7 @@ class Navigation extends React.Component {
                 style={{ paddingRight: 0 }}
               >
                 <UserAvatar user={this.props.viewer.user} className="flex-none flex items-center" style={{ width: 26, height: 26 }} />
-                <span className="flex items-center xs-hide ml1"><span className="truncate" style={{ maxWidth: "9em" }} data-current-user-name={true}>{this.props.viewer.user.name}</span></span>
+                <span className="flex items-center xs-hide sm-flex ml1"><span className="truncate" style={{ maxWidth: "8em" }} data-current-user-name={true}>{this.props.viewer.user.name}</span></span>
                 <span className="flex items-center">
                   <Icon icon="down-triangle" style={{ width: 7, height: 7, marginLeft: '.5em' }} />
                 </span>


### PR DESCRIPTION
Things are getting a little cramped on smaller screens:

<img width="1000" alt="boo" src="https://cloud.githubusercontent.com/assets/153/19958294/41df583c-a1f2-11e6-95a1-78cd7f73e5f8.png">

This hides the username from medium and small sized screens, and only shows it on extra-small (mobile, when it goes to two rows) and large.

<img width="1016" alt="hidden" src="https://cloud.githubusercontent.com/assets/153/19958324/76fff09e-a1f2-11e6-87c9-2785d2ae2620.png">

<img width="530" alt="smaller" src="https://cloud.githubusercontent.com/assets/153/19958333/8bd930fc-a1f2-11e6-9bb4-48c9dc4e33aa.png">
