### PR TITLE
Improved date formatting

### DIFF
--- a/app/components/shared/__snapshots__/Duration.spec.js.snap
+++ b/app/components/shared/__snapshots__/Duration.spec.js.snap
@@ -1,7 +1,7 @@
 exports[`Duration Duration.Full overrides allow overriding format behaviours 1`] = `
 <span
   className="tabular-numerals">
-  1332 weeks, 11 days, 7 hours, 29 minutes, 0 seconds
+  1330 weeks, 11 days, 7 hours, 29 minutes, 0 seconds
 </span>
 `;
 
@@ -50,14 +50,14 @@ exports[`Duration Duration.Full renders as expected 6`] = `
 exports[`Duration Duration.Full renders as expected 7`] = `
 <span
   className="tabular-numerals">
-  1 week, 13 days, 16 hours
+  13 days, 16 hours, 22 minutes
 </span>
 `;
 
 exports[`Duration Duration.Full renders as expected 8`] = `
 <span
   className="tabular-numerals">
-  9 weeks, 2 days, 20 hours
+  8 weeks, 2 days, 20 hours
 </span>
 `;
 
@@ -71,7 +71,7 @@ exports[`Duration Duration.Full tabularNumerals can be disabled 1`] = `
 exports[`Duration Duration.Micro overrides allow overriding format behaviours 1`] = `
 <span
   className="tabular-numerals">
-  1332w 11d 7h 29m 0s
+  1330w 11d 7h 29m 0s
 </span>
 `;
 
@@ -120,7 +120,7 @@ exports[`Duration Duration.Micro renders as expected 6`] = `
 exports[`Duration Duration.Micro renders as expected 7`] = `
 <span
   className="tabular-numerals">
-  3w
+  2w
 </span>
 `;
 
@@ -141,7 +141,7 @@ exports[`Duration Duration.Micro tabularNumerals can be disabled 1`] = `
 exports[`Duration Duration.Short overrides allow overriding format behaviours 1`] = `
 <span
   className="tabular-numerals">
-  1332w 11d 7h 29m 0s
+  1330w 11d 7h 29m 0s
 </span>
 `;
 
@@ -190,14 +190,14 @@ exports[`Duration Duration.Short renders as expected 6`] = `
 exports[`Duration Duration.Short renders as expected 7`] = `
 <span
   className="tabular-numerals">
-  1w 14d
+  13d 16h
 </span>
 `;
 
 exports[`Duration Duration.Short renders as expected 8`] = `
 <span
   className="tabular-numerals">
-  9w 3d
+  8w 3d
 </span>
 `;
 

--- a/app/lib/__snapshots__/date.spec.js.snap
+++ b/app/lib/__snapshots__/date.spec.js.snap
@@ -22,17 +22,17 @@ exports[`getDurationString correctly handles \`full\` dates when given \`2016-05
 
 exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-08T16:03:21.000+10:00\` and no format override 1`] = `"1 day, 7 hours, 3 minutes"`;
 
-exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and a length of 5 in a format override 1`] = `"1 week, 13 days, 16 hours, 22 minutes, 12 seconds"`;
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and a length of 5 in a format override 1`] = `"13 days, 16 hours, 22 minutes, 12 seconds"`;
 
-exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and no format override 1`] = `"1 week, 13 days, 16 hours"`;
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and no format override 1`] = `"13 days, 16 hours, 22 minutes"`;
 
-exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and a length of 5 in a format override 1`] = `"9 weeks, 2 days, 19 hours, 34 minutes, 17 seconds"`;
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and a length of 5 in a format override 1`] = `"8 weeks, 2 days, 19 hours, 34 minutes, 17 seconds"`;
 
-exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and no format override 1`] = `"9 weeks, 2 days, 20 hours"`;
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and no format override 1`] = `"8 weeks, 2 days, 20 hours"`;
 
-exports[`getDurationString correctly handles \`full\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and a length of 5 in a format override 1`] = `"2 weeks, 15 days, 8 hours, 30 minutes, 40 seconds"`;
+exports[`getDurationString correctly handles \`full\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and a length of 5 in a format override 1`] = `"15 days, 8 hours, 30 minutes, 40 seconds"`;
 
