### PR TITLE
Treat those descenders right

### DIFF
--- a/app/components/layout/Navigation/dropdown-button.js
+++ b/app/components/layout/Navigation/dropdown-button.js
@@ -12,7 +12,7 @@ class DropdownButton extends React.Component {
 
   render() {
     return (
-      <button style={this.props.style} className={classNames("btn black hover-lime focus-lime semi-bold", this.props.className)}>
+      <button style={this.props.style} className={classNames("btn black hover-lime focus-lime semi-bold line-height-3", this.props.className)}>
         <div className="flex items-center flex-none">
           {this.props.children}
         </div>


### PR DESCRIPTION
Descenders in the organization and user dropdown buttons were cut off, as their line-heights were 1. This sets them (using `.line-height-3`) to `1.25em`, which provides enough clearance for descenders, and doesn't affect their vertical position because Thanks, Flexbox™!

**Before:**
<img width="148" alt="screen shot 2017-01-17 at 4 53 18 pm" src="https://cloud.githubusercontent.com/assets/282113/22046529/2b7d98f0-dcd6-11e6-8dd2-653aedc8674e.png">

**After:**
<img width="146" alt="screen shot 2017-01-17 at 4 53 27 pm" src="https://cloud.githubusercontent.com/assets/282113/22046543/3e8fb5a4-dcd6-11e6-939a-389acc413cc0.png">

fixes https://3.basecamp.com/3453178/buckets/2169122/todos/323587909