### PR TITLE
Refactored "My Builds" data loading

### DIFF
--- a/app/components/layout/Navigation/MyBuilds/index.js
+++ b/app/components/layout/Navigation/MyBuilds/index.js
@@ -151,7 +151,7 @@ class MyBuilds extends React.Component {
     // If `includeBuilds` hasn't been set to `true` yet (perhaps the mouseEnter
     // event never got triggered because we're on a mobile device) trigger a
     // load of the builds as the dropdown opens.
-    if(!this.props.relay.variables.includeBuilds) {
+    if (!this.props.relay.variables.includeBuilds) {
       this.props.relay.forceFetch({ includeBuilds: true });
     }
 
@@ -168,7 +168,7 @@ class MyBuilds extends React.Component {
   // If the user is hovering over the "My Builds" button, be sneaky and start
   // loading the build data in the background.
   handleButtonMouseEnter = () => {
-    if(!this.props.relay.variables.includeBuilds) {
+    if (!this.props.relay.variables.includeBuilds) {
       this.props.relay.forceFetch({ includeBuilds: true });
     }
   };
@@ -182,10 +182,10 @@ class MyBuilds extends React.Component {
   // then the builds would update a few moments later when the GraphQL query
   // finishes, which would be a bit weird.
   handlePusherWebsocketEvent = (payload) => {
-    const scheduledBuildsCountChanged = this.state.scheduledBuildsCount != payload.scheduledBuildsCount;
-    const runningBuildsCountChanged = this.state.runningBuildsCount != payload.runningBuildsCount;
+    const scheduledBuildsCountChanged = this.state.scheduledBuildsCount !== payload.scheduledBuildsCount;
+    const runningBuildsCountChanged = this.state.runningBuildsCount !== payload.runningBuildsCount;
 
-    if(scheduledBuildsCountChanged || runningBuildsCountChanged) {
+    if (scheduledBuildsCountChanged || runningBuildsCountChanged) {
       this.props.relay.forceFetch();
     }
   };
@@ -193,7 +193,7 @@ class MyBuilds extends React.Component {
 
 // Wrap the MyBuilds in a CachedStateWrapper so we get access to methods
 // like `setCachedState`
-const CachedMyBuilds = CachedStateWrapper(MyBuilds, { validLength: 1::hour })
+const CachedMyBuilds = CachedStateWrapper(MyBuilds, { validLength: 1::hour });
 
 export default Relay.createContainer(CachedMyBuilds, {
   initialVariables: {

--- a/app/components/layout/Navigation/MyBuilds/index.js
+++ b/app/components/layout/Navigation/MyBuilds/index.js
@@ -73,7 +73,7 @@ class MyBuilds extends React.Component {
   render() {
     return (
       <Dropdown width={320} className="flex" onToggle={this.handleDropdownToggle}>
-        <DropdownButton className={classNames("py0", { "lime": this.state.isDropdownVisible })}>
+        <DropdownButton className={classNames("py0", { "lime": this.state.isDropdownVisible })} onMouseEnter={this.handleButtonMouseEnter}>
           {'My Builds '}
           <div className="xs-hide">
             <ReactCSSTransitionGroup transitionName="transition-appear-pop" transitionEnterTimeout={200} transitionLeaveTimeout={200}>
@@ -148,6 +148,13 @@ class MyBuilds extends React.Component {
   }
 
   handleDropdownToggle = (visible) => {
+    // If `includeBuilds` hasn't been set to `true` yet (perhaps the mouseEnter
+    // event never got triggered because we're on a mobile device) trigger a
+    // load of the builds as the dropdown opens.
+    if(!this.props.relay.variables.includeBuilds) {
+      this.props.relay.forceFetch({ includeBuilds: true });
+    }
+
     this.setState({ isDropdownVisible: visible });
   };
 
@@ -156,6 +163,14 @@ class MyBuilds extends React.Component {
     // connected, we should force a refetch of the latest `scheduledBuilds` and
     // `runningBuilds` counts from GraphQL.
     this.props.relay.forceFetch({ includeBuildCounts: true });
+  };
+
+  // If the user is hovering over the "My Builds" button, be sneaky and start
+  // loading the build data in the background.
+  handleButtonMouseEnter = () => {
+    if(!this.props.relay.variables.includeBuilds) {
+      this.props.relay.forceFetch({ includeBuilds: true });
+    }
   };
 
   // When we recieve a Pusher event, check to see if the build counts have
@@ -182,8 +197,8 @@ const CachedMyBuilds = CachedStateWrapper(MyBuilds, { validLength: 1::hour })
 
 export default Relay.createContainer(CachedMyBuilds, {
   initialVariables: {
-    includeBuildCounts: false,
-    includeBuilds: false
+    includeBuilds: false,
+    includeBuildCounts: false
   },
 
   fragments: {

--- a/app/components/layout/Navigation/dropdown-button.js
+++ b/app/components/layout/Navigation/dropdown-button.js
@@ -7,12 +7,13 @@ class DropdownButton extends React.Component {
   static propTypes = {
     style: React.PropTypes.object,
     className: React.PropTypes.string,
-    children: React.PropTypes.node
+    children: React.PropTypes.node,
+    onMouseEnter: React.PropTypes.func
   };
 
   render() {
     return (
-      <button style={this.props.style} className={classNames("btn black hover-lime focus-lime semi-bold line-height-3", this.props.className)}>
+      <button style={this.props.style} className={classNames("btn black hover-lime focus-lime semi-bold line-height-3", this.props.className)} onMouseEnter={this.props.onMouseEnter}>
         <div className="flex items-center flex-none">
           {this.props.children}
         </div>


### PR DESCRIPTION
So I've tweaked the data loading of the dropdown to be a bit smarter to avoid the spinner as much as possible.

1. When the page loads, it uses the build numbers from the cache, shows them first.
2. After Pusher has connected, it refetches the latest values from GraphQL.

This ensures that we have the latest values, and we'll be notified when we get new ones.

When it comes to loading the actual builds:

- We start preloading the data on "mouse enter" to reduce the initial spinner time. Doesn't matter if they decide not to load it anyway
- If we receive a "user builds change" Pusher event, we refresh the "builds" and "counts", and render them at the same time. We ignore the data from pusher (which does include the latest build counts), but we'll refetch from GraphQL and use those as the source of truth to keep the UI in sync. So if you're viewing a page, and you see the number change in the nav, you'll know that there's something underneath it for you to look at.