### PR TITLE
Use tabular numerals for durations too

### DIFF
--- a/app/components/shared/Duration.js
+++ b/app/components/shared/Duration.js
@@ -72,7 +72,7 @@ class Duration extends React.Component {
 
   render() {
     return (
-      <span>{this.state.value}</span>
+      <span className="tabular-numerals">{this.state.value}</span>
     );
   }
 }

--- a/app/components/shared/__snapshots__/Duration.spec.js.snap
+++ b/app/components/shared/__snapshots__/Duration.spec.js.snap
@@ -1,143 +1,167 @@
 exports[`Duration Duration.Full renders as expected 1`] = `
-<span>
+<span
+  className="tabular-numerals">
   0 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 2`] = `
-<span>
+<span
+  className="tabular-numerals">
   5 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 3`] = `
-<span>
+<span
+  className="tabular-numerals">
   15 minutes, 7 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 4`] = `
-<span>
+<span
+  className="tabular-numerals">
   1 hour, 45 minutes, 16 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 5`] = `
-<span>
+<span
+  className="tabular-numerals">
   4 hours, 59 minutes, 3 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 6`] = `
-<span>
+<span
+  className="tabular-numerals">
   1 day, 7 hours, 3 minutes
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 7`] = `
-<span>
+<span
+  className="tabular-numerals">
   1 week, 13 days, 16 hours
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 8`] = `
-<span>
+<span
+  className="tabular-numerals">
   9 weeks, 2 days, 20 hours
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 1`] = `
-<span>
+<span
+  className="tabular-numerals">
   0s
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 2`] = `
-<span>
+<span
+  className="tabular-numerals">
   5s
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 3`] = `
-<span>
+<span
+  className="tabular-numerals">
   15m
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 4`] = `
-<span>
+<span
+  className="tabular-numerals">
   2h
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 5`] = `
-<span>
+<span
+  className="tabular-numerals">
   5h
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 6`] = `
-<span>
+<span
+  className="tabular-numerals">
   1d
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 7`] = `
-<span>
+<span
+  className="tabular-numerals">
   3w
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 8`] = `
-<span>
+<span
+  className="tabular-numerals">
   9w
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 1`] = `
-<span>
+<span
+  className="tabular-numerals">
   0s
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 2`] = `
-<span>
+<span
+  className="tabular-numerals">
   5s
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 3`] = `
-<span>
+<span
+  className="tabular-numerals">
   15m 7s
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 4`] = `
-<span>
+<span
+  className="tabular-numerals">
   1h 45m
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 5`] = `
-<span>
+<span
+  className="tabular-numerals">
   4h 59m
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 6`] = `
-<span>
+<span
+  className="tabular-numerals">
   1d 7h
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 7`] = `
-<span>
+<span
+  className="tabular-numerals">
   1w 14d
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 8`] = `
-<span>
+<span
+  className="tabular-numerals">
   9w 3d
 </span>
 `;


### PR DESCRIPTION
Before:

![tabular](https://cloud.githubusercontent.com/assets/153/20088951/ce0a4518-a5d7-11e6-8e4a-2b37458e021b.gif)

After:

![after](https://cloud.githubusercontent.com/assets/153/20088955/d1b5fa04-a5d7-11e6-99d6-23c4ce640c16.gif)

This will apply to all the pipeline tooltips too.