### PR TITLE
Handle large team sizes in Team list

### DIFF
--- a/app/components/team/Row.js
+++ b/app/components/team/Row.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Relay from 'react-relay';
 import shallowCompare from 'react-addons-shallow-compare';
 
+import { formatNumber } from '../../lib/number';
 import Panel from '../shared/Panel';
 import UserAvatar from '../shared/UserAvatar';
 import Emojify from '../shared/Emojify';
@@ -101,11 +102,11 @@ class TeamRow extends React.Component {
 
     if (extrasCount > 0) {
       return (
-        <div className="inline-block bg-gray bold circle center border border-white semi-bold"
-          style={{ width: avatarSize, height: avatarSize, lineHeight: `${avatarSize - 4}px`, fontSize: 11, borderWidth: 2 }}
-          title={`and another ${extrasCount} member${extrasCount === 1 ? '' : 's'}`}
+        <div className="inline-block bg-gray bold center border border-white semi-bold px1"
+          style={{ borderRadius: avatarSize / 2, minWidth: avatarSize, height: avatarSize, lineHeight: `${avatarSize - 4}px`, fontSize: 11, borderWidth: 2 }}
+          title={`and another ${formatNumber(extrasCount)} member${extrasCount === 1 ? '' : 's'}`}
         >
-          {"+" + extrasCount}
+          {"+" + formatNumber(extrasCount)}
         </div>
       );
     }


### PR DESCRIPTION
<img width="268" alt="screen shot 2017-03-31 at 1 14 26 pm" src="https://cloud.githubusercontent.com/assets/282113/24533531/25b55dfa-1614-11e7-9c12-500407c22918.png">

:sparkles:

<img width="279" alt="screen shot 2017-03-31 at 1 15 22 pm" src="https://cloud.githubusercontent.com/assets/282113/24533532/25ef1e28-1614-11e7-854d-f081c56782f4.png">