-exports[`getDurationString correctly handles \`full\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and no format override 1`] = `"2 weeks, 15 days, 9 hours"`;
+exports[`getDurationString correctly handles \`full\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and no format override 1`] = `"15 days, 8 hours, 31 minutes"`;
 
 exports[`getDurationString correctly handles \`full\` dates when given \`undefined\` and \`2016-10-06T08:09:25.000+10:00\` and a length of 5 in a format override 1`] = `"0 seconds"`;
 
@@ -74,17 +74,17 @@ exports[`getDurationString correctly handles \`micro\` dates when given \`2016-0
 
 exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-08T16:03:21.000+10:00\` and no format override 1`] = `"1d"`;
 
-exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and a length of 5 in a format override 1`] = `"1w 13d 16h 22m 12s"`;
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and a length of 5 in a format override 1`] = `"13d 16h 22m 12s"`;
 
-exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and no format override 1`] = `"3w"`;
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and no format override 1`] = `"2w"`;
 
-exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and a length of 5 in a format override 1`] = `"9w 2d 19h 34m 17s"`;
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and a length of 5 in a format override 1`] = `"8w 2d 19h 34m 17s"`;
 
 exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and no format override 1`] = `"9w"`;
 
-exports[`getDurationString correctly handles \`micro\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and a length of 5 in a format override 1`] = `"2w 15d 8h 30m 40s"`;
+exports[`getDurationString correctly handles \`micro\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and a length of 5 in a format override 1`] = `"15d 8h 30m 40s"`;
 
-exports[`getDurationString correctly handles \`micro\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and no format override 1`] = `"4w"`;
+exports[`getDurationString correctly handles \`micro\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and no format override 1`] = `"2w"`;
 
 exports[`getDurationString correctly handles \`micro\` dates when given \`undefined\` and \`2016-10-06T08:09:25.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
 
@@ -126,17 +126,17 @@ exports[`getDurationString correctly handles \`short\` dates when given \`2016-0
 
 exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-08T16:03:21.000+10:00\` and no format override 1`] = `"1d 7h"`;
 
-exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and a length of 5 in a format override 1`] = `"1w 13d 16h 22m 12s"`;
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and a length of 5 in a format override 1`] = `"13d 16h 22m 12s"`;
 
-exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and no format override 1`] = `"1w 14d"`;
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and no format override 1`] = `"13d 16h"`;
 
-exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and a length of 5 in a format override 1`] = `"9w 2d 19h 34m 17s"`;
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and a length of 5 in a format override 1`] = `"8w 2d 19h 34m 17s"`;
 
-exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and no format override 1`] = `"9w 3d"`;
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and no format override 1`] = `"8w 3d"`;
 
-exports[`getDurationString correctly handles \`short\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and a length of 5 in a format override 1`] = `"2w 15d 8h 30m 40s"`;
+exports[`getDurationString correctly handles \`short\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and a length of 5 in a format override 1`] = `"15d 8h 30m 40s"`;
 
