### PR TITLE
Sticky team selections: Follow up, Handle GraphQL failures from missing teams

### DIFF
--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -56,6 +56,10 @@ class OrganizationPipelines extends React.Component {
           // updated by the parent setVariables call!
           this.props.relay.setVariables({ isMounted: true, teamSearch: null }, (readyState) => {
             // flash error once we've got data so it behaves more like its backend counterpart!
+            //
+            // NOTE: We check `aborted` as well as `done` because it *should* return `done` but
+            // it looks like if it's canceled during a query it'll return `aborted` but render
+            // the right data.
             if (readyState.aborted || readyState.done) {
               FlashesStore.flash(FlashesStore.ERROR, "The requested team couldn’t be found! Switched back to All teams.");
             }

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -57,7 +57,7 @@ class OrganizationPipelines extends React.Component {
           this.props.relay.setVariables({ isMounted: true, teamSearch: null }, (readyState) => {
             // flash error once we've got data so it behaves more like its backend counterpart!
             if (readyState.done) {
-              FlashesStore.flash(FlashesStore.ERROR, "The requested team couldn’t be found! Switched back to All teams.")
+              FlashesStore.flash(FlashesStore.ERROR, "The requested team couldn’t be found! Switched back to All teams.");
             }
           });
         }

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -27,6 +27,10 @@ class OrganizationPipelines extends React.Component {
     team: React.PropTypes.string
   };
 
+  static contextTypes = {
+    router: React.PropTypes.object.isRequired
+  };
+
   state = {
     fetching: false
   }
@@ -35,13 +39,22 @@ class OrganizationPipelines extends React.Component {
     // After the `OrganizationPipelines` component has mounted, kick off a
     // Relay query to load in all the pipelines. `includeGraphData` is still
     // false at this point because we'll load in that data after this.
-    this.props.relay.setVariables({ isMounted: true, teamSearch: this.props.team }, (readyState) => {
-      if (readyState.done) {
+    this.props.relay.setVariables({ isMounted: true, teamSearch: this.props.team }, ({ done, error }) => {
+      if (done) {
         // Now kick off a full reload, which will grab the pipelines again, but
         // this time with all the graph data.
         setTimeout(() => {
           this.props.relay.forceFetch({ includeGraphData: true });
         }, 0);
+      } else if (error) {
+        // if we couldn't find that team in GraphQL, let's redirect to not requesting a team!
+        if (error.source.errors.some(({ message }) => message === 'No team found')) {
+          this.context.router.push(`/${this.props.organization.slug}`);
+          this.maybeUpdateDefaultTeam(this.props.organization.id, null);
+          // WARNING: We need to set isMounted here because it didn't get successfuly
+          // updated by the parent setVariables call!
+          this.props.relay.setVariables({ isMounted: true, teamSearch: null });
+        }
       }
     });
 

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -3,6 +3,7 @@ import Relay from 'react-relay';
 
 import SectionLoader from '../shared/SectionLoader';
 
+import FlashesStore from '../../stores/FlashesStore';
 import UserSessionStore from '../../stores/UserSessionStore';
 
 import Pipeline from './Pipeline';
@@ -53,7 +54,12 @@ class OrganizationPipelines extends React.Component {
           this.maybeUpdateDefaultTeam(this.props.organization.id, null);
           // WARNING: We need to set isMounted here because it didn't get successfuly
           // updated by the parent setVariables call!
-          this.props.relay.setVariables({ isMounted: true, teamSearch: null });
+          this.props.relay.setVariables({ isMounted: true, teamSearch: null }, (readyState) => {
+            // flash error once we've got data so it behaves more like its backend counterpart!
+            if (readyState.done) {
+              FlashesStore.flash(FlashesStore.ERROR, "The requested team couldn’t be found! Switched back to All teams.")
+            }
+          });
         }
       }
     });

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -56,7 +56,7 @@ class OrganizationPipelines extends React.Component {
           // updated by the parent setVariables call!
           this.props.relay.setVariables({ isMounted: true, teamSearch: null }, (readyState) => {
             // flash error once we've got data so it behaves more like its backend counterpart!
-            if (readyState.done) {
+            if (readyState.aborted || readyState.done) {
               FlashesStore.flash(FlashesStore.ERROR, "The requested team couldn’t be found! Switched back to All teams.");
             }
           });


### PR DESCRIPTION
- [x] Handle failures and redirect to “All teams”
- [x] Flash the user a message when redirecting