### PR TITLE
Tabular numerals in build timers

### DIFF
--- a/app/components/organization/Pipeline/build-tooltip.js
+++ b/app/components/organization/Pipeline/build-tooltip.js
@@ -43,7 +43,7 @@ class BuildTooltip extends React.Component {
             <Media align="top">
               <Media.Image className="mr2 center" style={{ width: 30 }} >
                 <UserAvatar user={this.props.build.createdBy} className="block fit" />
-                <small className="dark-gray"><Duration.Micro {...buildTime(this.props.build)} /></small>
+                <small className="dark-gray"><Duration.Micro {...buildTime(this.props.build)} tabularNumerals={false} /></small>
               </Media.Image>
               <Media.Description className="flex-auto line-height-2">
                 <span className="block line-height-3 overflow-hidden overflow-ellipsis">

--- a/app/components/shared/Duration.js
+++ b/app/components/shared/Duration.js
@@ -14,12 +14,14 @@ class Duration extends React.Component {
       React.PropTypes.number,
       React.PropTypes.instanceOf(Date)
     ]),
+    tabularNumerals: React.PropTypes.bool.isRequired,
     format: React.PropTypes.oneOf(getDurationString.formats),
     updateFrequency: React.PropTypes.number
   };
 
   static defaultProps = {
-    updateFrequency: 1000
+    updateFrequency: 1000,
+    tabularNumerals: true
   };
 
   state = {
@@ -71,8 +73,17 @@ class Duration extends React.Component {
   }
 
   render() {
+    const { state: { value }, props: { tabularNumerals } } = this;
+    const spanProps = {};
+
+    if (tabularNumerals) {
+      spanProps.className = 'tabular-numerals';
+    }
+
     return (
-      <span>{this.state.value}</span>
+      <span {...spanProps}>
+        {value}
+      </span>
     );
   }
 }

--- a/app/components/shared/Duration.spec.js
+++ b/app/components/shared/Duration.spec.js
@@ -37,6 +37,17 @@ describe('Duration', () => {
         });
       });
 
+      describe('tabularNumerals', () => {
+        it('can be disabled', () => {
+          const component = ReactTestRenderer.create(
+            <DurationComponent tabularNumerals={false} from="2016-05-07T09:00:00.000Z" to="2016-05-07T09:00:00.000Z" updateFrequency={0} />
+          );
+
+          const tree = component.toJSON();
+          expect(tree).toMatchSnapshot();
+        });
+      });
+
       xdescribe('updateFrequency', () => {
         // TODO: Need to be able to instrument updating and interactions
         it('sets an interval if supplied with a frequency greater than zero', () => {

--- a/app/components/shared/__snapshots__/Duration.spec.js.snap
+++ b/app/components/shared/__snapshots__/Duration.spec.js.snap
@@ -1,144 +1,186 @@
 exports[`Duration Duration.Full renders as expected 1`] = `
-<span>
+<span
+  className="tabular-numerals">
   0 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 2`] = `
-<span>
+<span
+  className="tabular-numerals">
   5 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 3`] = `
-<span>
+<span
+  className="tabular-numerals">
   15 minutes, 7 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 4`] = `
-<span>
+<span
+  className="tabular-numerals">
   1 hour, 45 minutes, 16 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 5`] = `
-<span>
+<span
+  className="tabular-numerals">
   4 hours, 59 minutes, 3 seconds
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 6`] = `
-<span>
+<span
+  className="tabular-numerals">
   1 day, 7 hours, 3 minutes
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 7`] = `
-<span>
+<span
+  className="tabular-numerals">
   1 week, 13 days, 16 hours
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 8`] = `
-<span>
+<span
+  className="tabular-numerals">
   9 weeks, 2 days, 20 hours
 </span>
 `;
 
-exports[`Duration Duration.Micro renders as expected 1`] = `
+exports[`Duration Duration.Full tabularNumerals can be disabled 1`] = `
 <span>
+  0 seconds
+</span>
+`;
+
+exports[`Duration Duration.Micro renders as expected 1`] = `
+<span
+  className="tabular-numerals">
   0s
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 2`] = `
-<span>
+<span
+  className="tabular-numerals">
   5s
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 3`] = `
-<span>
+<span
+  className="tabular-numerals">
   15m
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 4`] = `
-<span>
+<span
+  className="tabular-numerals">
   2h
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 5`] = `
-<span>
+<span
+  className="tabular-numerals">
   5h
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 6`] = `
-<span>
+<span
+  className="tabular-numerals">
   1d
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 7`] = `
-<span>
+<span
+  className="tabular-numerals">
   3w
 </span>
 `;
 
 exports[`Duration Duration.Micro renders as expected 8`] = `
-<span>
+<span
+  className="tabular-numerals">
   9w
 </span>
 `;
 
-exports[`Duration Duration.Short renders as expected 1`] = `
+exports[`Duration Duration.Micro tabularNumerals can be disabled 1`] = `
 <span>
   0s
 </span>
 `;
 
+exports[`Duration Duration.Short renders as expected 1`] = `
+<span
+  className="tabular-numerals">
+  0s
+</span>
+`;
+
 exports[`Duration Duration.Short renders as expected 2`] = `
-<span>
+<span
+  className="tabular-numerals">
   5s
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 3`] = `
-<span>
+<span
+  className="tabular-numerals">
   15m 7s
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 4`] = `
-<span>
+<span
+  className="tabular-numerals">
   1h 45m
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 5`] = `
-<span>
+<span
+  className="tabular-numerals">
   4h 59m
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 6`] = `
-<span>
+<span
+  className="tabular-numerals">
   1d 7h
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 7`] = `
-<span>
+<span
+  className="tabular-numerals">
   1w 14d
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 8`] = `
-<span>
+<span
+  className="tabular-numerals">
   9w 3d
+</span>
+`;
+
+exports[`Duration Duration.Short tabularNumerals can be disabled 1`] = `
+<span>
+  0s
 </span>
 `;
 

--- a/app/components/user/BuildsDropdown/build.js
+++ b/app/components/user/BuildsDropdown/build.js
@@ -36,7 +36,7 @@ class BuildsDropdownBuild extends React.Component {
         <a href={this.props.build.url} className="flex text-decoration-none dark-gray hover-lime mb2" onMouseOver={this.handleMouseOver} onMouseOut={this.handleMouseOut}>
           <div className="pr2 center">
             <BuildState.Small className="block" state={this.props.build.state} />
-            <small><Duration.Micro className="dark-gray" {...buildTime(this.props.build)} /></small>
+            <small><Duration.Micro className="dark-gray" {...buildTime(this.props.build)} tabularNumerals={false} /></small>
           </div>
           <div className="flex-auto line-height-2">
             <span className="block line-height-3 overflow-hidden overflow-ellipsis">


### PR DESCRIPTION
This applies tabular numerals to most usages of the build timer component.

These places spend a lot of time counting in real-time, and frankly look a little funny flopping all over the place!

The exception to this is the my builds dropdown, and the build tooltip, where the build timer is in “micro” format, and isn’t presented within a sentence - those stay as they were!