### PR TITLE
Fix WebPack chunking

### DIFF
--- a/webpack/config.js
+++ b/webpack/config.js
@@ -46,7 +46,10 @@ var plugins = [
   // Split emojis, vendor javascript up. The loader JS doesn't have any modules
   // inside it, but since it's the last one, that's where Webpack will dump all
   // of it's bootstrapping JS. This file will change on every compilation.
-  new webpack.optimize.CommonsChunkPlugin({ names: ["emojis", "vendor", "loader"], chunks: ["emojis", "vendor", "loader"] }),
+  new webpack.optimize.CommonsChunkPlugin({
+    names: ["emojis", "vendor", "loader"],
+    minChunks: 2
+  }),
 
   // After Webpack compilation, spit out a 'manifest.json' file with a mapping
   // of file name, to compiled name.


### PR DESCRIPTION
For a while our WebPack chunking has been broken. For example, `RelayRecordWriter` shouldn't appear anywhere in our `app.js` bundle:

```
$ curl -s https://buildkiteassets.com/frontend/955d7d07c58846c1b0fc2cfeeb1c6abbbd078b33/app-435291416144e82caf08.js | grep -i 'RelayRecordWriter' | wc -l
2
```

This updates our webpack config to output the correct chunks.

Before:

```
$ ls -l dist/*
-rw-r--r-- 1 tim  11M Feb 26 21:48 dist/app.js
-rw-r--r-- 1 tim 793K Feb 26 21:48 dist/emojis.js
-rw-r--r-- 1 tim 3.5K Feb 26 21:48 dist/loader.js
-rw-r--r-- 1 tim  240 Feb 26 21:48 dist/manifest.json
-rw-r--r-- 1 tim 114K Feb 26 21:48 dist/public.js
-rw-r--r-- 1 tim 7.8M Feb 26 21:48 dist/vendor.js
$ grep -i 'RelayRecordWriter' dist/vendor.js | wc -l
3
$ grep -i 'RelayRecordWriter' dist/app.js | wc -l
3
```

After:

```
$ ls -l dist/*
-rw-r--r-- 1 tim 3.9M Feb 26 21:50 dist/app.js
-rw-r--r-- 1 tim 818K Feb 26 21:50 dist/emojis.js
-rw-r--r-- 1 tim 3.5K Feb 26 21:50 dist/loader.js
-rw-r--r-- 1 tim  240 Feb 26 21:50 dist/manifest.json
-rw-r--r-- 1 tim  87K Feb 26 21:50 dist/public.js
-rw-r--r-- 1 tim 7.8M Feb 26 21:50 dist/vendor.js
$ grep -i 'RelayRecordWriter' dist/vendor.js | wc -l
3
$ grep -i 'RelayRecordWriter' dist/app.js | wc -l
0
```