### PR TITLE
Add missing build state icons

### DIFF
--- a/app/components/icons/BuildState.js
+++ b/app/components/icons/BuildState.js
@@ -25,7 +25,9 @@ const STATE_COLORS = {
   blocked: '#90c73e',
   failed: '#F83F23',
   canceled: '#F83F23',
-  canceling: '#F83F23'
+  canceling: '#F83F23',
+  skipped: '#83B0E4',
+  not_run: '#83B0E4'
 };
 
 class BuildState extends React.Component {
@@ -150,6 +152,8 @@ class BuildState extends React.Component {
         break;
 
       case 'pending':
+      case 'skipped':
+      case 'not_run':
         content = (
           <path d="M11,16H21" fill="none" {...applyStroke} />
         );

--- a/app/components/icons/BuildState.js
+++ b/app/components/icons/BuildState.js
@@ -24,7 +24,8 @@ const STATE_COLORS = {
   passed: '#90c73e',
   blocked: '#90c73e',
   failed: '#F83F23',
-  canceled: '#F83F23'
+  canceled: '#F83F23',
+  canceling: '#F83F23'
 };
 
 class BuildState extends React.Component {
@@ -130,6 +131,7 @@ class BuildState extends React.Component {
 
       case 'scheduled':
       case 'running':
+      case 'canceling':
         defs = (
           <mask id={maskId} x="9" y="9" width="14" height="14" maskUnits="userSpaceOnUse">
             <polygon

--- a/app/components/icons/BuildState.spec.js
+++ b/app/components/icons/BuildState.spec.js
@@ -12,7 +12,9 @@ const BUILD_STATES = [
   'passed',
   'blocked',
   'failed',
-  'canceled'
+  'canceled',
+  'skipped',
+  'not_run'
 ];
 
 describe('BuildState', () => {

--- a/app/components/icons/__snapshots__/BuildState.spec.js.snap
+++ b/app/components/icons/__snapshots__/BuildState.spec.js.snap
@@ -111,6 +111,39 @@ exports[`BuildState BuildState.Regular renders correctly for build state \`faile
 </svg>
 `;
 
+exports[`BuildState BuildState.Regular renders correctly for build state \`not_run\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  style={undefined}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#83B0E4"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#83B0E4"
+    strokeWidth={2} />
+</svg>
+`;
+
 exports[`BuildState BuildState.Regular renders correctly for build state \`passed\` 1`] = `
 <svg
   className={undefined}
@@ -288,6 +321,39 @@ exports[`BuildState BuildState.Regular renders correctly for build state \`sched
 </svg>
 `;
 
+exports[`BuildState BuildState.Regular renders correctly for build state \`skipped\` 1`] = `
+<svg
+  className={undefined}
+  height={32}
+  style={undefined}
+  viewBox="0 0 32 32"
+  width={32}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#83B0E4"
+      strokeWidth={4} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#83B0E4"
+    strokeWidth={2} />
+</svg>
+`;
+
 exports[`BuildState BuildState.Small renders correctly for build state \`blocked\` 1`] = `
 <svg
   className={undefined}
@@ -398,6 +464,39 @@ exports[`BuildState BuildState.Small renders correctly for build state \`failed\
     <path
       d="M11.3997245,0.600275489 L0.600275489,11.3997245" />
   </g>
+</svg>
+`;
+
+exports[`BuildState BuildState.Small renders correctly for build state \`not_run\` 1`] = `
+<svg
+  className={undefined}
+  height={20}
+  style={undefined}
+  viewBox="0 0 32 32"
+  width={20}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#83B0E4"
+      strokeWidth={6} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#83B0E4"
+    strokeWidth={3} />
 </svg>
 `;
 
@@ -578,6 +677,39 @@ exports[`BuildState BuildState.Small renders correctly for build state \`schedul
 </svg>
 `;
 
+exports[`BuildState BuildState.Small renders correctly for build state \`skipped\` 1`] = `
+<svg
+  className={undefined}
+  height={20}
+  style={undefined}
+  viewBox="0 0 32 32"
+  width={20}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#83B0E4"
+      strokeWidth={6} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#83B0E4"
+    strokeWidth={3} />
+</svg>
+`;
+
 exports[`BuildState BuildState.XSmall renders correctly for build state \`blocked\` 1`] = `
 <svg
   className={undefined}
@@ -688,6 +820,39 @@ exports[`BuildState BuildState.XSmall renders correctly for build state \`failed
     <path
       d="M11.3997245,0.600275489 L0.600275489,11.3997245" />
   </g>
+</svg>
+`;
+
+exports[`BuildState BuildState.XSmall renders correctly for build state \`not_run\` 1`] = `
+<svg
+  className={undefined}
+  height={13}
+  style={undefined}
+  viewBox="0 0 32 32"
+  width={13}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#83B0E4"
+      strokeWidth={8} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#83B0E4"
+    strokeWidth={4} />
 </svg>
 `;
 
@@ -865,6 +1030,39 @@ exports[`BuildState BuildState.XSmall renders correctly for build state \`schedu
       stroke="#bbbbbb"
       strokeWidth={4} />
   </g>
+</svg>
+`;
+
+exports[`BuildState BuildState.XSmall renders correctly for build state \`skipped\` 1`] = `
+<svg
+  className={undefined}
+  height={13}
+  style={undefined}
+  viewBox="0 0 32 32"
+  width={13}>
+  <defs>
+    <circle
+      cx="16"
+      cy="16"
+      fill="none"
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle"
+      r="15"
+      stroke="#83B0E4"
+      strokeWidth={8} />
+    <clipPath
+      id="BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath">
+      <use
+        xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+    </clipPath>
+  </defs>
+  <use
+    clipPath="url(#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_strokeClipPath)"
+    xlinkHref="#BuildState_NORMALLY-UUID-GOES-HERE-BUTNEVERMIND_circle" />
+  <path
+    d="M11,16H21"
+    fill="none"
+    stroke="#83B0E4"
+    strokeWidth={4} />
 </svg>
 `;
 

--- a/app/components/organization/Pipeline/graph.js
+++ b/app/components/organization/Pipeline/graph.js
@@ -20,6 +20,10 @@ const SCHEDULED_COLOR = "#BBB";
 const SCHEDULED_COLOR_HOVER = "#888";
 const PENDING_COLOR = "#DDD";
 const PENDING_COLOR_HOVER = "#DDD";
+const SKIPPED_COLOR = "#83B0E4";
+const SKIPPED_COLOR_HOVER = "#3769A2";
+const NOT_RUN_COLOR = "#83B0E4";
+const NOT_RUN_COLOR_HOVER = "#3769A2";
 
 class Graph extends React.Component {
   static propTypes = {
@@ -146,6 +150,10 @@ class Graph extends React.Component {
       return RUNNING_COLOR;
     } else if (build.state === "passed" || build.state === "blocked") {
       return PASSED_COLOR;
+    } else if (build.state === "skipped") {
+      return SKIPPED_COLOR;
+    } else if (build.state === "not_run") {
+      return NOT_RUN_COLOR;
     } else {
       return FAILED_COLOR;
     }
@@ -158,6 +166,10 @@ class Graph extends React.Component {
       return RUNNING_COLOR_HOVER;
     } else if (build.state === "passed" || build.state === "blocked") {
       return PASSED_COLOR_HOVER;
+    } else if (build.state === "skipped") {
+      return SKIPPED_COLOR_HOVER;
+    } else if (build.state === "not_run") {
+      return NOT_RUN_COLOR_HOVER;
     } else {
       return FAILED_COLOR_HOVER;
     }

--- a/app/components/organization/Pipeline/graph.js
+++ b/app/components/organization/Pipeline/graph.js
@@ -22,8 +22,8 @@ const PENDING_COLOR = "#DDD";
 const PENDING_COLOR_HOVER = "#DDD";
 const SKIPPED_COLOR = "#83B0E4";
 const SKIPPED_COLOR_HOVER = "#3769A2";
-const NOT_RUN_COLOR = "#83B0E4";
-const NOT_RUN_COLOR_HOVER = "#3769A2";
+const NOT_RUN_COLOR = SKIPPED_COLOR;
+const NOT_RUN_COLOR_HOVER = SKIPPED_COLOR_HOVER;
 
 class Graph extends React.Component {
   static propTypes = {


### PR DESCRIPTION
Currently this adds a "Cancelling" build state icon, which is the same as running build but red (the same as cancelled, which is a red cross). So the icon change will be from grey spinning to red spinning.

The current handled states are:

- `pending`
- `scheduled`
- `running`
- `passed`
- `blocked`
- `failed`
- `canceled`
- `canceling`

Are we missing any others?

Closes #147