-exports[`getDurationString correctly handles \`short\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and no format override 1`] = `"2w 15d"`;
+exports[`getDurationString correctly handles \`short\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and no format override 1`] = `"15d 9h"`;
 
 exports[`getDurationString correctly handles \`short\` dates when given \`undefined\` and \`2016-10-06T08:09:25.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
 

--- a/app/lib/__snapshots__/date.spec.js.snap
+++ b/app/lib/__snapshots__/date.spec.js.snap
@@ -1,3 +1,171 @@
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:00.000+10:00\` and a length of 5 in a format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:00.000+10:00\` and no format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:05.000+10:00\` and a length of 5 in a format override 1`] = `"5 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:05.000+10:00\` and no format override 1`] = `"5 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:15:07.000+10:00\` and a length of 5 in a format override 1`] = `"15 minutes, 7 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:15:07.000+10:00\` and no format override 1`] = `"15 minutes, 7 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T10:45:16.000+10:00\` and a length of 5 in a format override 1`] = `"1 hour, 45 minutes, 16 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T10:45:16.000+10:00\` and no format override 1`] = `"1 hour, 45 minutes, 16 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T13:59:03.000+10:00\` and a length of 5 in a format override 1`] = `"4 hours, 59 minutes, 3 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T13:59:03.000+10:00\` and no format override 1`] = `"4 hours, 59 minutes, 3 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-08T16:03:21.000+10:00\` and a length of 5 in a format override 1`] = `"1 day, 7 hours, 3 minutes, 21 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-08T16:03:21.000+10:00\` and no format override 1`] = `"1 day, 7 hours, 3 minutes"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and a length of 5 in a format override 1`] = `"1 week, 13 days, 16 hours, 22 minutes, 12 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and no format override 1`] = `"1 week, 13 days, 16 hours"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and a length of 5 in a format override 1`] = `"9 weeks, 2 days, 19 hours, 34 minutes, 17 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and no format override 1`] = `"9 weeks, 2 days, 20 hours"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and a length of 5 in a format override 1`] = `"2 weeks, 15 days, 8 hours, 30 minutes, 40 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and no format override 1`] = `"2 weeks, 15 days, 9 hours"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`undefined\` and \`2016-10-06T08:09:25.000+10:00\` and a length of 5 in a format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`undefined\` and \`2016-10-06T08:09:25.000+10:00\` and no format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`undefined\` and \`2016-10-06T08:09:55.000+10:00\` and a length of 5 in a format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`undefined\` and \`2016-10-06T08:09:55.000+10:00\` and no format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`undefined\` and \`2016-10-06T08:10:25.000+10:00\` and a length of 5 in a format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`undefined\` and \`2016-10-06T08:10:25.000+10:00\` and no format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`undefined\` and \`undefined\` and a length of 5 in a format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`full\` dates when given \`undefined\` and \`undefined\` and no format override 1`] = `"0 seconds"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:00.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:00.000+10:00\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:05.000+10:00\` and a length of 5 in a format override 1`] = `"5s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:05.000+10:00\` and no format override 1`] = `"5s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:15:07.000+10:00\` and a length of 5 in a format override 1`] = `"15m 7s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:15:07.000+10:00\` and no format override 1`] = `"15m"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T10:45:16.000+10:00\` and a length of 5 in a format override 1`] = `"1h 45m 16s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T10:45:16.000+10:00\` and no format override 1`] = `"2h"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T13:59:03.000+10:00\` and a length of 5 in a format override 1`] = `"4h 59m 3s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T13:59:03.000+10:00\` and no format override 1`] = `"5h"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-08T16:03:21.000+10:00\` and a length of 5 in a format override 1`] = `"1d 7h 3m 21s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-08T16:03:21.000+10:00\` and no format override 1`] = `"1d"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and a length of 5 in a format override 1`] = `"1w 13d 16h 22m 12s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and no format override 1`] = `"3w"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and a length of 5 in a format override 1`] = `"9w 2d 19h 34m 17s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and no format override 1`] = `"9w"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and a length of 5 in a format override 1`] = `"2w 15d 8h 30m 40s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and no format override 1`] = `"4w"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`undefined\` and \`2016-10-06T08:09:25.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`undefined\` and \`2016-10-06T08:09:25.000+10:00\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`undefined\` and \`2016-10-06T08:09:55.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`undefined\` and \`2016-10-06T08:09:55.000+10:00\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`undefined\` and \`2016-10-06T08:10:25.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`undefined\` and \`2016-10-06T08:10:25.000+10:00\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`undefined\` and \`undefined\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`micro\` dates when given \`undefined\` and \`undefined\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:00.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:00.000+10:00\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:05.000+10:00\` and a length of 5 in a format override 1`] = `"5s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:00:05.000+10:00\` and no format override 1`] = `"5s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:15:07.000+10:00\` and a length of 5 in a format override 1`] = `"15m 7s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T09:15:07.000+10:00\` and no format override 1`] = `"15m 7s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T10:45:16.000+10:00\` and a length of 5 in a format override 1`] = `"1h 45m 16s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T10:45:16.000+10:00\` and no format override 1`] = `"1h 45m"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T13:59:03.000+10:00\` and a length of 5 in a format override 1`] = `"4h 59m 3s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-07T13:59:03.000+10:00\` and no format override 1`] = `"4h 59m"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-08T16:03:21.000+10:00\` and a length of 5 in a format override 1`] = `"1d 7h 3m 21s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-08T16:03:21.000+10:00\` and no format override 1`] = `"1d 7h"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and a length of 5 in a format override 1`] = `"1w 13d 16h 22m 12s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-05-21T01:22:12.000+10:00\` and no format override 1`] = `"1w 14d"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and a length of 5 in a format override 1`] = `"9w 2d 19h 34m 17s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2016-05-07T09:00:00.000+10:00\` and \`2016-07-10T04:34:17.000+10:00\` and no format override 1`] = `"9w 3d"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and a length of 5 in a format override 1`] = `"2w 15d 8h 30m 40s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`2017-01-17T08:57:30.994-08:00\` and \`2017-02-01T17:28:11.712-08:00\` and no format override 1`] = `"2w 15d"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`undefined\` and \`2016-10-06T08:09:25.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`undefined\` and \`2016-10-06T08:09:25.000+10:00\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`undefined\` and \`2016-10-06T08:09:55.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`undefined\` and \`2016-10-06T08:09:55.000+10:00\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`undefined\` and \`2016-10-06T08:10:25.000+10:00\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`undefined\` and \`2016-10-06T08:10:25.000+10:00\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`undefined\` and \`undefined\` and a length of 5 in a format override 1`] = `"0s"`;
+
+exports[`getDurationString correctly handles \`short\` dates when given \`undefined\` and \`undefined\` and no format override 1`] = `"0s"`;
+
+exports[`getDurationString defaults to full dates 1`] = `"5 seconds"`;
+
+exports[`getDurationString falls back to \`now\` when not supplied a \`to\` value 1`] = `"1 day, 4 hours, 30 minutes"`;
+
+exports[`getDurationString falls back to \`now\` when not supplied a \`to\` value 2`] = `"1d 5h"`;
+
+exports[`getDurationString falls back to \`now\` when not supplied a \`to\` value 3`] = `"0s"`;
+
+exports[`getDurationString formats are supplied as an array 1`] = `3`;
+
+exports[`getDurationString throws if supplied with an unknown format 1`] = `"getDurationString: Unknown format \`not-a-date-format\`."`;
+
 exports[`getRelativeDateString when supplied with options=\`{"capitalized":false,"inPast":false}\` renders a correct time in the future (now: 2016-05-07T09:00:00+10:00, date: 2016-05-07T09:00:00+10:00) 1`] = `"today at 9:00 AM"`;
 
 exports[`getRelativeDateString when supplied with options=\`{"capitalized":false,"inPast":false}\` renders a correct time in the future (now: 2016-05-07T09:00:00+10:00, date: 2016-05-07T16:45:16+10:00) 1`] = `"today at 4:45 PM"`;
