### PR TITLE
Only show the email prompt if theres no associated user

### DIFF
--- a/app/components/build/AvatarWithUnknownEmailPrompt.js
+++ b/app/components/build/AvatarWithUnknownEmailPrompt.js
@@ -72,7 +72,7 @@ class AvatarWithUnknownEmailPrompt extends React.Component {
   componentDidMount() {
     const { createdBy } = this.props.build;
 
-    if (createdBy && createdBy.email && createdBy.__typename == "UnregisteredUser" && !this.isCurrentUsersValidatedEmail(createdBy.email)) {
+    if (createdBy && createdBy.email && createdBy.__typename === "UnregisteredUser" && !this.isCurrentUsersValidatedEmail(createdBy.email)) {
       this.props.relay.setVariables(
         {
           isTryingToPrompt: true,

--- a/app/components/build/AvatarWithUnknownEmailPrompt.js
+++ b/app/components/build/AvatarWithUnknownEmailPrompt.js
@@ -72,7 +72,7 @@ class AvatarWithUnknownEmailPrompt extends React.Component {
   componentDidMount() {
     const { createdBy } = this.props.build;
 
-    if (createdBy && createdBy.email && !this.isCurrentUsersValidatedEmail(createdBy.email)) {
+    if (createdBy && createdBy.email && createdBy.__typename == "UnregisteredUser" && !this.isCurrentUsersValidatedEmail(createdBy.email)) {
       this.props.relay.setVariables(
         {
           isTryingToPrompt: true,
@@ -258,6 +258,7 @@ export default Relay.createContainer(AvatarWithUnknownEmailPrompt, {
     build: () => Relay.QL`
       fragment on Build {
         createdBy {
+          __typename
           ...on UnregisteredUser {
             name
             email


### PR DESCRIPTION
Before we'd show the prompt even if there was an associated user. This changes the code so it'll only prompt if GraphQL says: "hey, we actually don't have a user here"