### PR TITLE
More explicitly connect git commit email with My Builds

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -173,7 +173,7 @@ class Navigation extends React.Component {
     }
 
     return (
-      <Dropdown width={300} className="flex" onToggle={this.handleBuildsDropdownToggle}>
+      <Dropdown width={320} className="flex" onToggle={this.handleBuildsDropdownToggle}>
         <DropdownButton className={classNames("py0", { "lime": this.state.showingBuildsDropdown })}>
           {'My Builds '}
           <div className="xs-hide">

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -173,7 +173,7 @@ class Navigation extends React.Component {
     }
 
     return (
-      <Dropdown width={250} className="flex" onToggle={this.handleBuildsDropdownToggle}>
+      <Dropdown width={300} className="flex" onToggle={this.handleBuildsDropdownToggle}>
         <DropdownButton className={classNames("py0", { "lime": this.state.showingBuildsDropdown })}>
           {'My Builds '}
           <div className="xs-hide">

--- a/app/components/shared/Button.js
+++ b/app/components/shared/Button.js
@@ -14,7 +14,7 @@ const OUTLINE_THEMES = {
   primary: "btn-outline border-blue blue",
   success: "btn-outline border-lime lime",
   warning: "btn-outline border-orange orange",
-  default: "btn-outline border-gray",
+  default: "btn-outline border-gray hover-black",
   error: "btn-outline border-red red"
 };
 

--- a/app/components/user/BuildsDropdown/index.js
+++ b/app/components/user/BuildsDropdown/index.js
@@ -58,8 +58,8 @@ class BuildsDropdown extends React.Component {
   renderSetupInstructions() {
     return (
       <div className="px3 py2">
-        <div className="mb3 dark-gray">Created builds but they’re not showing up here? Make sure you’ve added your commit email (e.g. <code className="border border-gray black" style={{ padding: '.1em .3em' }}>git config user.email</code>) to your list of verified email addresses.</div>
-        <Button href="/user/emails" theme="primary" className="center" style={{ width: "100%" }}>Update Email Addresses</Button>
+        <div className="mb3 dark-gray">To have your builds shown here, make sure to add and verify your commit email address (e.g. <code className="border border-gray black" style={{ padding: '.1em .3em' }}>git config user.email</code>) to your list of email addresses.</div>
+        <Button href="/user/emails" theme="default" outline={true} className="center" style={{ width: "100%" }}>Update Email Addresses</Button>
       </div>
     );
   }

--- a/app/components/user/BuildsDropdown/index.js
+++ b/app/components/user/BuildsDropdown/index.js
@@ -58,8 +58,8 @@ class BuildsDropdown extends React.Component {
   renderSetupInstructions() {
     return (
       <div className="px3 py2">
-        <div className="mb3">It looks like you haven’t created any builds yet. If you have created builds check that you’ve added all your git commit email addresses in your personal settings.</div>
-        <Button href="/user/emails" theme="default" outline={true} className="center" style={{ width: "100%" }}>Update Email Settings</Button>
+        <div className="mb3 dark-gray">Created builds but they’re not showing up here? Make sure you’ve added your commit email (e.g. <code className="border border-gray black" style={{ padding: '.1em .3em' }}>git config user.email</code>) to your list of verified email addresses.</div>
+        <Button href="/user/emails" theme="primary" className="center" style={{ width: "100%" }}>Update Email Addresses</Button>
       </div>
     );
   }

--- a/app/components/user/BuildsDropdown/index.js
+++ b/app/components/user/BuildsDropdown/index.js
@@ -58,7 +58,7 @@ class BuildsDropdown extends React.Component {
   renderSetupInstructions() {
     return (
       <div className="px3 py2">
-        <div className="mb2">To have your builds appear here, make sure that your commit email address (e.g. <code className="border border-gray dark-gray" style={{ padding: '.1em .3em' }}>git config user.email</code>) is added and verfified in your list of personal email addresses.</div>
+        <div className="mb2">To have your builds appear here, make sure that your commit email address (e.g. <code className="border border-gray dark-gray" style={{ padding: '.1em .3em' }}>git config user.email</code>) is added and verified in your list of personal email addresses.</div>
         <Button href="/user/emails" theme="default" outline={true} className="center" style={{ width: "100%" }}>Update Email Addresses</Button>
       </div>
     );

--- a/app/components/user/BuildsDropdown/index.js
+++ b/app/components/user/BuildsDropdown/index.js
@@ -58,7 +58,7 @@ class BuildsDropdown extends React.Component {
   renderSetupInstructions() {
     return (
       <div className="px3 py2">
-        <div className="mb2">To have your builds shown here, make sure to add and verify your commit email address (e.g. <code className="border border-gray dark-gray" style={{ padding: '.1em .3em' }}>git config user.email</code>) to your list of email addresses.</div>
+        <div className="mb2">To have your builds appear here, make sure that your commit email address (e.g. <code className="border border-gray dark-gray" style={{ padding: '.1em .3em' }}>git config user.email</code>) is added and verfified in your list of personal email addresses.</div>
         <Button href="/user/emails" theme="default" outline={true} className="center" style={{ width: "100%" }}>Update Email Addresses</Button>
       </div>
     );

--- a/app/components/user/BuildsDropdown/index.js
+++ b/app/components/user/BuildsDropdown/index.js
@@ -58,7 +58,7 @@ class BuildsDropdown extends React.Component {
   renderSetupInstructions() {
     return (
       <div className="px3 py2">
-        <div className="mb3 dark-gray">To have your builds shown here, make sure to add and verify your commit email address (e.g. <code className="border border-gray black" style={{ padding: '.1em .3em' }}>git config user.email</code>) to your list of email addresses.</div>
+        <div className="mb2">To have your builds shown here, make sure to add and verify your commit email address (e.g. <code className="border border-gray dark-gray" style={{ padding: '.1em .3em' }}>git config user.email</code>) to your list of email addresses.</div>
         <Button href="/user/emails" theme="default" outline={true} className="center" style={{ width: "100%" }}>Update Email Addresses</Button>
       </div>
     );


### PR DESCRIPTION
At the moment if you don't have your emails configured correctly, or you're a new user, this is what you see when you click on My Builds:

<img width="308" alt="my-builds-before" src="https://cloud.githubusercontent.com/assets/153/22094152/619bb59a-de5f-11e6-9259-ca960f598625.png">

The problem is that "you haven't created any builds yet" could be untrue. They could have created builds, they just haven't added their commit email address to their list of Buildkite email addresses.

<img width="357" alt="my-builds-after" src="https://cloud.githubusercontent.com/assets/153/22094269/625914ea-de60-11e6-92a1-f106936bea9f.png">

* Handles the case where people aren't using git, but some other SCM and using the API (that's why the `git config user.email` is just an example, and it's referred to as "commit email" instead of "git config email" or "git email".
* Helps to remind them what the command is to find out what git commit email they're using.
* Makes the dropdown a bit wider to fit the text. I wanted to do anyway because it gets a bit cramped and tall sometimes even though there's plenty of real estate. And in case you're wondering, it does  seem to handle mobile/small screens AOK already as well 👌🏼
* Makes the button a primary green one. I'm not 100% on this, but I figured it fits with the push of getting people to link their email up properly to builds, so it's probably better.