@@ -1005,159 +1173,3 @@ exports[`getRelativeDateString when supplied with options=\`undefined\` renders 
 exports[`getRelativeDateString when supplied with options=\`undefined\` renders a correct time in the past or present (now: 2016-07-10T04:34:17+08:00, date: 2016-05-07T09:00:00+10:00) 1`] = `"Sat 7th May at 9:00 AM"`;
 
 exports[`getRelativeDateString when supplied with options=\`undefined\` renders a correct time in the past or present (now: 2018-01-01T04:34:17-07:00, date: 2016-05-07T09:00:00+10:00) 1`] = `"Sat 7th May 16 at 9:00 AM"`;
-
-exports[`getDurationString correctly handles \`full\` dates 1`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 2`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 3`] = `"5 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 4`] = `"5 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 5`] = `"15 minutes, 7 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 6`] = `"15 minutes, 7 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 7`] = `"1 hour, 45 minutes, 16 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 8`] = `"1 hour, 45 minutes, 16 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 9`] = `"4 hours, 59 minutes, 3 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 10`] = `"4 hours, 59 minutes, 3 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 11`] = `"1 day, 7 hours, 3 minutes"`;
-
-exports[`getDurationString correctly handles \`full\` dates 12`] = `"1 day, 7 hours, 3 minutes, 21 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 13`] = `"1 week, 13 days, 16 hours"`;
-
-exports[`getDurationString correctly handles \`full\` dates 14`] = `"1 week, 13 days, 16 hours, 22 minutes, 12 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 15`] = `"9 weeks, 2 days, 20 hours"`;
-
-exports[`getDurationString correctly handles \`full\` dates 16`] = `"9 weeks, 2 days, 19 hours, 34 minutes, 17 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 17`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 18`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 19`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 20`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 21`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 22`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 23`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`full\` dates 24`] = `"0 seconds"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 1`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 2`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 3`] = `"5s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 4`] = `"5s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 5`] = `"15m"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 6`] = `"15m 7s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 7`] = `"2h"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 8`] = `"1h 45m 16s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 9`] = `"5h"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 10`] = `"4h 59m 3s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 11`] = `"1d"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 12`] = `"1d 7h 3m 21s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 13`] = `"3w"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 14`] = `"1w 13d 16h 22m 12s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 15`] = `"9w"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 16`] = `"9w 2d 19h 34m 17s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 17`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 18`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 19`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 20`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 21`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 22`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 23`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`micro\` dates 24`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 1`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 2`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 3`] = `"5s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 4`] = `"5s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 5`] = `"15m 7s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 6`] = `"15m 7s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 7`] = `"1h 45m"`;
-
-exports[`getDurationString correctly handles \`short\` dates 8`] = `"1h 45m 16s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 9`] = `"4h 59m"`;
-
-exports[`getDurationString correctly handles \`short\` dates 10`] = `"4h 59m 3s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 11`] = `"1d 7h"`;
-
-exports[`getDurationString correctly handles \`short\` dates 12`] = `"1d 7h 3m 21s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 13`] = `"1w 14d"`;
-
-exports[`getDurationString correctly handles \`short\` dates 14`] = `"1w 13d 16h 22m 12s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 15`] = `"9w 3d"`;
-
-exports[`getDurationString correctly handles \`short\` dates 16`] = `"9w 2d 19h 34m 17s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 17`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 18`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 19`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 20`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 21`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 22`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 23`] = `"0s"`;
-
-exports[`getDurationString correctly handles \`short\` dates 24`] = `"0s"`;
-
-exports[`getDurationString defaults to full dates 1`] = `"5 seconds"`;
-
-exports[`getDurationString falls back to \`now\` when not supplied a \`to\` value 1`] = `"1 day, 4 hours, 30 minutes"`;
-
-exports[`getDurationString falls back to \`now\` when not supplied a \`to\` value 2`] = `"1d 5h"`;
-
-exports[`getDurationString falls back to \`now\` when not supplied a \`to\` value 3`] = `"0s"`;
-
-exports[`getDurationString formats are supplied as an array 1`] = `3`;
-
-exports[`getDurationString throws if supplied with an unknown format 1`] = `"getDurationString: Unknown format \`not-a-date-format\`."`;

