### PR TITLE
Rename the Autocomplete field

### DIFF
--- a/app/components/pipeline/teams/Index/index.js
+++ b/app/components/pipeline/teams/Index/index.js
@@ -4,7 +4,7 @@ import DocumentTitle from 'react-document-title';
 
 import Panel from '../../../shared/Panel';
 import Emojify from '../../../shared/Emojify';
-import FormAutoCompleteField from '../../../shared/FormAutoCompleteField';
+import AutocompleteField from '../../../shared/AutocompleteField';
 
 import FlashesStore from '../../../../stores/FlashesStore';
 
@@ -54,7 +54,7 @@ class Index extends React.Component {
           <Panel.Header>Teams</Panel.Header>
 
           <Panel.Section>
-            <FormAutoCompleteField onSearch={this.handleTeamSearch}
+            <AutocompleteField onSearch={this.handleTeamSearch}
               onSelect={this.handleTeamSelect}
               items={this.renderAutoCompleteSuggestions(this.props.relay.variables.search)}
               placeholder="Add a team…"
@@ -107,9 +107,9 @@ class Index extends React.Component {
       });
     } else if (search !== "") {
       return [
-        <FormAutoCompleteField.ErrorMessage key="error">
+        <AutocompleteField.ErrorMessage key="error">
           Could not find a team with name <em>{search}</em>
-        </FormAutoCompleteField.ErrorMessage>
+        </AutocompleteField.ErrorMessage>
       ];
     } else {
       return [];

--- a/app/components/shared/AutocompleteField/error-message.js
+++ b/app/components/shared/AutocompleteField/error-message.js
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 class ErrorMessage extends React.Component {
-  static displayName = "FormAutoCompleteField.ErrorMessage";
+  static displayName = "AutocompleteField.ErrorMessage";
 
   static propTypes = {
     children: React.PropTypes.node.isRequired,

--- a/app/components/shared/AutocompleteField/index.js
+++ b/app/components/shared/AutocompleteField/index.js
@@ -7,7 +7,7 @@ import Spinner from '../Spinner';
 import Suggestion from './suggestion';
 import ErrorMessage from './error-message';
 
-class FormAutoCompleteField extends React.Component {
+class AutocompleteField extends React.Component {
   static propTypes = {
     onSelect: React.PropTypes.func.isRequired,
     onSearch: React.PropTypes.func.isRequired,
@@ -70,7 +70,7 @@ class FormAutoCompleteField extends React.Component {
   }
 
   isErrorMessageComponent(node) {
-    return node && node.type && node.type.displayName === "FormAutoCompleteField.ErrorMessage";
+    return node && node.type && node.type.displayName === "AutocompleteField.ErrorMessage";
   }
 
   render() {
@@ -263,6 +263,6 @@ class FormAutoCompleteField extends React.Component {
   };
 }
 
-FormAutoCompleteField.ErrorMessage = ErrorMessage;
+AutocompleteField.ErrorMessage = ErrorMessage;
 
-export default FormAutoCompleteField;
+export default AutocompleteField;

--- a/app/components/shared/AutocompleteField/suggestion.js
+++ b/app/components/shared/AutocompleteField/suggestion.js
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 class Suggestion extends React.Component {
-  static displayName = "FormAutoCompleteField.Suggestion";
+  static displayName = "AutocompleteField.Suggestion";
 
   static propTypes = {
     children: React.PropTypes.node.isRequired,

--- a/app/components/team/Members/index.js
+++ b/app/components/team/Members/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Relay from 'react-relay';
 
 import Panel from '../../shared/Panel';
-import FormAutoCompleteField from '../../shared/FormAutoCompleteField';
+import AutocompleteField from '../../shared/AutocompleteField';
 import permissions from '../../../lib/permissions';
 
 import FlashesStore from '../../../stores/FlashesStore';
@@ -63,7 +63,7 @@ class Members extends React.Component {
         allowed: "teamMemberCreate",
         render: () => (
           <Panel.Section>
-            <FormAutoCompleteField onSearch={this.handleUserSearch}
+            <AutocompleteField onSearch={this.handleUserSearch}
               onSelect={this.handleUserSelect}
               items={this.renderAutoCompleteSuggstions(this.props.relay.variables.search)}
               placeholder="Add user…"
@@ -98,9 +98,9 @@ class Members extends React.Component {
       });
     } else if (search !== "") {
       return [
-        <FormAutoCompleteField.ErrorMessage key="error">
+        <AutocompleteField.ErrorMessage key="error">
           Could not find a user with name <em>{search}</em>
-        </FormAutoCompleteField.ErrorMessage>
+        </AutocompleteField.ErrorMessage>
       ];
     } else {
       return [];

--- a/app/components/team/Pipelines/index.js
+++ b/app/components/team/Pipelines/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Relay from 'react-relay';
 
 import Panel from '../../shared/Panel';
-import FormAutoCompleteField from '../../shared/FormAutoCompleteField';
+import AutocompleteField from '../../shared/AutocompleteField';
 import permissions from '../../../lib/permissions';
 
 import FlashesStore from '../../../stores/FlashesStore';
@@ -63,7 +63,7 @@ class Pipelines extends React.Component {
         allowed: "teamPipelineCreate",
         render: () => (
           <Panel.Section>
-            <FormAutoCompleteField onSearch={this.handlePipelineSearch}
+            <AutocompleteField onSearch={this.handlePipelineSearch}
               onSelect={this.handlePipelineSelect}
               items={this.renderAutoCompleteSuggstions(this.props.relay.variables.search)}
               placeholder="Add pipeline…"
@@ -97,7 +97,7 @@ class Pipelines extends React.Component {
         return [<Pipeline key={pipeline.id} pipeline={pipeline} />, pipeline];
       });
     } else if (search !== "") {
-      return [<FormAutoCompleteField.ErrorMessage key={"error"}>Could not find a pipeline with name <em>{search}</em></FormAutoCompleteField.ErrorMessage>];
+      return [<AutocompleteField.ErrorMessage key={"error"}>Could not find a pipeline with name <em>{search}</em></AutocompleteField.ErrorMessage>];
     } else {
       return [];
     }


### PR DESCRIPTION
The Autocomplete Field does not act like other components prefixed with `Form-` (which as far as I can tell are intended as a consistent set of things for labeled, feedback-providing form controls), and that's currently the intended behaviour.

This, therefore, renames it to `AutocompleteField` to remove the implication that they're related.