### PR TITLE
Remove full page Agents Page spinner

### DIFF
--- a/app/components/agent/Index/agent-tokens.js
+++ b/app/components/agent/Index/agent-tokens.js
@@ -10,6 +10,11 @@ class AgentTokens extends React.Component {
     organization: React.PropTypes.shape({
       agentTokens: React.PropTypes.shape({
         edges: React.PropTypes.array.isRequired
+      }),
+      permissions: React.PropTypes.shape({
+        agentTokenView: React.PropTypes.shape({
+          allowed: React.PropTypes.bool.isRequired
+        }).isRequired
       })
     }).isRequired,
     relay: React.PropTypes.object.isRequired,

--- a/app/components/agent/Index/agent-tokens.js
+++ b/app/components/agent/Index/agent-tokens.js
@@ -43,7 +43,15 @@ class AgentTokens extends React.Component {
 
   renderBody() {
     if (this.props.organization.agentTokens) {
-      return this.props.organization.agentTokens.edges.map((edge) => this.renderRow(edge.node));
+      if (this.props.organization.permissions.agentTokenView.allowed) {
+        return this.props.organization.agentTokens.edges.map((edge) => this.renderRow(edge.node));
+      } else {
+        return (
+          <Panel.Section>
+            <p className="dark-gray">You don’t have permission to see your organization’s Agent tokens.</p>
+          </Panel.Section>
+        );
+      }
     } else {
       return (
         <Panel.Section className="center">
@@ -85,6 +93,11 @@ export default Relay.createContainer(AgentTokens, {
   fragments: {
     organization: () => Relay.QL`
       fragment on Organization {
+        permissions @include(if: $isMounted) {
+          agentTokenView {
+            allowed
+          }
+        }
         agentTokens(first: 50, revoked: false) @include(if: $isMounted) {
           edges {
             node {

--- a/app/components/agent/Index/index.js
+++ b/app/components/agent/Index/index.js
@@ -15,70 +15,64 @@ class AgentIndex extends React.Component {
       query: React.PropTypes.object
     }).isRequired,
     organization: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      permissions: React.PropTypes.shape({
-        agentTokenView: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
-        }).isRequired
-      }).isRequired
+      name: React.PropTypes.string.isRequired
     }).isRequired,
     viewer: React.PropTypes.object.isRequired
   };
 
   render() {
+    let content;
+    if (this.props.location.query.setup === 'true') {
+      content = this.renderSetupPage();
+    } else {
+      content = this.renderNormalPage();
+    }
+
     return (
       <DocumentTitle title={`Agents · ${this.props.organization.name}`}>
         <PageWithContainer>
-          {this.renderContent()}
+          {content}
         </PageWithContainer>
       </DocumentTitle>
     );
   }
 
-  renderContent() {
-    // Switches between showing just the agents, or the agents along with
-    // registration tokens.
-    if (this.props.organization.permissions.agentTokenView.allowed) {
-      if (this.props.location.query.setup === 'true') {
-        return (
-          <div className="clearfix mxn3 md-col-9 lg-col-8 mx-auto">
-            <QuickStart
-              title="Select the environment to set up your first agent"
-              center={false}
-              organization={this.props.organization}
-              viewer={this.props.viewer}
-              location={this.props.location}
-            />
-            <AgentInstallation organization={this.props.organization} />
-            <AgentTokens
-              title="Your agent token"
-              organization={this.props.organization}
-              setupMode={true}
-            />
-          </div>
-        );
-      }
+  renderSetupPage() {
+    return (
+      <div className="clearfix mxn3 md-col-9 lg-col-8 mx-auto">
+        <QuickStart
+          title="Select the environment to set up your first agent"
+          center={false}
+          organization={this.props.organization}
+          viewer={this.props.viewer}
+          location={this.props.location}
+        />
+        <AgentInstallation organization={this.props.organization} />
+        <AgentTokens
+          title="Your agent token"
+          organization={this.props.organization}
+          setupMode={true}
+        />
+      </div>
+    );
+  }
 
-      return (
-        <div className="clearfix mxn3">
-          <div className="sm-col sm-col-8 px3">
-            <QuickStart
-              organization={this.props.organization}
-              viewer={this.props.viewer}
-              location={this.props.location}
-            />
-            <Agents organization={this.props.organization} />
-          </div>
-          <div className="sm-col sm-col-4 px3">
-            <AgentTokens organization={this.props.organization} />
-          </div>
+  renderNormalPage() {
+    return (
+      <div className="clearfix mxn3">
+        <div className="sm-col sm-col-8 px3">
+          <QuickStart
+            organization={this.props.organization}
+            viewer={this.props.viewer}
+            location={this.props.location}
+          />
+          <Agents organization={this.props.organization} />
         </div>
-      );
-    } else {
-      return (
-        <Agents organization={this.props.organization} />
-      );
-    }
+        <div className="sm-col sm-col-4 px3">
+          <AgentTokens organization={this.props.organization} />
+        </div>
+      </div>
+    );
   }
 }
 
@@ -96,11 +90,6 @@ export default Relay.createContainer(AgentIndex, {
         ${AgentInstallation.getFragment('organization')}
         ${QuickStart.getFragment('organization')}
         name
-        permissions {
-          agentTokenView {
-            allowed
-          }
-        }
       }
     `
   }

--- a/app/components/agent/Index/quick-start.js
+++ b/app/components/agent/Index/quick-start.js
@@ -34,7 +34,7 @@ class QuickStart extends React.Component {
     organization: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
       slug: React.PropTypes.string.isRequired,
-      uuid: React.PropTypes.string.isRequired,
+      uuid: React.PropTypes.string,
       agentTokens: React.PropTypes.shape({
         edges: React.PropTypes.array.isRequired
       })
@@ -132,6 +132,12 @@ class QuickStart extends React.Component {
     const { name, slug, uuid, agentTokens: { edges: agentTokens } = {} } = this.props.organization;
     const { apiAccessTokens: { edges: apiAccessTokens } = {} } = this.props.viewer;
 
+    // Only show the token in the parameter table if we've got access to one
+    let token;
+    if (agentTokens && agentTokens.length && agentTokens[0].node.token) {
+      token = agentTokens[0].node.token;
+    }
+
     if (GuideToRender) {
       return (
         <GuideToRender
@@ -155,11 +161,7 @@ class QuickStart extends React.Component {
               className: 'h5 semi-bold'
             }
           }}
-          token={
-            agentTokens
-              && agentTokens.length
-              && agentTokens[0].node.token
-          }
+          token={token}
           apiAccessTokens={apiAccessTokens ? apiAccessTokens.map((edge) => edge.node) : []}
           organization={{ name, slug, uuid }}
         />
@@ -213,7 +215,7 @@ export default Relay.createContainer(QuickStart, {
       fragment on Organization {
         name
         slug
-        uuid
+        uuid @include(if: $isMounted)
         agentTokens(first: 1, revoked: false) @include(if: $isMounted) {
           edges {
             node {

--- a/app/components/docs/09-aws/parameter-table.js
+++ b/app/components/docs/09-aws/parameter-table.js
@@ -66,7 +66,7 @@ function AWSParameterTable(props) {
         </AWSTableRow>
         <AWSTableRow title="BuildkiteOrgSlug">
           <code className="monospace" style={{ fontSize: '.85em' }}>
-            {props.organization.slug || 'INSERT-YOUR-ACCOUNT-SLUG-HERE'}
+            {props.organization.slug || 'INSERT-YOUR-ORGANIZATION-SLUG-HERE'}
           </code>
         </AWSTableRow>
         <AWSTableRow title="BuildkiteApiAccessToken">


### PR DESCRIPTION
This change removes the initial full page spinner from showing the new Agents Page. It also changes the Agents page so it looks the same for all users - regardless of whether or not they have access to view Agent Registration Tokens.