### PR TITLE
Improved agent searching

### DIFF
--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -19,6 +19,9 @@ const PAGE_SIZE = 100;
 class Agents extends React.Component {
   static propTypes = {
     organization: React.PropTypes.shape({
+      allAgents: React.PropTypes.shape({
+        count: React.PropTypes.number.isRequired
+      }),
       agents: React.PropTypes.shape({
         count: React.PropTypes.number.isRequired,
         pageInfo: React.PropTypes.shape({
@@ -264,10 +267,8 @@ class Agents extends React.Component {
   }
 
   get useLocalSearch() {
-    // If we've loaded the agents, and there's no more pages of data, then we can do a local search
     return this.props.organization.agents &&
-      this.props.organization.agents.edges.length > 0 &&
-      !this.props.organization.agents.pageInfo.hasNextPage;
+      this.props.organization.allAgents.count <= PAGE_SIZE;
   }
 
   get useRemoteSearch() {
@@ -355,6 +356,9 @@ export default Relay.createContainer(Agents, {
   fragments: {
     organization: () => Relay.QL`
       fragment on Organization {
+        allAgents: agents @include(if: $isMounted) {
+          count
+        }
         agents(first: $pageSize, search: $search) @include(if: $isMounted) {
           count
           edges {

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -104,6 +104,7 @@ class Agents extends React.Component {
                 placeholder="Filter"
                 style={{ fontSize: 12, lineHeight: 1.1, height: 30, width: 160 }}
                 onSearch={this.handleSearch}
+                delayed={this.useRemoteSearch}
               />
             </div>
           </div>
@@ -217,17 +218,23 @@ class Agents extends React.Component {
     );
   }
 
+  get useLocalSearch() {
+    // If we've loaded the agents, and there's no more pages of data, then we can do a local search
+    return this.props.organization.agents &&
+      this.props.organization.agents.edges.length > 0 &&
+      !this.props.organization.agents.pageInfo.hasNextPage;
+  }
+
+  get useRemoteSearch() {
+    return !this.useLocalSearch;
+  }
+
   handleSearch = (query) => {
-    const { organization } = this.props;
-
-    // if we have the full set of agents locally, do our searching here
-    if (organization.agents && organization.agents.edges.length > 0 && !organization.agents.pageInfo.hasNextPage) {
+    if (this.useLocalSearch) {
       return this.handleLocalSearch(query);
+    } else {
+      return this.handleRemoteSearch(query);
     }
-
-    // if we haven't loaded anything yet, last retrieved a total of 0 agents,
-    // or have more agents than are displayed, do the searching on the server
-    return this.handleRemoteSearch(query);
   };
 
   handleLocalSearch = (query) => {

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -105,7 +105,6 @@ class Agents extends React.Component {
                 placeholder="Filter"
                 style={{ fontSize: 12, lineHeight: 1.1, height: 30, width: 160 }}
                 onSearch={this.handleSearch}
-                delayed={this.useRemoteSearch}
               />
             </div>
           </div>

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -172,9 +172,11 @@ class Agents extends React.Component {
 
           // Key=Value matching
           //
+          // 'moo=tr' matches 'moo=true'
           // 'moo=true' matches 'moo=true'
+          // 'moo=rue' doesn't match 'moo=true'
           // 'moo=false' doesn't match 'moo=true'
-          if (query.metaDataKey === key && query.metaDataValue === value) {
+          if (query.metaDataKey === key && value.indexOf(query.metaDataValue) === 0) {
             return true;
           }
         });

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -174,11 +174,13 @@ class Agents extends React.Component {
       return relevantAgents.map(({ node: agent }) => <AgentRow key={agent.id} agent={agent} />);
     }
 
-    return (
-      <Panel.Section className="dark-gray">
-        No agents {isContextFiltered ? 'found' : 'connected'}
-      </Panel.Section>
-    );
+    if (!isContextFiltered) {
+      return (
+        <Panel.Section className="dark-gray">
+          No agents {isContextFiltered ? 'found' : 'connected'}
+        </Panel.Section>
+      );
+    }
   }
 
   renderFooter() {

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -36,6 +36,7 @@ class Agents extends React.Component {
   state = {
     loading: false,
     searchingRemotely: false,
+    searchingRemotelyIsSlow: false,
     localSearchQuery: null
   };
 
@@ -120,7 +121,7 @@ class Agents extends React.Component {
   }
 
   renderSearchSpinner() {
-    if (this.state.searchingRemotely) {
+    if (this.state.searchingRemotelyIsSlow) {
       return (
         <Spinner className="mr2" />
       );
@@ -318,13 +319,27 @@ class Agents extends React.Component {
   handleRemoteSearch = (query) => {
     this.setState({ localSearchQuery: null, searchingRemotely: true });
 
+    if (this.remoteSearchIsSlowTimeout) {
+      clearTimeout(this.remoteSearchIsSlowTimeout);
+    }
+
+    this.remoteSearchIsSlowTimeout = setTimeout(() => {
+      this.setState({ searchingRemotelyIsSlow: true });
+    }, 1::seconds);
+
     this.props.relay.forceFetch(
       {
         search: query
       },
       (readyState) => {
         if (readyState.done) {
-          this.setState({ searchingRemotely: false });
+          if (this.remoteSearchIsSlowTimeout) {
+            clearTimeout(this.remoteSearchIsSlowTimeout);
+          }
+          this.setState({
+            searchingRemotely: false,
+            searchingRemotelyIsSlow: false
+          });
         }
       }
     );

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -98,7 +98,8 @@ class Agents extends React.Component {
         <div className="bg-silver semi-bold">
           <div className="flex items-center">
             <div className="flex-auto py2 px3">Agents</div>
-            <div className="mr3">
+            <div className="flex items-center mr3">
+              {this.renderSearchSpinner()}
               <Search
                 className="input py1 px2"
                 placeholder="Filter"
@@ -114,6 +115,14 @@ class Agents extends React.Component {
         {this.renderFooter()}
       </Panel>
     );
+  }
+
+  renderSearchSpinner() {
+    if (this.state.searchingRemotely) {
+      return (
+        <Spinner className="mr2" />
+      );
+    }
   }
 
   getRelevantAgents() {
@@ -145,7 +154,7 @@ class Agents extends React.Component {
     const { organization: { agents }, relay: { variables: { search: remoteSearchQuery } } } = this.props;
     const { searchingRemotely, localSearchQuery } = this.state;
 
-    if ((localSearchQuery && relevantAgents) || remoteSearchQuery && agents && !searchingRemotely) {
+    if ((localSearchQuery && relevantAgents) || remoteSearchQuery && agents) {
       return (
         <div className="bg-silver semi-bold py2 px3">
           <small className="dark-gray">
@@ -158,26 +167,22 @@ class Agents extends React.Component {
 
   renderAgentList(relevantAgents) {
     const { relay: { variables: { search: remoteSearchQuery } } } = this.props;
-    const { searchingRemotely, localSearchQuery } = this.state;
+    const { localSearchQuery } = this.state;
 
     const isContextFiltered = !!(remoteSearchQuery || localSearchQuery);
 
-    if (!relevantAgents || searchingRemotely) {
+    if (!relevantAgents) {
       return (
         <Panel.Section className="center">
           <Spinner />
         </Panel.Section>
       );
-    }
-
-    if (relevantAgents.length > 0) {
+    } else if (relevantAgents.length > 0) {
       return relevantAgents.map(({ node: agent }) => <AgentRow key={agent.id} agent={agent} />);
-    }
-
-    if (!isContextFiltered) {
+    } else if (!isContextFiltered) {
       return (
         <Panel.Section className="dark-gray">
-          No agents {isContextFiltered ? 'found' : 'connected'}
+          No agents connected
         </Panel.Section>
       );
     }
@@ -187,8 +192,8 @@ class Agents extends React.Component {
     const { organization } = this.props;
     const { loading, searchingRemotely, localSearchQuery } = this.state;
 
-    // don't show any footer if we're searching locally, or awaiting results
-    if (localSearchQuery || searchingRemotely) {
+    // don't show any footer if we're searching locally
+    if (localSearchQuery) {
       return;
     }
 

--- a/app/components/agent/Index/search.js
+++ b/app/components/agent/Index/search.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import throttleit from 'throttleit';
+import throttle from 'throttleit';
 
 class Search extends React.Component {
   static propTypes = {
@@ -13,8 +13,11 @@ class Search extends React.Component {
   constructor(props) {
     super();
 
-    const delay = props.delayed ? 250 : 1;
-    this.handleKeyUpThrottled = throttleit(() => { this.handleKeyUp(); }, delay);
+    if (props.delayed) {
+      this.handleKeyUpThrottled = throttle(() => { this.handleKeyUp(); }, 250);
+    } else {
+      this.handleKeyUpThrottled = this.handleKeyUp;
+    }
   }
 
   render() {

--- a/app/components/agent/Index/search.js
+++ b/app/components/agent/Index/search.js
@@ -5,7 +5,12 @@ class Search extends React.Component {
     className: React.PropTypes.string,
     placeholder: React.PropTypes.string,
     style: React.PropTypes.object,
-    onSearch: React.PropTypes.func
+    onSearch: React.PropTypes.func,
+    delayed: React.PropTypes.bool
+  };
+
+  state = {
+    onSearchTimeout: this.props.delayed ? 250 : 1
   };
 
   render() {
@@ -26,7 +31,7 @@ class Search extends React.Component {
       clearTimeout(this._timeout);
     }
 
-    this._timeout = setTimeout(this.handleEntryTimeout, 500);
+    this._timeout = setTimeout(this.handleEntryTimeout, this.state.onSearchTimeout);
   };
 
   handleEntryTimeout = () => {

--- a/app/components/agent/Index/search.js
+++ b/app/components/agent/Index/search.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import throttleit from 'throttleit';
 
 class Search extends React.Component {
   static propTypes = {
@@ -9,9 +10,12 @@ class Search extends React.Component {
     delayed: React.PropTypes.bool
   };
 
-  state = {
-    onSearchTimeout: this.props.delayed ? 250 : 1
-  };
+  constructor(props) {
+    super();
+
+    const delay = props.delayed ? 250 : 1;
+    this.handleKeyUpThrottled = throttleit(() => { this.handleKeyUp(); }, delay);
+  }
 
   render() {
     return (
@@ -21,20 +25,12 @@ class Search extends React.Component {
         className={this.props.className}
         placeholder={this.props.placeholder}
         style={this.props.style}
-        onKeyUp={this.handleKeyUp}
+        onKeyUp={this.handleKeyUpThrottled}
       />
     );
   }
 
   handleKeyUp = () => {
-    if (this._timeout) {
-      clearTimeout(this._timeout);
-    }
-
-    this._timeout = setTimeout(this.handleEntryTimeout, this.state.onSearchTimeout);
-  };
-
-  handleEntryTimeout = () => {
     if (this._value !== this.input.value && this.props.onSearch) {
       this._value = this.input.value;
       this.props.onSearch(this.input.value);

--- a/app/components/agent/Index/search.js
+++ b/app/components/agent/Index/search.js
@@ -1,24 +1,12 @@
 import React from 'react';
-import throttle from 'throttleit';
 
 class Search extends React.Component {
   static propTypes = {
     className: React.PropTypes.string,
     placeholder: React.PropTypes.string,
     style: React.PropTypes.object,
-    onSearch: React.PropTypes.func,
-    delayed: React.PropTypes.bool
+    onSearch: React.PropTypes.func
   };
-
-  constructor(props) {
-    super();
-
-    if (props.delayed) {
-      this.handleKeyUpThrottled = throttle(() => { this.handleKeyUp(); }, 250);
-    } else {
-      this.handleKeyUpThrottled = this.handleKeyUp;
-    }
-  }
 
   render() {
     return (
@@ -28,7 +16,7 @@ class Search extends React.Component {
         className={this.props.className}
         placeholder={this.props.placeholder}
         style={this.props.style}
-        onKeyUp={this.handleKeyUpThrottled}
+        onKeyUp={this.handleKeyUp}
       />
     );
   }

--- a/app/components/agent/Index/search.js
+++ b/app/components/agent/Index/search.js
@@ -17,6 +17,9 @@ class Search extends React.Component {
         placeholder={this.props.placeholder}
         style={this.props.style}
         onKeyUp={this.handleKeyUp}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
       />
     );
   }


### PR DESCRIPTION
Changes to remote search (> 100 agents):

* Sends the query to the server on every keyup
* Only shows a spinner if the search is taking > 1 second
* The spinner now lives next to the search field
* Fixes a bug where local search could be triggered by accident

Changes to local search (< 100 agents):

* Filters immediately on keyup
* Fixes the matching logic to match the backend/remote matching logic