### PR TITLE
Sticky team selections: Chunk 1, Frontend amazingness

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -32,7 +32,8 @@ class Navigation extends React.Component {
   }
 
   componentWillMount() {
-    if (this.props.organization && this.props.organization.slug) {
+    // When the page loads, we want to pull the last default team out of the SessionHashStore.
+    if (this.props.organization && this.props.organization.id) {
       this.setState({
         lastDefaultTeam: SessionHashStore.get(`organization-default-team:${this.props.organization.id}`)
       });
@@ -40,7 +41,9 @@ class Navigation extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.organization && nextProps.organization.slug && nextProps.organization.slug !== this.props.organization.slug) {
+    // If we're moving between organizations, we need to pull out the new organization's default team setting,
+    // if it's available.
+    if (nextProps.organization && nextProps.organization.id && nextProps.organization.id !== this.props.organization.id) {
       this.setState({
         lastDefaultTeam: SessionHashStore.get(`organization-default-team:${nextProps.organization.id}`)
       });
@@ -60,6 +63,8 @@ class Navigation extends React.Component {
   };
 
   handleSessionDataChange = ({ key, newValue }) => {
+    // When the SessionHashStore gets a change, if the update was to the
+    // currently displayed team, update the state with the new value!
     if (key === `organization-default-team:${this.props.organization.id}`) {
       this.setState({
         lastDefaultTeam: newValue
@@ -165,6 +170,7 @@ class Navigation extends React.Component {
   getOrganizationPipelinesUrl(organization) {
     let link = `/${organization.slug}`;
 
+    // Make the link default to the user's default team, if that data exists
     if (this.state.lastDefaultTeam) {
       link = `${link}?team=${this.state.lastDefaultTeam}`;
     }

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -34,7 +34,7 @@ class Navigation extends React.Component {
   componentWillMount() {
     if (this.props.organization && this.props.organization.slug) {
       this.setState({
-        lastDefaultTeam: SessionHashStore.get(`organization-default-team:${this.props.organization.slug}`)
+        lastDefaultTeam: SessionHashStore.get(`organization-default-team:${this.props.organization.id}`)
       });
     }
   }
@@ -42,7 +42,7 @@ class Navigation extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.organization && nextProps.organization.slug && nextProps.organization.slug !== this.props.organization.slug) {
       this.setState({
-        lastDefaultTeam: SessionHashStore.get(`organization-default-team:${nextProps.organization.slug}`)
+        lastDefaultTeam: SessionHashStore.get(`organization-default-team:${nextProps.organization.id}`)
       });
     }
   }
@@ -60,7 +60,7 @@ class Navigation extends React.Component {
   };
 
   handleSessionDataChange = ({ key, newValue }) => {
-    if (key === `organization-default-team:${this.props.organization.slug}`) {
+    if (key === `organization-default-team:${this.props.organization.id}`) {
       this.setState({
         lastDefaultTeam: newValue
       });

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -3,6 +3,8 @@ import Relay from 'react-relay';
 
 import SectionLoader from '../shared/SectionLoader';
 
+import SessionHashStore from '../../stores/SessionHashStore';
+
 import Pipeline from './Pipeline';
 import Welcome from './Welcome';
 
@@ -41,6 +43,8 @@ class OrganizationPipelines extends React.Component {
         }, 0);
       }
     });
+
+    this.maybeUpdateDefaultTeam(this.props.organization.slug, this.props.team);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -57,6 +61,20 @@ class OrganizationPipelines extends React.Component {
           }
         });
       });
+    }
+
+    this.maybeUpdateDefaultTeam(nextProps.organization.slug, nextProps.team);
+  }
+
+  maybeUpdateDefaultTeam(organization, team) {
+    const orgDefaultTeamKey = `organization-default-team:${organization}`;
+
+    if (team !== SessionHashStore.get(orgDefaultTeamKey)) {
+      if (team) {
+        SessionHashStore.set(orgDefaultTeamKey, team);
+      } else {
+        SessionHashStore.remove(orgDefaultTeamKey);
+      }
     }
   }
 

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -45,6 +45,7 @@ class OrganizationPipelines extends React.Component {
       }
     });
 
+    // We might've started out with a new team, so let's see about updating the default!
     this.maybeUpdateDefaultTeam(this.props.organization.id, this.props.team);
   }
 
@@ -64,6 +65,9 @@ class OrganizationPipelines extends React.Component {
       });
     }
 