--- a/app/lib/date.js
+++ b/app/lib/date.js
@@ -93,10 +93,12 @@ export function getDurationString(from, to = moment(), format = 'full', override
     let amount;
 
     if (times.length === 0) {
-      // the first one needs to take into account all larger units
-      amount = Math.floor(duration.as(label));
+      // the first one needs to take into account all larger units,
+      // otherwise we'd  end up with results not taking into account
+      // units larger than the largest unit in `TIME_SPANS`
+      amount = duration.as(label);
     } else {
-      // the rest work fine as Moment defines them
+      // further time spans do not require the above consideration
       amount = duration.get(label);
     }
 
@@ -104,28 +106,67 @@ export function getDurationString(from, to = moment(), format = 'full', override
     amount = Math.max(amount, 0);
 
     // the last label is always supplied, even if it's 0
-    if (amount > 0 || index === labels.length - 1) {
+    if (Math.floor(amount) > 0 || index === labels.length - 1) {
       times.push({ amount, label });
     }
   });
 
-  // only keep the most significant digits
-  const displayedTimes = times.slice(0, configuration.length);
+  // if we have more than one time span, we need to do some processing, because
+  //  a) the first time span will _include_ some smaller time spans
+  //  b) we'll need to include discarded time spans in the last time span
+  // otherwise, if we only have a single time span, we can rely on the value
+  // returned as the first index by `Moment#as`
+  if (times.length > 1) {
+    const firstTime = times[0];
 
-  if (displayedTimes.length < times.length) {
-    // let's round the last item using the next item we'd have shown
-    const lastTime = displayedTimes[displayedTimes.length - 1];
-    const nextTime = times[displayedTimes.length];
+    if (configuration.length > 1) {
+      // if we're accepting more than one time span, we need to subtract the
+      // second most significant span from the most significant time span, then
+      // floor it, as the most significant span include smaller time spans.
 
-    lastTime.amount = Math.round(
-      moment
-        .duration(lastTime.amount, lastTime.label)
-        .add(nextTime.amount, nextTime.label)
-        .as(lastTime.label)
-    );
+      const secondTime = times[1];
+
+      firstTime.amount = Math.floor(
+        moment
+          .duration(firstTime.amount, firstTime.label)
+          .subtract(secondTime.amount, secondTime.label)
+          .as(firstTime.label)
+      );
+    } else {
+      // otherwise, we simply round the first time span
+      firstTime.amount = Math.round(firstTime.amount);
+    }
+
+    // if the first time span is now zero, we can ignore it, and the next time
+    // span does not require the same processing it did
+    if (firstTime.amount < 1) {
+      times.shift();
+    }
+
+    // if we still have data we're discarding, let's add the first discarded
+    // item to the last shown item and round the result
+    if (configuration.length < times.length && configuration.length > 1) {
+      const lastTime = times[configuration.length - 1];
+      const nextTime = times[configuration.length];
+
+      lastTime.amount = Math.round(
+        moment
+          .duration(lastTime.amount, lastTime.label)
+          .add(nextTime.amount, nextTime.label)
+          .as(lastTime.label)
+      );
+    }
   }
 
-  return displayedTimes.map(configuration.render).join(configuration.commas ? ', ' : ' ');
+  return times
+    // only keep the most significant digits
+    .slice(0, configuration.length)
+    .map(configuration.render)
+    .join(
+      configuration.commas
+        ? ', '
+        : ' '
+    );
 }
 
 getDurationString.formats = Object.keys(DATE_FORMATS);

--- a/app/lib/date.spec.js
+++ b/app/lib/date.spec.js
@@ -70,6 +70,7 @@ const DURATION_FIXTURES = [
   { from: "2016-05-07T09:00:00.000+10:00", to: "2016-05-08T16:03:21.000+10:00" },
   { from: "2016-05-07T09:00:00.000+10:00", to: "2016-05-21T01:22:12.000+10:00" },
   { from: "2016-05-07T09:00:00.000+10:00", to: "2016-07-10T04:34:17.000+10:00" },
+  { from: "2017-01-17T08:57:30.994-08:00", to: "2017-02-01T17:28:11.712-08:00" },
   { from: undefined, to: undefined },
   { from: undefined, to: "2016-10-06T08:10:25.000+10:00" },
   { from: undefined, to: "2016-10-06T08:09:55.000+10:00" },
@@ -89,10 +90,17 @@ describe('getDurationString', () => {
   });
 
   getDurationString.formats.map((format) => {
-    it(`correctly handles \`${format}\` dates`, () => {
+    describe(`correctly handles \`${format}\` dates`, () => {
       DURATION_FIXTURES.forEach(({ from, to }) => {
-        expect(getDurationString(from, to, format)).toMatchSnapshot();
-        expect(getDurationString(from, to, format, { length: 5 })).toMatchSnapshot();
+        describe(`when given \`${from}\` and \`${to}\``, () => {
+          it(`and no format override`, () => {
+            expect(getDurationString(from, to, format)).toMatchSnapshot();
+          });
+
+          it(`and a length of 5 in a format override`, () => {
+            expect(getDurationString(from, to, format, { length: 5 })).toMatchSnapshot();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
A bug existed which meant the most significant unit of duration would be shown including the value of next most significant unit of duration. This caused strangely divergent results between `micro` and `full` date rendering.

This improves the logic which controls truncation and merging of duration segments, and fixes #165's issue. It also improves the output of the date spec suite (for best results, inspect the changes in 027b904, as they are _after_ the improved date spec suite was added)