### PR TITLE
Make navigation scrollbars lazy

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -145,7 +145,7 @@ class Navigation extends React.Component {
     if (this.props.organization) {
       return (
         <div className="border-top border-gray lg-hide">
-          <div className="container flex flex-stretch" style={{ height: 45, overflowX: 'scroll' }}>
+          <div className="container flex flex-stretch" style={{ height: 45, overflowX: 'auto' }}>
             {this.renderOrganizationMenu({ paddingLeft: 0 })}
           </div>
         </div>


### PR DESCRIPTION
When a use has scrollbars forced on (mouse is plugged in, using a tablet) and `overflow` properties are set to `scroll`, scrollbars are always shown. On OSX by default, most scrollbars sit above the content, whereas when they are shown they collapse the content. With this change, scrollbars are shown when the screen is small and the content is wide, but not triggered in the default case.

**Previously (note the weird gray lines on the secondary navigation):**

![screen shot 2017-01-03 at 12 09 22 pm](https://cloud.githubusercontent.com/assets/718/21621348/6b159e56-d1ad-11e6-99d4-59ff99f3d927.png)

**After the fix:**

_Wide:_

![screen shot 2017-01-03 at 12 04 25 pm](https://cloud.githubusercontent.com/assets/718/21621368/85aee506-d1ad-11e6-8908-25f0c75157dd.png)

_Thin:_

![screen shot 2017-01-03 at 12 04 19 pm](https://cloud.githubusercontent.com/assets/718/21621375/8b613206-d1ad-11e6-8ce7-daa78aca0f5b.png)



