### PR TITLE
Add a few missing vendor libs

### DIFF
--- a/webpack/config.js
+++ b/webpack/config.js
@@ -82,6 +82,7 @@ var plugins = [
 ];
 
 var vendor_modules = [
+  "autosize",
   "babel-polyfill",
   "classnames",
   "deepmerge",
@@ -91,17 +92,25 @@ var vendor_modules = [
   "graphql",
   "graphql-relay",
   "history",
+  "metrick",
   "moment",
   "object-assign",
   "pusher-js",
   "react",
+  "react-addons-css-transition-group",
   "react-addons-pure-render-mixin",
+  "react-addons-shallow-compare",
   "react-addons-update",
+  "react-confetti",
   "react-document-title",
   "react-dom",
   "react-relay",
   "react-router",
   "react-router-relay",
+  "react-type-snob",
+  "styled-components",
+  "throttleit",
+  "uuid",
   "whatwg-fetch"
 ];
 


### PR DESCRIPTION
Thanks to #210 I spotted a few missing vendor libs.

Before:

![before](https://cloud.githubusercontent.com/assets/153/24085793/778c7c9c-0d56-11e7-9922-a22dd69fc106.png)

After:

![after](https://cloud.githubusercontent.com/assets/153/24085796/7b3cd03a-0d56-11e7-9ded-cd58677cf062.png)

Also, [this Twitter thread](https://twitter.com/TheLarkInn/status/842817690951733248) ([#whatsinyourbundle](https://twitter.com/hashtag/whatsinyourbundle)) from Sean Larkin on the Webpack core team has lots of gold.

I think the next biggest wins are:

* Remove inlining of images in the JS as base64
* Move a whole bunch of components out to only load on demand, with a few nice touches ala [react-loadable](https://medium.com/@thejameskyle/react-loadable-2674c59de178#.vxo622qxr)