### PR TITLE
Don't build twice when analysing bundle

### DIFF
--- a/.buildkite/steps/bundle-analyze.sh
+++ b/.buildkite/steps/bundle-analyze.sh
@@ -7,10 +7,7 @@ export FRONTEND_HOST=https://example.com/
 export EMOJI_HOST=https://example.com/
 export NODE_ENV=production
 
-echo "+++ :package::mag: Generating production bundle for analyzing"
-yarn run build-production
-
-echo "+++ :package::mag: Running webpack-bundle-analyzer"
+echo "+++ :package::mag: Running webpack-bundle-analyzer on a production bundle"
 yarn run bundle-analyze
 
 echo "+++ :package::bar_chart: Analysis saved to tmp/bundle-analyzer-report.html"


### PR DESCRIPTION
It looks like we were running two production builds in the bundle analyser step. This removes the first, which hopefully should halve the job's time!