### PR TITLE
Fix breakpoint misses

### DIFF
--- a/app/css/container.css
+++ b/app/css/container.css
@@ -7,9 +7,11 @@
   @media (min-width: 768px) {
     width: 750px;
   }
+
   @media (min-width: 992px) {
     width: 970px;
   }
+
   @media (min-width: 1200px) {
     width: 1170px;
   }
@@ -17,7 +19,7 @@
 
 /* Override the breakpoints set in basscss-hide so they match up with the container
  * widths above */
-@custom-media --breakpoint-xs (max-width: 768px);
-@custom-media --breakpoint-sm-md (min-width: 768px) and (max-width: 992px);
-@custom-media --breakpoint-md-lg (min-width: 992px) and (max-width: 1200px);
+@custom-media --breakpoint-xs (max-width: 767px);
+@custom-media --breakpoint-sm-md (min-width: 768px) and (max-width: 991px);
+@custom-media --breakpoint-md-lg (min-width: 992px) and (max-width: 1199px);
 @custom-media --breakpoint-lg (min-width: 1200px);


### PR DESCRIPTION
Previously, the boundary sizes described by our breakpoints would overlap, causing ssingle-pixel sizes where behaviours were inconsistent.

This fixes this by subtracting one pixel from the max-width definitions of each breakpoint type.