### PR TITLE
Fix awkward timestamp line breaks in build popovers

### DIFF
--- a/app/components/organization/Pipeline/status.js
+++ b/app/components/organization/Pipeline/status.js
@@ -39,6 +39,7 @@ class Status extends React.Component {
             className="color-inherit relative"
             onMouseOver={this.handleMouseOver}
             onMouseOut={this.handleMouseOut}
+            width={300}
           >
             <span className="block line-height-1"><BuildState.Regular state={build.state} /></span>
           </a>


### PR DESCRIPTION
For older builds with larger timestamps, the pipelines build popover width can be too narrow to fit the last line:
![feb-12-2017 13-03-07](https://cloud.githubusercontent.com/assets/153/22859048/c6011800-f123-11e6-8641-fd226cc38da6.gif)

Instead of using the default `AnchoredPopover` width of 250, this sets it explicitly to 300 which covers most cases for the last line.