### PR TITLE
Remove react-type-snob from the `vendor` bundle

### DIFF
--- a/webpack/config.js
+++ b/webpack/config.js
@@ -18,6 +18,11 @@ if (process.env.FRONTEND_HOST.slice(-1) !== "/") {
   throw "FRONTEND_HOST must end with a /";
 }
 
+// Ensure a EMOJI_HOST is setup since we need it for emoji
+if (!process.env.EMOJI_HOST) {
+  throw "No EMOJI_HOST set";
+}
+
 const IS_PRODUCTION = (process.env.NODE_ENV === "production");
 
 // Include a hash of the bundle in the name when we're building these files for

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -113,7 +113,6 @@ var vendor_modules = [
   "react-relay",
   "react-router",
   "react-router-relay",
-  "react-type-snob",
   "styled-components",
   "throttleit",
   "uuid",


### PR DESCRIPTION
This prevents an extraneous error from being thrown in production. `react-type-snob` is neither referred to nor used in production and can thus be safely removed!

Also adds a throw when no `EMOJI_HOST` is set, which means you get a failure after 0.5 seconds rather than 90.