### PR TITLE
Less harsh button line height

### DIFF
--- a/app/components/build/StateSwitcher.js
+++ b/app/components/build/StateSwitcher.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import shallowCompare from 'react-addons-shallow-compare';
 
 import { formatNumber } from '../../lib/number';
 
@@ -12,16 +13,29 @@ class StateSwitcher extends React.Component {
     path: React.PropTypes.string
   };
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
   renderLink(label, state, count) {
     const url = state ? `${this.props.path}?state=${state}` : this.props.path;
     const active = this.props.state === state;
-    const classes = classNames("py1 px3 hover-black hover-bg-silver text-decoration-none", {
+    const classes = classNames("hover-black hover-bg-silver text-decoration-none", {
       "dark-gray": !active,
       "black": active
     });
 
     return (
-      <a href={url} className={classes} style={{ lineHeight: "1.8" }}>{formatNumber(count)} {label}</a>
+      <a
+        href={url}
+        className={classes}
+        style={{
+          lineHeight: 1.2,
+          padding: '.75em 1em'
+        }}
+      >
+        {formatNumber(count)} {label}
+      </a>
     );
   }
 

--- a/app/components/organization/NewPipelinesPageNotice.js
+++ b/app/components/organization/NewPipelinesPageNotice.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Relay from 'react-relay';
+import shallowCompare from 'react-addons-shallow-compare';
 
 import Emojify from '../shared/Emojify';
 
@@ -13,6 +14,10 @@ class NewPipelinesPageNotice extends React.Component {
     }).isRequired
   };
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
   render() {
     if (this.props.viewer.notice.dismissedAt) {
       return null;
@@ -20,12 +25,12 @@ class NewPipelinesPageNotice extends React.Component {
       return (
         <div style={{ backgroundColor: "#f0fdc1", marginTop: -10 }} className="mb4">
           <div className="container flex items-center">
-            <div className="flex-auto mr4 py1" style={{ color: "#254329" }}>
+            <div className="flex-auto mr3 py1" style={{ color: "#254329" }}>
               Welcome to the new pipelines page <Emojify text=":sparkles:"/>
               {' '}
               Read the <a href="https://building.buildkite.com/new-in-buildkite-pipeline-metrics-b5e7bf187272" className="lime text-decoration-none hover-underline semi-bold">announcement</a> to find out all about it!
             </div>
-            <button className="btn px4 mxn4 py4 lime text-decoration-none hover-underline" onClick={this.handleDismissClick}>Dismiss</button>
+            <button className="btn py4 mnx3 px3 lime text-decoration-none hover-underline" onClick={this.handleDismissClick}>Dismiss</button>
           </div>
         </div>
       );

--- a/app/css/btn.css
+++ b/app/css/btn.css
@@ -5,7 +5,7 @@
   text-decoration: none;
   cursor: pointer;
   display: inline-block;
-  line-height: 1;
+  line-height: 1.2;
   padding: .75em 1em;
   margin: 0;
   height: auto;


### PR DESCRIPTION
This tweaks the `.btn` class’ line-height to `1.2`, rather than `1`. This fixes a lot of our `.btn`-derived elements chopping descenders off their text content.

A couple of components which stood out as having been affected negatively by this change have been updated. Those components also had `shallowCompare` applied because why not. :sparkles: