### PR TITLE
Make the Changelogs badge bulletproof

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -24,7 +24,6 @@ class Navigation extends React.Component {
     relay: React.PropTypes.object.isRequired
   };
 
-
   componentDidMount() {
     this.props.relay.setVariables({ isMounted: true });
   }
@@ -192,7 +191,15 @@ class Navigation extends React.Component {
                   style={{ width: 27, height: 18, marginTop: 7.5, marginBottom: 4.5 }}
                 />
               </NavigationButton>
-              <NewChangelogsBadge className="mr2 relative" style={{ top: -5, marginLeft: -8 }} viewer={this.props.viewer} />
+              <NewChangelogsBadge
+                className="mr2 relative"
+                style={{
+                  top: -5,
+                  marginLeft: -8
+                }}
+                viewer={this.props.viewer}
+                isMounted={this.props.relay.variables.isMounted}
+              />
             </span>
 
             <Dropdown width={250} className="flex" style={{ minWidth: "5em" }} onToggle={this.handleOrgDropdownToggle}>
@@ -288,9 +295,10 @@ export default Relay.createContainer(Navigation, {
           }
         }
       `,
-    viewer: () => Relay.QL`
+    viewer: (variables) => Relay.QL`
         fragment on Viewer {
           ${MyBuilds.getFragment('viewer')}
+          ${NewChangelogsBadge.getFragment('viewer', variables)}
           user {
             name
             avatar {
@@ -304,9 +312,6 @@ export default Relay.createContainer(Navigation, {
                 name
               }
             }
-          }
-          unreadChangelogs: changelogs(read: false) @include(if: $isMounted) {
-            count
           }
         }
       `

--- a/app/components/user/NewChangelogsBadge.js
+++ b/app/components/user/NewChangelogsBadge.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import Relay from 'react-relay';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 
 import PusherStore from '../../stores/PusherStore';
@@ -15,10 +17,6 @@ class NewChangelogsBadge extends React.Component {
     })
   };
 
-  state = {
-    unreadChangelogsCount: this.props.viewer.unreadChangelogs ? this.props.viewer.unreadChangelogs.count : 0
-  };
-
   componentDidMount() {
     PusherStore.on("user_stats:change", this.handlePusherWebsocketEvent);
   }
@@ -28,41 +26,71 @@ class NewChangelogsBadge extends React.Component {
   }
 
   handlePusherWebsocketEvent = (payload) => {
-    this.setState({ unreadChangelogsCount: payload.unreadChangelogsCount });
+    this.props.relay.forceFetch();
   };
 
-  componentWillReceiveProps = (nextProps) => {
-    if (nextProps.viewer.unreadChangelogs) {
-      this.setState({ unreadChangelogsCount: nextProps.viewer.unreadChangelogs.count });
-    }
-  }
-
   shouldComponentUpdate = (nextProps, nextState) => {
-    const { unreadChangeLogsCount: lastChangeLogsCount } = this.state;
-
-    const { unreadChangeLogsCount: newChangeLogsCount } = nextState;
-    const { unreadChangelogs: newUnreadChangelogs } = nextProps.viewer;
-
-    return (
-      (newUnreadChangelogs && newUnreadChangelogs.count !== lastChangeLogsCount)
-      || (newChangeLogsCount !== lastChangeLogsCount)
-    );
+    return shallowCompare(this, nextProps, nextState);
   };
 
   render() {
-    if (this.state.unreadChangelogsCount > 0) {
-      return (
-        <ReactCSSTransitionGroup transitionName="transition-changelog-appear" transitionAppear={true} transitionAppearTimeout={3000} transitionEnterTimeout={5000} transitionLeaveTimeout={5000}>
-          <span key="badge" className={classNames(this.props.className, "inline-block hover-faded")} style={this.props.style}>
-            <a href="/changelog" className="btn bg-lime white hover-white focus-white line-height-1" style={{ padding: '3px 4px', fontSize: '9px', borderRadius: 5 }}>NEW</a>
-            <img className="pointer-events-none" src={require('../../images/new-changelog-badge-bottom-corner.svg')} style={{ width: 12, height: 12, position: 'absolute', left: -3, bottom: -2 }} />
-          </span>
-        </ReactCSSTransitionGroup>
-      );
-    } else {
+    if (!this.props.viewer.unreadChangelogs || !this.props.viewer.unreadChangelogs.count) {
       return null;
     }
+
+    return (
+      <ReactCSSTransitionGroup
+        transitionName="transition-changelog-appear"
+        transitionAppear={true}
+        transitionAppearTimeout={3000}
+        transitionEnterTimeout={5000}
+        transitionLeaveTimeout={5000}
+      >
+        <span
+          key="badge"
+          className={classNames(this.props.className, "inline-block hover-faded")}
+          style={this.props.style}
+        >
+          <a
+            href="/changelog"
+            className="btn bg-lime white hover-white focus-white line-height-1"
+            style={{
+              padding: '3px 4px',
+              fontSize: 9,
+              borderRadius: 5
+            }}
+          >
+            NEW
+          </a>
+          <img
+            className="pointer-events-none"
+            src={require('../../images/new-changelog-badge-bottom-corner.svg')}
+            style={{
+              width: 12,
+              height: 12,
+              position: 'absolute',
+              left: -3,
+              bottom: -2
+            }}
+          />
+        </span>
+      </ReactCSSTransitionGroup>
+    );
   }
 }
 
-export default NewChangelogsBadge;
+export default Relay.createContainer(NewChangelogsBadge, {
+  initialVariables: {
+    isMounted: false
+  },
+
+  fragments: {
+    viewer: () => Relay.QL`
+        fragment on Viewer {
+          unreadChangelogs: changelogs(read: false) @include(if: $isMounted) {
+            count
+          }
+        }
+      `
+  }
+});

--- a/app/components/user/NewChangelogsBadge.js
+++ b/app/components/user/NewChangelogsBadge.js
@@ -9,6 +9,7 @@ import PusherStore from '../../stores/PusherStore';
 class NewChangelogsBadge extends React.Component {
   static propTypes = {
     className: React.PropTypes.string,
+    relay: React.PropTypes.object.isRequired,
     style: React.PropTypes.object,
     viewer: React.PropTypes.shape({
       unreadChangelogs: React.PropTypes.shape({
@@ -25,7 +26,7 @@ class NewChangelogsBadge extends React.Component {
     PusherStore.off("user_stats:change", this.handlePusherWebsocketEvent);
   }
 
-  handlePusherWebsocketEvent = (payload) => {
+  handlePusherWebsocketEvent = () => {
     this.props.relay.forceFetch();
   };
 


### PR DESCRIPTION
Previously, it suffered from the same state caching issues as other Pusher-powered things that could also be interacted with (opening, for instance, the Organizations dropdown, would cause it to use the cached state), this updates it to act correctly in all cases.

It also makes it a relay container which accepts the isMounted variable from its parent, so that it can force an update of only its data set whilst also being updated on-mount without triggering a separate request for its data!