### PR TITLE
Fix AgentsCount inconsistencies

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -50,7 +50,6 @@ window["Webpack"] = {
     "components/shared/FormTextField": require("./components/shared/FormTextField").default,
     "components/shared/FriendlyTime": require("./components/shared/FriendlyTime").default,
     "components/shared/Icon": require("./components/shared/Icon").default,
-    "components/organization/AgentsCount": require("./components/organization/AgentsCount").default,
     "components/organization/SettingsMenu": require("./components/organization/SettingsMenu").default,
     "components/user/SettingsMenu": require("./components/user/SettingsMenu").default,
     "components/user/BuildCountsBreakdown": require("./components/user/BuildCountsBreakdown").default,

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -265,12 +265,10 @@ export default Relay.createContainer(Navigation, {
   fragments: {
     organization: () => Relay.QL`
         fragment on Organization {
+          ${AgentsCount.getFragment('organization')}
           name
           id
           slug
-          agents {
-            count
-          }
           permissions {
             organizationUpdate {
               allowed

--- a/app/components/organization/AgentsCount.js
+++ b/app/components/organization/AgentsCount.js
@@ -28,12 +28,10 @@ class AgentsCount extends React.Component {
   };
 
   componentDidMount() {
-    console.debug('AgentsCount didMount');
     PusherStore.on('organization_stats:change', this.handlePusherWebsocketEvent);
   }
 
   componentWillUnmount() {
-    console.debug('AgentsCount willUnmount');
     PusherStore.off('organization_stats:change', this.handlePusherWebsocketEvent);
   }
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "react-type-snob": "^0.0.3",
     "shuffle-array": "^1.0.0",
     "styled-components": "^1.1.2",
+    "throttleit": "^1.0.0",
     "uuid": "^3.0.1",
     "whatwg-fetch": "^1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6647,6 +6647,10 @@ throat@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.0.0.tgz#e7c64c867cbb3845f10877642f7b60055b8ec0d6"
 
+throttleit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
+
 through2-filter@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/through2-filter/-/through2-filter-2.0.0.tgz#60bc55a0dacb76085db1f9dae99ab43f83d622ec"


### PR DESCRIPTION
This updates the AgentsCount component to be Relay-aware, and instead of alternatingly trusting the Pusher agent count and Relay agent count, instead takes a change on the Pusher end as a cue to `forceFetch` updated values from Relay.

This causes the component to stay pretty stable when it comes to repaints.

I also took the opportunity to switch over to using `shallowCompare` in `shouldComponentUpdate` and remove the component from the Webpack bridge in app.js

Fixes https://3.basecamp.com/3453178/buckets/1445180/todos/323608085