### PR TITLE
shallowCompare -> React.PureComponent

### DIFF
--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Relay from 'react-relay';
 import { second, seconds } from 'metrick/duration';
-import shallowCompare from 'react-addons-shallow-compare';
 import throttle from 'throttleit';
 
 import Panel from '../../shared/Panel';
@@ -16,7 +15,7 @@ import AgentRow from './row';
 
 const PAGE_SIZE = 100;
 
-class Agents extends React.Component {
+class Agents extends React.PureComponent {
   static propTypes = {
     organization: React.PropTypes.shape({
       allAgents: React.PropTypes.shape({
@@ -91,10 +90,6 @@ class Agents extends React.Component {
     },
     3::seconds
   );
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     // grab (potentially) filtered agent list here, as we need it in several places

--- a/app/components/agent/Index/installation.js
+++ b/app/components/agent/Index/installation.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Relay from 'react-relay';
 import { seconds } from 'metrick/duration';
-import shallowCompare from 'react-addons-shallow-compare';
 import Confetti from 'react-confetti';
 
 import Button from '../../shared/Button';
@@ -9,7 +8,7 @@ import Dialog from '../../shared/Dialog';
 import Emojify from '../../shared/Emojify';
 import Panel from '../../shared/Panel';
 
-class AgentInstallation extends React.Component {
+class AgentInstallation extends React.PureComponent {
   static propTypes = {
     organization: React.PropTypes.shape({
       agents: React.PropTypes.shape({
@@ -41,10 +40,6 @@ class AgentInstallation extends React.Component {
     if (nextProps.organization.agents && this.props.organization.agents && nextProps.organization.agents.count > this.props.organization.agents.count) {
       this.setState({ isDialogOpen: true });
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   render() {

--- a/app/components/agent/Index/quick-start.js
+++ b/app/components/agent/Index/quick-start.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Relay from 'react-relay';
 import { Link } from 'react-router';
-import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 
 import Emojify from '../../shared/Emojify';
@@ -23,7 +22,7 @@ const GUIDES = ((guideRequire) =>
 const getEmojiForGuide = ({ emoji, title }) => emoji || `:${title.toLowerCase()}:`;
 const getSlugForGuide = ({ slug, title }) => slug || encodeURIComponent(title.toLowerCase());
 
-class QuickStart extends React.Component {
+class QuickStart extends React.PureComponent {
   static propTypes = {
     center: React.PropTypes.bool.isRequired,
     location: React.PropTypes.shape({
@@ -58,10 +57,6 @@ class QuickStart extends React.Component {
       isMounted: true,
       organizationSlug: this.props.organization.slug
     });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   getSlugFromHash() {

--- a/app/components/build/AvatarWithUnknownEmailPrompt.js
+++ b/app/components/build/AvatarWithUnknownEmailPrompt.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Dropdown from '../shared/Dropdown';
 import Icon from '../shared/Icon';
@@ -12,7 +11,7 @@ import FlashesStore from '../../stores/FlashesStore';
 import EmailCreateMutation from '../../mutations/EmailCreate';
 import NoticeDismissMutation from '../../mutations/NoticeDismiss';
 
-class AvatarWithUnknownEmailPrompt extends React.Component {
+class AvatarWithUnknownEmailPrompt extends React.PureComponent {
   static propTypes = {
     build: React.PropTypes.shape({
       createdBy: React.PropTypes.shape({
@@ -74,10 +73,6 @@ class AvatarWithUnknownEmailPrompt extends React.Component {
   // it's associated email to their user account
   isUnregisteredWithEmail(createdBy) {
     return (createdBy && createdBy.email && createdBy.__typename === "UnregisteredUser");
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidMount() {

--- a/app/components/build/StateSwitcher.js
+++ b/app/components/build/StateSwitcher.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import classNames from 'classnames';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import { formatNumber } from '../../lib/number';
 
-class StateSwitcher extends React.Component {
+class StateSwitcher extends React.PureComponent {
   static propTypes = {
     buildsCount: React.PropTypes.number,
     runningBuildsCount: React.PropTypes.number,
@@ -12,10 +11,6 @@ class StateSwitcher extends React.Component {
     state: React.PropTypes.string,
     path: React.PropTypes.string
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   renderLink(label, state, count) {
     const url = state ? `${this.props.path}?state=${state}` : this.props.path;

--- a/app/components/icons/BuildState.js
+++ b/app/components/icons/BuildState.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import { v4 as uuid } from 'uuid';
 
 import BuildStates from '../../constants/BuildStates';
@@ -32,7 +31,7 @@ const STATE_COLORS = {
   [BuildStates.NOT_RUN]: '#83B0E4'
 };
 
-class BuildState extends React.Component {
+class BuildState extends React.PureComponent {
   static propTypes = {
     className: React.PropTypes.string,
     size: React.PropTypes.number.isRequired,
@@ -49,10 +48,6 @@ class BuildState extends React.Component {
     this.setState({
       uuid: uuid()
     });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   render() {

--- a/app/components/icons/Favorite.js
+++ b/app/components/icons/Favorite.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import styled from 'styled-components';
 
 const starColor = "#f8cc1c";
@@ -19,14 +18,10 @@ const StarSVG = styled.svg`
   }
 `;
 
-class Favorite extends React.Component {
+class Favorite extends React.PureComponent {
   static propTypes = {
     favorite: React.PropTypes.bool.isRequired
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     return (

--- a/app/components/layout/Navigation/MyBuilds/build.js
+++ b/app/components/layout/Navigation/MyBuilds/build.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 import styled from 'styled-components';
 
 import Emojify from '../../../shared/Emojify';
@@ -23,7 +22,7 @@ BuildLink.defaultProps = {
   className: "flex text-decoration-none dark-gray hover-lime mb2"
 };
 
-class BuildsDropdownBuild extends React.Component {
+class BuildsDropdownBuild extends React.PureComponent {
   static propTypes = {
     build: React.PropTypes.object,
     relay: React.PropTypes.object.isRequired
@@ -42,10 +41,6 @@ class BuildsDropdownBuild extends React.Component {
       this.props.relay.forceFetch();
     }
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     const buildTime = buildStatus(this.props.build).timeValue;

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 
 import UserAvatar from '../../shared/UserAvatar';
@@ -19,7 +18,7 @@ import DropdownButton from './dropdown-button';
 import SupportDialog from './support-dialog';
 import MyBuilds from './MyBuilds';
 
-class Navigation extends React.Component {
+class Navigation extends React.PureComponent {
   static propTypes = {
     organization: React.PropTypes.object,
     viewer: React.PropTypes.object,
@@ -96,10 +95,6 @@ class Navigation extends React.Component {
 
   handleSupportDialogClose = () => {
     this.setState({ showingSupportDialog: false });
-  };
-
-  shouldComponentUpdate = (nextProps, nextState) => {
-    return shallowCompare(this, nextProps, nextState);
   };
 
   renderTopOrganizationMenu() {

--- a/app/components/layout/Navigation/support-dialog.js
+++ b/app/components/layout/Navigation/support-dialog.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import shuffle from 'shuffle-array';
 import styled, { keyframes } from 'styled-components';
 
@@ -49,17 +48,13 @@ const Mugshot = styled.img`
   margin: ${-IMAGE_PADDING_VERTICAL}px ${-IMAGE_PADDING_HORIZONTAL}px;
 `;
 
-class SupportDialog extends React.Component {
+class SupportDialog extends React.PureComponent {
   static displayName = "Navigation.SupportDialog";
 
   static propTypes = {
     isOpen: React.PropTypes.bool,
     onRequestClose: React.PropTypes.func
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     return (

--- a/app/components/member/Edit.js
+++ b/app/components/member/Edit.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Button from '../shared/Button';
 import FormCheckbox from '../shared/FormCheckbox';
@@ -18,7 +17,7 @@ import OrganizationMemberRoleConstants from '../../constants/OrganizationMemberR
 
 const AVATAR_SIZE = 50;
 
-class MemberEdit extends React.Component {
+class MemberEdit extends React.PureComponent {
   static propTypes = {
     viewer: React.PropTypes.shape({
       user: React.PropTypes.shape({
@@ -47,10 +46,6 @@ class MemberEdit extends React.Component {
     isAdmin: false,
     removing: false
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   componentWillMount() {
     this.setState({

--- a/app/components/member/Index.js
+++ b/app/components/member/Index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Relay from 'react-relay';
 import { second } from 'metrick/duration';
 import DocumentTitle from 'react-document-title';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Button from '../shared/Button';
 import Dropdown from '../shared/Dropdown';
@@ -26,7 +25,7 @@ const TEAM_ROLES =  [
 
 const PAGE_SIZE = 10;
 
-class MemberIndex extends React.Component {
+class MemberIndex extends React.PureComponent {
   static propTypes = {
     organization: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
@@ -62,10 +61,6 @@ class MemberIndex extends React.Component {
     searchingMembersIsSlow: false,
     loadingInvitations: false
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   componentDidMount() {
     // Use a `forceFetch` so every time the user comes back to this page we'll

--- a/app/components/member/InvitationRow.js
+++ b/app/components/member/InvitationRow.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Button from '../shared/Button';
 import Panel from '../shared/Panel';
@@ -12,7 +11,7 @@ import OrganizationInvitationRevoke from '../../mutations/OrganizationInvitation
 
 import OrganizationMemberRoleConstants from '../../constants/OrganizationMemberRoleConstants';
 
-class InvitationRow extends React.Component {
+class InvitationRow extends React.PureComponent {
   static propTypes = {
     organizationInvitation: React.PropTypes.shape({
       uuid: React.PropTypes.string.isRequired,
@@ -25,10 +24,6 @@ class InvitationRow extends React.Component {
     resending: false,
     revoking: false
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     const { resending, revoking } = this.state;

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Button from '../shared/Button';
 import FormCheckbox from '../shared/FormCheckbox';
@@ -18,7 +17,7 @@ import OrganizationInvitationCreateMutation from '../../mutations/OrganizationIn
 import OrganizationMemberRoleConstants from '../../constants/OrganizationMemberRoleConstants';
 import TeamMemberRoleConstants from '../../constants/TeamMemberRoleConstants';
 
-class MemberNew extends React.Component {
+class MemberNew extends React.PureComponent {
   static propTypes = {
     organization: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
@@ -44,10 +43,6 @@ class MemberNew extends React.Component {
     teams: [],
     isAdmin: false
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     return (

--- a/app/components/member/Row.js
+++ b/app/components/member/Row.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Panel from '../shared/Panel';
 import UserAvatar from '../shared/UserAvatar';
@@ -9,7 +8,7 @@ import OrganizationMemberRoleConstants from '../../constants/OrganizationMemberR
 
 const AVATAR_SIZE = 40;
 
-class MemberRow extends React.Component {
+class MemberRow extends React.PureComponent {
   static propTypes = {
     organization: React.PropTypes.shape({
       slug: React.PropTypes.string.isRequired
@@ -26,10 +25,6 @@ class MemberRow extends React.Component {
       }).isRequired
     }).isRequired
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     return (

--- a/app/components/organization/AgentsCount.js
+++ b/app/components/organization/AgentsCount.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 import throttle from 'throttleit';
 import { seconds } from 'metrick/duration';
 
@@ -13,7 +12,7 @@ import { formatNumber } from '../../lib/number';
 // given time window. I wish this was cleaner, kid, I really do.
 const requestUpdate = throttle((callback) => callback(), 3::seconds);
 
-class AgentsCount extends React.Component {
+class AgentsCount extends React.PureComponent {
   static propTypes = {
     organization: React.PropTypes.shape({
       agents: React.PropTypes.shape({
@@ -52,10 +51,6 @@ class AgentsCount extends React.Component {
     if (nextProps.organization.agents) {
       this.setState({ agentCount: nextProps.organization.agents.count });
     }
-  };
-
-  shouldComponentUpdate = (nextProps, nextState) => {
-    return shallowCompare(this, nextProps, nextState);
   };
 
   render() {

--- a/app/components/organization/Pipeline/bar.js
+++ b/app/components/organization/Pipeline/bar.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import BuildTooltip from './build-tooltip';
 import AnchoredPopover from '../../shared/Popover/anchored';
 
 import { BAR_HEIGHT_MINIMUM, BAR_WIDTH, BAR_WIDTH_WITH_SEPERATOR, GRAPH_HEIGHT } from './constants';
 
-class Bar extends React.Component {
+class Bar extends React.PureComponent {
   static propTypes = {
     href: React.PropTypes.string,
     color: React.PropTypes.string.isRequired,
@@ -27,10 +26,6 @@ class Bar extends React.Component {
 
   state = {
     hover: false
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   handleMouseOver = () => {

--- a/app/components/organization/Pipeline/build-tooltip.js
+++ b/app/components/organization/Pipeline/build-tooltip.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import BuildStatusDescription from '../../shared/BuildStatusDescription';
 import Duration from '../../shared/Duration';
@@ -10,7 +9,7 @@ import UserAvatar from '../../shared/UserAvatar';
 import { buildTime } from '../../../lib/builds';
 import { shortMessage, shortCommit } from '../../../lib/commits';
 
-class BuildTooltip extends React.Component {
+class BuildTooltip extends React.PureComponent {
   static propTypes = {
     build: React.PropTypes.shape({
       commit: React.PropTypes.string,
@@ -25,10 +24,6 @@ class BuildTooltip extends React.Component {
       finishedAt: React.PropTypes.string
     }).isRequired
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     return (

--- a/app/components/pipeline/CreateBuildDialog.js
+++ b/app/components/pipeline/CreateBuildDialog.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Button from '../shared/Button';
 import Dialog from '../shared/Dialog';
 import FormTextField from '../shared/FormTextField';
 import FormTextarea from '../shared/FormTextarea';
 
-class CreateBuildDialog extends React.Component {
+class CreateBuildDialog extends React.PureComponent {
   static propTypes = {
     pipeline: React.PropTypes.object.isRequired,
     isOpen: React.PropTypes.bool,
@@ -18,10 +17,6 @@ class CreateBuildDialog extends React.Component {
     showingMoreOptions: false,
     creatingBuild: false
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   componentDidUpdate(prevProps) {
     if (!prevProps.isOpen && this.props.isOpen) {

--- a/app/components/shared/AutocompleteField/index.js
+++ b/app/components/shared/AutocompleteField/index.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import SearchField from '../SearchField';
 import Suggestion from './suggestion';
 import ErrorMessage from './error-message';
 
-class AutocompleteField extends React.Component {
+class AutocompleteField extends React.PureComponent {
   static propTypes = {
     onSelect: React.PropTypes.func.isRequired,
     onSearch: React.PropTypes.func.isRequired,
@@ -18,10 +17,6 @@ class AutocompleteField extends React.Component {
     visible: false,
     searching: false
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.items) {

--- a/app/components/shared/BuildStatusDescription.js
+++ b/app/components/shared/BuildStatusDescription.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import { minute } from 'metrick/duration';
 import { getDateString, getRelativeDateString } from '../../lib/date';
 import { buildStatus } from '../../lib/builds';
 
-class BuildStatusDescription extends React.Component {
+class BuildStatusDescription extends React.PureComponent {
   static propTypes = {
     build: React.PropTypes.object.isRequired,
     updateFrequency: React.PropTypes.number.isRequired
@@ -57,10 +56,6 @@ class BuildStatusDescription extends React.Component {
     }
 
     this.updateBuildInfo(build);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   render() {

--- a/app/components/shared/Dropdown.js
+++ b/app/components/shared/Dropdown.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import classNames from 'classnames';
 
 import Popover, { calculateViewportOffsets } from './Popover';
 
-export default class Dropdown extends React.Component {
+export default class Dropdown extends React.PureComponent {
   static propTypes = {
     children: React.PropTypes.node.isRequired,
     width: React.PropTypes.number.isRequired,
@@ -27,10 +26,6 @@ export default class Dropdown extends React.Component {
     offsetY: 35,
     width: 250
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   handleWindowResize = () => {
     // when hidden, we wait for the resize to be finished!

--- a/app/components/shared/Duration.js
+++ b/app/components/shared/Duration.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 import { second } from 'metrick/duration';
 import { getDurationString } from '../../lib/date';
 
-class Duration extends React.Component {
+class Duration extends React.PureComponent {
   static propTypes = {
     from: React.PropTypes.oneOfType([
       React.PropTypes.string,
@@ -72,10 +71,6 @@ class Duration extends React.Component {
     this.setState({
       value: getDurationString(from, to, format, overrides)
     });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   render() {

--- a/app/components/shared/Emojify.js
+++ b/app/components/shared/Emojify.js
@@ -1,18 +1,13 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Emoji from '../../lib/Emoji';
 
-class Emojify extends React.Component {
+class Emojify extends React.PureComponent {
   static propTypes = {
     text: React.PropTypes.string,
     className: React.PropTypes.string,
     style: React.PropTypes.object
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     const { className, text, style } = this.props;

--- a/app/components/shared/FormCheckbox.js
+++ b/app/components/shared/FormCheckbox.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import classNames from 'classnames';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import FormInputErrors from './FormInputErrors';
 
-export default class FormCheckbox extends React.Component {
+export default class FormCheckbox extends React.PureComponent {
   static propTypes = {
     label: React.PropTypes.node.isRequired,
     name: React.PropTypes.string,
@@ -14,10 +13,6 @@ export default class FormCheckbox extends React.Component {
     onChange: React.PropTypes.func,
     errors: React.PropTypes.array
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     return (

--- a/app/components/shared/FormInputLabel.js
+++ b/app/components/shared/FormInputLabel.js
@@ -1,17 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
-import shallowCompare from 'react-addons-shallow-compare';
 
-class FormInputLabel extends React.Component {
+class FormInputLabel extends React.PureComponent {
   static propTypes = {
     label: React.PropTypes.node.isRequired,
     children: React.PropTypes.node,
     errors: React.PropTypes.bool
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     return (

--- a/app/components/shared/FriendlyTime.js
+++ b/app/components/shared/FriendlyTime.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import { minute } from 'metrick/duration';
 import { getDateString, getRelativeDateString } from '../../lib/date';
 
-class FriendlyTime extends React.Component {
+class FriendlyTime extends React.PureComponent {
   static propTypes = {
     value: React.PropTypes.string.isRequired,
     updateFrequency: React.PropTypes.number.isRequired,
@@ -61,10 +60,6 @@ class FriendlyTime extends React.Component {
     this.setState({
       value: getRelativeDateString(value, { capitalized, seconds })
     });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   render() {

--- a/app/components/shared/Panel/row-link.js
+++ b/app/components/shared/Panel/row-link.js
@@ -1,10 +1,9 @@
 import React from "react";
 import { Link } from 'react-router';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Icon from '../../shared/Icon';
 
-export default class RowLink extends React.Component {
+export default class RowLink extends React.PureComponent {
   static displayName = "Panel.RowLink";
 
   static propTypes = {
@@ -12,10 +11,6 @@ export default class RowLink extends React.Component {
     to: React.PropTypes.string,
     href: React.PropTypes.string
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     if (this.props.to) {

--- a/app/components/shared/Popover/anchored.js
+++ b/app/components/shared/Popover/anchored.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 
 import Popover from '.';
 import calculateViewportOffsets from './calculate-viewport-offsets';
 
-export default class AnchoredPopover extends React.Component {
+export default class AnchoredPopover extends React.PureComponent {
   static propTypes = {
     children: React.PropTypes.node.isRequired,
     className: React.PropTypes.string,
@@ -28,10 +27,6 @@ export default class AnchoredPopover extends React.Component {
     showing: false,
     width: 250
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   handleWindowResize = () => {
     // when hidden, we wait for the resize to be finished!

--- a/app/components/shared/Popover/index.js
+++ b/app/components/shared/Popover/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import styled from 'styled-components';
 
 const NIB_WIDTH = 32;
@@ -21,7 +20,7 @@ Nib.defaultProps = {
   className: 'absolute pointer-events-none'
 };
 
-export default class Popover extends React.Component {
+export default class Popover extends React.PureComponent {
   static propTypes = {
     children: React.PropTypes.node.isRequired,
     nibOffsetX: React.PropTypes.number.isRequired,
@@ -40,10 +39,6 @@ export default class Popover extends React.Component {
     innerRef() {},
     width: 250
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     const { children, innerRef, nibOffsetX, offsetX, offsetY: top, style, width } = this.props;

--- a/app/components/shared/SearchField.js
+++ b/app/components/shared/SearchField.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import classNames from 'classnames';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Icon from './Icon';
 import Spinner from './Spinner';
 
-export default class SearchField extends React.Component {
+export default class SearchField extends React.PureComponent {
   static propTypes = {
     className: React.PropTypes.string,
     onChange: React.PropTypes.func.isRequired,
@@ -20,10 +19,6 @@ export default class SearchField extends React.Component {
     placeholder: 'Search…',
     searching: false
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   clear() {
     this._inputNode.value = '';

--- a/app/components/team/Index.js
+++ b/app/components/team/Index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Panel from '../shared/Panel';
 import Button from '../shared/Button';
@@ -10,7 +9,7 @@ import permissions from '../../lib/permissions';
 
 import Row from './Row';
 
-class TeamIndex extends React.Component {
+class TeamIndex extends React.PureComponent {
   static propTypes = {
     organization: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
@@ -26,10 +25,6 @@ class TeamIndex extends React.Component {
     }).isRequired,
     relay: React.PropTypes.object.isRequired
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   componentDidMount() {
     this.props.relay.forceFetch({ isMounted: true });

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Chooser from '../../shared/Chooser';
 import Dropdown from '../../shared/Dropdown';
 
 import TeamMemberRoleConstants from '../../../constants/TeamMemberRoleConstants';
 
-class MemberRole extends React.Component {
+class MemberRole extends React.PureComponent {
   static displayName = "Team.Pipelines.Role";
 
   static propTypes = {
@@ -16,10 +15,6 @@ class MemberRole extends React.Component {
     onRoleChange: React.PropTypes.func.isRequired,
     savingNewRole: React.PropTypes.string
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     const saving = this.props.savingNewRole;

--- a/app/components/team/Pipelines/access-level.js
+++ b/app/components/team/Pipelines/access-level.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Chooser from '../../shared/Chooser';
 import Dropdown from '../../shared/Dropdown';
@@ -8,7 +7,7 @@ const MANAGE_BUILD_AND_READ = "MANAGE_BUILD_AND_READ";
 const BUILD_AND_READ = "BUILD_AND_READ";
 const READ_ONLY = "READ_ONLY";
 
-class AccessLevel extends React.Component {
+class AccessLevel extends React.PureComponent {
   static displayName = "Team.Pipelines.AccessLevel";
 
   static propTypes = {
@@ -18,10 +17,6 @@ class AccessLevel extends React.Component {
     onAccessLevelChange: React.PropTypes.func.isRequired,
     saving: React.PropTypes.string
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     const saving = this.props.saving;

--- a/app/components/team/Row.js
+++ b/app/components/team/Row.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Relay from 'react-relay';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import { formatNumber } from '../../lib/number';
 import Panel from '../shared/Panel';
@@ -11,7 +10,7 @@ import TeamPrivacyConstants from '../../constants/TeamPrivacyConstants';
 const maxAvatars = 4;
 const avatarSize = 30;
 
-class TeamRow extends React.Component {
+class TeamRow extends React.PureComponent {
   static propTypes = {
     team: React.PropTypes.shape({
       id: React.PropTypes.string.isRequired,
@@ -35,10 +34,6 @@ class TeamRow extends React.Component {
       }).isRequired
     }).isRequired
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     return (

--- a/app/components/team/Suggestion.js
+++ b/app/components/team/Suggestion.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import Relay from 'react-relay';
 import classNames from 'classnames';
-import shallowCompare from 'react-addons-shallow-compare';
 
 import Emojify from '../shared/Emojify';
 
-class TeamSuggestion extends React.Component {
+class TeamSuggestion extends React.PureComponent {
   static propTypes = {
     team: React.PropTypes.shape({
       name: React.PropTypes.string.isRequired,
@@ -16,10 +15,6 @@ class TeamSuggestion extends React.Component {
   static contextTypes = {
     autoCompletorSuggestion: React.PropTypes.object
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     // Toggle the `dark-gray` color on the description text if this component is

--- a/app/components/user/NewChangelogsBadge.js
+++ b/app/components/user/NewChangelogsBadge.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import Relay from 'react-relay';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
-import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 
 import PusherStore from '../../stores/PusherStore';
 
-class NewChangelogsBadge extends React.Component {
+class NewChangelogsBadge extends React.PureComponent {
   static propTypes = {
     className: React.PropTypes.string,
     relay: React.PropTypes.object.isRequired,
@@ -28,10 +27,6 @@ class NewChangelogsBadge extends React.Component {
 
   handlePusherWebsocketEvent = () => {
     this.props.relay.forceFetch();
-  };
-
-  shouldComponentUpdate = (nextProps, nextState) => {
-    return shallowCompare(this, nextProps, nextState);
   };
 
   render() {


### PR DESCRIPTION
[`shallowCompare`](https://facebook.github.io/react/docs/shallow-compare.html) is considered a legacy add-on. [`React.PureComponent`](https://facebook.github.io/react/docs/react-api.html#react.purecomponent) is the expected way to do pure-rendering components now and into the future.