### PR TITLE
Make Dropdowns viewport-aware

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -283,7 +283,7 @@ class Navigation extends React.Component {
               <NewChangelogsBadge className="mr2 relative" style={{ top: -5, marginLeft: -8 }} viewer={this.props.viewer} />
             </span>
 
-            <Dropdown align="left" width={250} className="flex" style={{ minWidth: "5em" }} onToggle={this.handleOrgDropdownToggle}>
+            <Dropdown width={250} className="flex" style={{ minWidth: "5em" }} onToggle={this.handleOrgDropdownToggle}>
               <DropdownButton
                 className={classNames("py0", { "lime": this.state.showingOrgDropdown })}
                 style={{
@@ -309,7 +309,7 @@ class Navigation extends React.Component {
             <NavigationButton className="py0 xs-hide sm-hide" href={`/docs`}>Documentation</NavigationButton>
             <NavigationButton className="py0 xs-hide sm-hide" onClick={this.handleSupportClick}>Support</NavigationButton>
 
-            <Dropdown align="right" width={170} className="flex" ref={(userDropdown) => this.userDropdown = userDropdown} onToggle={this.handleUserDropdownToggle}>
+            <Dropdown width={170} className="flex" ref={(userDropdown) => this.userDropdown = userDropdown} onToggle={this.handleUserDropdownToggle}>
               <DropdownButton className={classNames("py0", { "lime": this.state.showingUserDropdown })}
                 style={{ paddingRight: 0 }}
               >

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -173,7 +173,7 @@ class Navigation extends React.Component {
     }
 
     return (
-      <Dropdown align="center" width={250} className="flex" onToggle={this.handleBuildsDropdownToggle}>
+      <Dropdown width={250} className="flex" onToggle={this.handleBuildsDropdownToggle}>
         <DropdownButton className={classNames("py0", { "lime": this.state.showingBuildsDropdown })}>
           {'My Builds '}
           <div className="xs-hide">

--- a/app/components/organization/Teams.js
+++ b/app/components/organization/Teams.js
@@ -23,10 +23,14 @@ class Teams extends React.Component {
 
   renderDropdown() {
     return (
-      <Dropdown align="center" width={300} ref={(dropdownNode) => this.dropdownNode = dropdownNode}>
-        <button className="h4 p0 m0 light dark-gray inline-block btn" style={{ marginTop: 3, fontSize: 16 }}>
+      <Dropdown width={300} ref={(dropdownNode) => this.dropdownNode = dropdownNode}>
+        <button className="h4 px0 py1 m0 light dark-gray inline-block btn" style={{ fontSize: 16 }}>
           <div className="flex">
-            <span className="flex items-center"><span className="truncate">{this.renderLabel()}</span></span>
+            <span className="flex items-center">
+              <span className="truncate">
+                {this.renderLabel()}
+              </span>
+            </span>
             <span className="flex items-center">
               <Icon icon="down-triangle" style={{ width: 8, height: 8, marginLeft: '.5em' }} />
             </span>
@@ -35,7 +39,7 @@ class Teams extends React.Component {
 
         <Chooser selected={null} onSelect={this.handleDropdownSelect}>
           {this.renderOptions()}
-          <Chooser.Option value={""} className="btn block hover-bg-silver">
+          <Chooser.Option value="" className="btn block hover-bg-silver">
             <div>All teams</div>
           </Chooser.Option>
         </Chooser>

--- a/app/components/shared/Dropdown.js
+++ b/app/components/shared/Dropdown.js
@@ -54,10 +54,6 @@ class Dropdown extends React.Component {
   }
 
   handleWindowResize = () => {
-    if (this.props.align === 'center') {
-      return;
-    }
-
     // when hidden, we wait for the resize to be finished!
     // to do so, we clear timeouts on each event until we get
     // a good delay between them.

--- a/app/components/shared/Dropdown.js
+++ b/app/components/shared/Dropdown.js
@@ -43,6 +43,7 @@ const Popup = styled.div`
           case 'center':
             return `calc(50% - ${props.width / 2}px)`;
           default:
+          case 'right':
             return 'auto';
         }
       }

--- a/app/components/shared/Dropdown.js
+++ b/app/components/shared/Dropdown.js
@@ -17,7 +17,7 @@ const Popup = styled.div`
   right: 0;
   transform-origin: ${
     (props) => {
-      switch(props.align) {
+      switch (props.align) {
         case 'left':
           return '7.5% -15px';
         case 'right':

--- a/app/components/shared/Dropdown.js
+++ b/app/components/shared/Dropdown.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import styled from 'styled-components';
 
@@ -35,15 +36,16 @@ const Popup = styled.div`
   @media ${MOBILE_BREAKPOINT} {
     width: ${(props) => `${props.width}px`};
     left: ${
-      (props) => (
-        props.align === 'left'
-          ? '3px'
-          : (
-            props.align === 'center'
-              ? `calc(50% - ${props.width / 2}px)`
-              : 'auto'
-          )
-      )
+      (props) => {
+        switch (props.align) {
+          case 'left':
+            return '3px';
+          case 'center':
+            return `calc(50% - ${props.width / 2}px)`;
+          default:
+            return 'auto';
+        }
+      }
     };
     right: ${
       (props) => (
@@ -112,6 +114,10 @@ class Dropdown extends React.Component {
   state = {
     showing: false
   };
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
 
   componentDidMount() {
     document.documentElement.addEventListener('click', this.handleDocumentClick, false);

--- a/app/components/shared/Dropdown.js
+++ b/app/components/shared/Dropdown.js
@@ -31,13 +31,11 @@ class Dropdown extends React.Component {
     children: React.PropTypes.node.isRequired,
     width: React.PropTypes.number.isRequired,
     className: React.PropTypes.string,
-    align: React.PropTypes.string,
     onToggle: React.PropTypes.func,
     nibOffset: React.PropTypes.number
   };
 
   static defaultProps = {
-    align: 'center',
     nibOffset: 0,
     width: 250
   };
@@ -156,21 +154,13 @@ class Dropdown extends React.Component {
   }
 
   renderNib() {
-    const nibStyles = {};
-
-    if (this.props.align === 'right') {
-      nibStyles.right = 10;
-    } else if (this.props.align === 'left') {
-      nibStyles.left = 10;
-    } else if (this.props.align === 'center') {
-      nibStyles.left = '50%';
-      nibStyles.marginLeft = -(NIB_WIDTH / 2) - this.state.offsetX + this.props.nibOffset;
-    }
-
     return (
       <Nib
         src={require('../../images/up-pointing-white-nib.svg')}
-        style={nibStyles}
+        style={{
+          left: '50%',
+          marginLeft: -(NIB_WIDTH / 2) - this.state.offsetX + this.props.nibOffset
+        }}
         alt=""
       />
     );
@@ -190,17 +180,6 @@ class Dropdown extends React.Component {
       width: this.state.width,
       zIndex: 3
     };
-
-    if (this.props.align === 'left') {
-      popupStyles.left = 3;
-      popupStyles.transformOrigin = '7.5% -15px';
-    }
-
-    if (this.props.align === 'right') {
-      popupStyles.right = 3;
-      delete popupStyles.left;
-      popupStyles.transformOrigin = '92.5% -15px';
-    }
 
     return (
       <div

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -22,7 +22,7 @@ class MemberRole extends React.Component {
     const nib = this.props.teamMember.admin ? 3 : 15;
 
     return (
-      <Dropdown align="center" width={270} nibOffset={nib}>
+      <Dropdown width={270} nibOffset={nib}>
         <div style={{ width: 87 }} className="right-align">
           <div className="underline-dotted cursor-pointer inline-block regular">{label}</div>
         </div>

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
 
 import Spinner from '../../shared/Spinner';
 import Chooser from '../../shared/Chooser';
@@ -15,6 +16,10 @@ class MemberRole extends React.Component {
     onRoleChange: React.PropTypes.func.isRequired,
     savingNewRole: React.PropTypes.string
   };
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
 
   render() {
     const label = this.props.teamMember.admin ? "Team Admin" : "Member";

--- a/app/components/team/Pipelines/access-level.js
+++ b/app/components/team/Pipelines/access-level.js
@@ -42,7 +42,7 @@ class AccessLevel extends React.Component {
     }
 
     return (
-      <Dropdown align="center" width={270} nibOffset={nibOffset}>
+      <Dropdown width={270} nibOffset={nibOffset}>
         <div style={{ width: 90 }} className="right-align">
           <div className="underline-dotted cursor-pointer inline-block regular">{label}</div>
         </div>

--- a/app/components/team/Pipelines/access-level.js
+++ b/app/components/team/Pipelines/access-level.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
 
 import Spinner from '../../shared/Spinner';
 import Chooser from '../../shared/Chooser';
@@ -19,6 +20,10 @@ class AccessLevel extends React.Component {
     onAccessLevelChange: React.PropTypes.func.isRequired,
     saving: React.PropTypes.string
   };
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
 
   render() {
     let label;

--- a/app/components/user/BuildsDropdown/build.js
+++ b/app/components/user/BuildsDropdown/build.js
@@ -19,6 +19,10 @@ const BuildLink = styled.a`
   }
 `;
 
+BuildLink.defaultProps = {
+  className: "flex text-decoration-none dark-gray hover-lime mb2"
+};
+
 class BuildsDropdownBuild extends React.Component {
   static propTypes = {
     build: React.PropTypes.object,
@@ -48,7 +52,7 @@ class BuildsDropdownBuild extends React.Component {
     const buildTimeAbsolute = getDateString(buildTime);
 
     return (
-      <BuildLink href={this.props.build.url} className="flex text-decoration-none dark-gray hover-lime mb2">
+      <BuildLink href={this.props.build.url}>
         <div className="pr2 center">
           <BuildState.Small
             className="block"

--- a/app/components/user/BuildsDropdown/index.js
+++ b/app/components/user/BuildsDropdown/index.js
@@ -7,7 +7,7 @@ import Spinner from '../../shared/Spinner';
 
 import Build from './build';
 
-class BuildsDropdownIndex extends React.Component {
+class BuildsDropdown extends React.Component {
   static propTypes = {
     viewer: React.PropTypes.object,
     relay: React.PropTypes.object.isRequired
@@ -83,7 +83,7 @@ class BuildsDropdownIndex extends React.Component {
   };
 }
 
-export default Relay.createContainer(BuildsDropdownIndex, {
+export default Relay.createContainer(BuildsDropdown, {
   initialVariables: {
     isMounted: false
   },

--- a/app/css/transitions.css
+++ b/app/css/transitions.css
@@ -1,17 +1,5 @@
 /* popup */
 
-.transition-popup-t {
-  transform-origin: 42.5% -15px;
-}
-
-.transition-popup-tl {
-  transform-origin: 7.5% -15px;
-}
-
-.transition-popup-tr {
-  transform-origin: 92.5% -15px;
-}
-
 .transition-popup-enter {
   opacity: 0;
   transform: scaleX(.8) scaleY(.5);


### PR DESCRIPTION
**Before:**
<img width="320" alt="screen shot 2016-12-05 at 12 30 02 pm" src="https://cloud.githubusercontent.com/assets/282113/20901321/de420e24-bae6-11e6-94df-5df70ba69fe0.png">

**After:**
<img width="320" alt="screen shot 2016-12-07 at 2 05 16 pm" src="https://cloud.githubusercontent.com/assets/282113/20988584/415de244-bc86-11e6-9678-b0e56cf5855b.png">

- makes the dropdown viewport-aware
  - Dropdowns with `align="center"` (now the default) will automatically position (and resize, if necessary) themselves to stay within the viewport!
  - they'll make sure their bodies are visible, set the position of their nibs to match their parents, and set their `transformOrigin` to line up (bonus points: `transformOrigin`s for centered Dropdowns were actually previously slightly wrong!)
  - resizing is handled with intelligent debouncing;
    - if a dropdown is shown, it'll update every 100ms until resizing ceases, which seems to be about the right spot for it to feel right
    - if a dropdown isn't shown, we're rather lazier and only update 250ms after the last resize event (this is good because reading DOM layout is expensive!)
- *all* Dropdowns (including those which were previously on-screen already) now use this viewport-aware behaviour
  - we can probably delete the left and right alignment code! ✨
- this introduces a new way of using Styled Components; in an attempt to attain "composition," I've tried out using defaultProps on the component definitions. This means that the styles and the classes they compose are shown in the same location, but it doesn't read quite as well as I'd have hoped - let me know what you think of it!