### PR TITLE
Make it clear when assuming a user

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -32,7 +32,7 @@ class Navigation extends React.Component {
     showingOrgDropdown: false,
     showingUserDropdown: false,
     showingSupportDialog: false,
-    assumed: window['_adminIsAssumingUser']
+    warning: window['_navigation'] && window['_navigation']['warning']
   };
 
   handleOrgDropdownToggle = (visible) => {
@@ -175,7 +175,7 @@ class Navigation extends React.Component {
   render() {
     return (
       <div
-        className={classNames("border-bottom border-gray bg-silver", { "bg-warning-stripes": this.state.assumed })}
+        className={classNames("border-bottom border-gray bg-silver", { "bg-warning-stripes": this.state.warning })}
         style={{ fontSize: 13, marginBottom: 25 }}
         data-tag={true}
       >
@@ -248,7 +248,7 @@ class Navigation extends React.Component {
                 <input type="hidden" name="_method" value={"delete"} />
                 <input type="hidden" name={window._csrf.param} value={window._csrf.token} />
                 <NavigationButton href="#" onClick={this.handleLogoutClick}>
-                  {this.state.assumed ? 'Unassume User' : 'Logout'}
+                  {this.state.warning ? 'Unassume User' : 'Logout'}
                 </NavigationButton>
               </form>
             </Dropdown>

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -21,7 +21,8 @@ class Navigation extends React.Component {
   static propTypes = {
     organization: React.PropTypes.object,
     viewer: React.PropTypes.object,
-    relay: React.PropTypes.object.isRequired
+    relay: React.PropTypes.object.isRequired,
+    assumed: React.PropTypes.bool
   };
 
   componentDidMount() {
@@ -173,7 +174,11 @@ class Navigation extends React.Component {
 
   render() {
     return (
-      <div className="border-bottom border-gray bg-silver" style={{ fontSize: 13, marginBottom: 25 }} data-tag={true}>
+      <div
+        className={classNames("border-bottom border-gray bg-silver", { "bg-warning-stripes": this.props.assumed })}
+        style={{ fontSize: 13, marginBottom: 25 }}
+        data-tag={true}
+      >
         <div className="container">
           <div className="flex flex-stretch" style={{ height: 45 }}>
             <span className="flex relative border-right border-gray items-center">
@@ -242,7 +247,9 @@ class Navigation extends React.Component {
               <form action="/logout" method="post" ref={(logoutFormNode) => this.logoutFormNode = logoutFormNode}>
                 <input type="hidden" name="_method" value={"delete"} />
                 <input type="hidden" name={window._csrf.param} value={window._csrf.token} />
-                <NavigationButton href="#" onClick={this.handleLogoutClick}>Logout</NavigationButton>
+                <NavigationButton href="#" onClick={this.handleLogoutClick}>
+                  {this.props.assumed ? 'Unassume User' : 'Logout'}
+                </NavigationButton>
               </form>
             </Dropdown>
           </div>

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -21,8 +21,7 @@ class Navigation extends React.Component {
   static propTypes = {
     organization: React.PropTypes.object,
     viewer: React.PropTypes.object,
-    relay: React.PropTypes.object.isRequired,
-    assumed: React.PropTypes.bool
+    relay: React.PropTypes.object.isRequired
   };
 
   componentDidMount() {
@@ -32,7 +31,8 @@ class Navigation extends React.Component {
   state = {
     showingOrgDropdown: false,
     showingUserDropdown: false,
-    showingSupportDialog: false
+    showingSupportDialog: false,
+    assumed: window['_adminIsAssumingUser']
   };
 
   handleOrgDropdownToggle = (visible) => {
@@ -175,7 +175,7 @@ class Navigation extends React.Component {
   render() {
     return (
       <div
-        className={classNames("border-bottom border-gray bg-silver", { "bg-warning-stripes": this.props.assumed })}
+        className={classNames("border-bottom border-gray bg-silver", { "bg-warning-stripes": this.state.assumed })}
         style={{ fontSize: 13, marginBottom: 25 }}
         data-tag={true}
       >
@@ -248,7 +248,7 @@ class Navigation extends React.Component {
                 <input type="hidden" name="_method" value={"delete"} />
                 <input type="hidden" name={window._csrf.param} value={window._csrf.token} />
                 <NavigationButton href="#" onClick={this.handleLogoutClick}>
-                  {this.props.assumed ? 'Unassume User' : 'Logout'}
+                  {this.state.assumed ? 'Unassume User' : 'Logout'}
                 </NavigationButton>
               </form>
             </Dropdown>

--- a/app/css/background-colors.css
+++ b/app/css/background-colors.css
@@ -19,13 +19,3 @@
 .bg-fuchsia { background-color: var(--fuchsia) }
 .bg-purple  { background-color: var(--purple) }
 .bg-maroon  { background-color: var(--maroon) }
-
-.bg-warning-stripes {
-  background: repeating-linear-gradient(
-    -55deg,
-    #FFF1D9,
-    #FFF1D9 10px,
-    #FFFFEB 10px,
-    #FFFFEB 20px
-  );
-}

--- a/app/css/background-colors.css
+++ b/app/css/background-colors.css
@@ -19,3 +19,13 @@
 .bg-fuchsia { background-color: var(--fuchsia) }
 .bg-purple  { background-color: var(--purple) }
 .bg-maroon  { background-color: var(--maroon) }
+
+.bg-warning-stripes {
+  background: repeating-linear-gradient(
+    -55deg,
+    #FFF1D9,
+    #FFF1D9 10px,
+    #FFFFEB 10px,
+    #FFFFEB 20px
+  );
+}

--- a/app/css/backgrounds.css
+++ b/app/css/backgrounds.css
@@ -1,0 +1,9 @@
+.bg-warning-stripes {
+  background: repeating-linear-gradient(
+    -55deg,
+    #FFF1D9,
+    #FFF1D9 10px,
+    #FFFFEB 10px,
+    #FFFFEB 20px
+  );
+}

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -2,6 +2,7 @@
 @import 'btn-primary';
 @import 'btn-outline';
 @import 'backdrop';
+@import 'backgrounds';
 @import 'background-colors';
 @import 'background-hover-colors';
 @import 'border-colors';


### PR DESCRIPTION
This adds an `assuming` prop to `Navigation`, so we can make it clearer when you're assuming a user:

![assuming-user](https://cloud.githubusercontent.com/assets/153/22637161/67335a38-ec94-11e6-81b9-588c5b10f5c2.png)