### PR TITLE
Use tabular numerals in navbar badges

### DIFF
--- a/app/components/shared/Badge.js
+++ b/app/components/shared/Badge.js
@@ -8,10 +8,15 @@ class Badge extends React.Component {
   };
 
   render() {
+    const { children, className } = this.props;
+
+    const badgeClassName = classNames(
+      "inline-block bg-black white rounded ml1 small p1 line-height-1 tabular-numerals",
+      className
+    );
+
     return (
-      <span className={classNames("inline-block bg-black white rounded ml1 small p1 line-height-1", this.props.className)}>
-        {this.props.children}
-      </span>
+      <span className={badgeClassName}>{children}</span>
     );
   }
 }

--- a/app/css/fonts.css
+++ b/app/css/fonts.css
@@ -1,3 +1,9 @@
 .monospace {
   font-family: var(--font-family-mono);
 }
+
+.tabular-numerals {
+  /* Enables OpenType tabular numerals */
+  font-feature-settings: "tnum"; /* not the "correct" property, but it works in IE10+ */
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
This makes the badges less prone to little changes in layout thanks to changing numbers - they'll only change width if there's a new significant digit (where fitted).

Here’s an image from the CSS fonts level 3 spec, demonstrating proportional and tabular numerals;

![example image from spec](https://drafts.csswg.org/css-fonts-3/numberstyles.png)

And here’s how it changed on Buildkite;

<img width="111" alt="screen shot 2016-11-04 at 2 51 29 pm" src="https://cloud.githubusercontent.com/assets/282113/19996962/35588a1e-a29e-11e6-997d-2eb321a6b54d.png">
🔜
<img width="120" alt="screen shot 2016-11-04 at 2 51 10 pm" src="https://cloud.githubusercontent.com/assets/282113/19996963/35cadc18-a29e-11e6-8a94-f02b0564a4dc.png">