+    // Let's try updating the default team - we don't rely on the last team
+    // being different here because the store might've gotten out of sync,
+    // and we do out own check!
     this.maybeUpdateDefaultTeam(nextProps.organization.id, nextProps.team);
   }
 

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -11,6 +11,7 @@ import Welcome from './Welcome';
 class OrganizationPipelines extends React.Component {
   static propTypes = {
     organization: React.PropTypes.shape({
+      id: React.PropTypes.string.isRequired,
       slug: React.PropTypes.string.isRequired,
       pipelines: React.PropTypes.shape({
         edges: React.PropTypes.arrayOf(
@@ -44,7 +45,7 @@ class OrganizationPipelines extends React.Component {
       }
     });
 
-    this.maybeUpdateDefaultTeam(this.props.organization.slug, this.props.team);
+    this.maybeUpdateDefaultTeam(this.props.organization.id, this.props.team);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -63,7 +64,7 @@ class OrganizationPipelines extends React.Component {
       });
     }
 
-    this.maybeUpdateDefaultTeam(nextProps.organization.slug, nextProps.team);
+    this.maybeUpdateDefaultTeam(nextProps.organization.id, nextProps.team);
   }
 
   maybeUpdateDefaultTeam(organization, team) {
@@ -142,6 +143,7 @@ export default Relay.createContainer(OrganizationPipelines, {
   fragments: {
     organization: (variables) => Relay.QL`
       fragment on Organization {
+        id
         slug
         pipelines(first: 500, team: $teamSearch, order: PIPELINE_ORDER_NAME) @include(if: $isMounted) {
           edges {

--- a/app/stores/SessionHashStore.js
+++ b/app/stores/SessionHashStore.js
@@ -2,10 +2,10 @@ import EventEmitter from 'eventemitter3';
 
 const LOCALSTORAGE_PREFIX = 'SessionHashStore:';
 
-const keyWithPrefix = (key='') => `${LOCALSTORAGE_PREFIX}${key}`;
+const keyWithPrefix = (key = '') => `${LOCALSTORAGE_PREFIX}${key}`;
 const keySansPrefix = (prefixedKey) => {
   if (prefixedKey.indexOf(LOCALSTORAGE_PREFIX) !== 0) {
-    throw new Error('keySansPrefix called with invalid key')
+    throw new Error('keySansPrefix called with invalid key');
   }
   return prefixedKey.slice(LOCALSTORAGE_PREFIX.length);
 };
@@ -58,7 +58,7 @@ class SessionHashStore extends EventEmitter {
     Object.keys(localStorage)
       .filter((key) => key.indexOf(LOCALSTORAGE_PREFIX) === 0)
       .forEach((key) => {
-        localStorage.removeItem(key)
+        localStorage.removeItem(key);
 
         this.sendVirtualEvent(
           keySansPrefix(key),

--- a/app/stores/SessionHashStore.js
+++ b/app/stores/SessionHashStore.js
@@ -1,0 +1,87 @@
+import EventEmitter from 'eventemitter3';
+
+const LOCALSTORAGE_PREFIX = 'SessionHashStore:';
+
+const keyWithPrefix = (key='') => `${LOCALSTORAGE_PREFIX}${key}`;
+const keySansPrefix = (prefixedKey) => {
+  if (prefixedKey.indexOf(LOCALSTORAGE_PREFIX) !== 0) {
+    throw new Error('keySansPrefix called with invalid key')
+  }
+  return prefixedKey.slice(LOCALSTORAGE_PREFIX.length);
+};
+
+class SessionHashStore extends EventEmitter {
+  constructor() {
+    super(...arguments);
+
+    // NOTE: Storage events are *only* sent to tabs/windows which did
+    // not initiate the change! This tripped me up for half an hour. 🙄
+    window.addEventListener('storage', this.handleStorageEvent, false);
+  }
+
+  handleStorageEvent = ({ key: prefixedKey, oldValue, newValue }) => {
+    if (prefixedKey.indexOf(keyWithPrefix()) === 0) {
+      this.emitMessage(keySansPrefix(prefixedKey), oldValue, newValue);
+    }
+  };
+
+  get(key) {
+    return localStorage.getItem(keyWithPrefix(key));
+  }
+
+  set(key, value) {
+    const prefixedKey = keyWithPrefix(key);
+
+    this.emitMessage(
+      key,
+      localStorage.getItem(prefixedKey),
+      value
+    );
+
+    localStorage.setItem(prefixedKey, value);
+  }
+
+  remove(key) {
+    const prefixedKey = keyWithPrefix(key);
+
+    this.emitMessage(
+      key,
+      localStorage.getItem(prefixedKey),
+      null
+    );
+
+    localStorage.removeItem(prefixedKey);
+  }
+
+  clear() {
+    // clear SessionHashStore-managed localStorage items
+    Object.keys(localStorage)
+      .filter((key) => key.indexOf(LOCALSTORAGE_PREFIX) === 0)
+      .forEach((key) => {
+        localStorage.removeItem(key)
+
+        this.sendVirtualEvent(
+          keySansPrefix(key),
+          localStorage.getItem(key),
+          null
+        );
+      });
+  }
+
+  emitMessage(key, oldValue, newValue) {
+    if (oldValue === newValue) {
+      return;
+    }
+
+    this.emit(
+      'change',
+      {
+        key,
+        oldValue,
+        newValue
+      }
+    );
+  }
+}
+
+export default new SessionHashStore();


### PR DESCRIPTION
This pull request persists the last selected* team for a given Organization to a user’s localStorage, and updates the Navigation link to match.

- [x] 1. Create a localStorage-based store technology for session key-values
- [x] 2. Push last seen team selection on pipelines page into 1
  - [x] If page loads with a selected team, update key-value store with team slug
  - [x] If changing the team in the UI, update the store with the team slug
- [x] 3. Listen to store in navigation, update pipelines page link with team slug

_*this means it can get inconsistent when switching tabs, which is a bit weird, but hey_