### PR TITLE
Clean up type sizes

### DIFF
--- a/app/components/agent/Index/installation.js
+++ b/app/components/agent/Index/installation.js
@@ -64,7 +64,7 @@ class AgentInstallation extends React.PureComponent {
               <p className="m0 mb2">
                 <Emojify text=":raised_hands:" style={{ fontSize: 32 }} />
               </p>
-              <p className="m0 h4 bold mb2" style={{ paddingLeft: '1.5em', paddingRight: '1.5em' }}>
+              <p className="m0 h3 bold mb2" style={{ paddingLeft: '1.5em', paddingRight: '1.5em' }}>
                 You’ve connected your first Buildkite Agent!
               </p>
               <Button outline={true} theme="default" link={`/${organization.slug}`} className="mt2">Manage Your Pipelines</Button>

--- a/app/components/agent/Index/quick-start.js
+++ b/app/components/agent/Index/quick-start.js
@@ -153,7 +153,7 @@ class QuickStart extends React.PureComponent {
               className: 'border border-gray rounded bg-silver overflow-auto p2 monospace'
             },
             'h2': {
-              className: 'h5 semi-bold'
+              className: 'h4 semi-bold'
             }
           }}
           token={token}

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -61,8 +61,8 @@ class AgentShow extends React.Component {
   renderExtraItem(title, content) {
     return (
       <tr key={title} style={{ marginTop: 3 }} className="border-gray border-bottom">
-        <th className="h5 p2 semi-bold left-align align-top" width={100}>{title}</th>
-        <td className="h5 p2">{content}</td>
+        <th className="h4 p2 semi-bold left-align align-top" width={100}>{title}</th>
+        <td className="h4 p2">{content}</td>
       </tr>
     );
   }

--- a/app/components/build/AvatarWithUnknownEmailPrompt.js
+++ b/app/components/build/AvatarWithUnknownEmailPrompt.js
@@ -125,7 +125,7 @@ class AvatarWithUnknownEmailPrompt extends React.PureComponent {
 
       message = (
         <div>
-          <h1 className="h5 m0 mb1 bold">Email verification needed</h1>
+          <h1 className="h4 m0 mb1 bold">Email verification needed</h1>
           <p>We’ve sent a verification email to <strong className="semi-bold">{this.props.build.createdBy.email}</strong>. Click the link in that email to finish adding it to your account.</p>
           <p className="dark-gray mt0 dark-gray m0 h7">You can resend the verification email or remove this email address in your <a className="semi-bold lime hover-lime hover-underline" href="/user/emails">Personal Email Settings</a></p>
         </div>
@@ -134,7 +134,7 @@ class AvatarWithUnknownEmailPrompt extends React.PureComponent {
       // Otherwise, we've got an unknown (to Buildkite) email address on our hands!
       message = (
         <div>
-          <h1 className="h5 m0 mb1 bold">Unknown build commit email</h1>
+          <h1 className="h4 m0 mb1 bold">Unknown build commit email</h1>
           <p className="m0">The email <strong className="semi-bold">{this.props.build.createdBy.email}</strong> could not be matched to any users in your organization. If this email address belongs to you, add it to your personal list of email addresses.</p>
         </div>
       );

--- a/app/components/layout/Navigation/support-dialog.js
+++ b/app/components/layout/Navigation/support-dialog.js
@@ -79,12 +79,12 @@ class SupportDialog extends React.PureComponent {
             )}
           </Mugshots>
 
-          <div className="mx-auto mb2 pt1 px3 sm-col-10 semi-bold line-height-4 h5">
+          <div className="mx-auto mb2 pt1 px3 sm-col-10 semi-bold line-height-4 h4">
             If you have a question, problem, or just need a hand send us an email and we’ll help you out.
           </div>
 
           <div className="pt1">
-            <Button className="h5 bold" href="mailto:support@buildkite.com" theme="default" outline={true}>Email support@buildkite.com</Button>
+            <Button className="h4 bold" href="mailto:support@buildkite.com" theme="default" outline={true}>Email support@buildkite.com</Button>
           </div>
         </div>
       </Dialog>

--- a/app/components/organization/Pipeline/Metrics/metric.js
+++ b/app/components/organization/Pipeline/Metrics/metric.js
@@ -22,7 +22,7 @@ class Metric extends React.Component {
 
   renderValue() {
     const match = String(this.props.pipelineMetric.value).match(/([\d\.]+)(.*)/);
-    const valueClasses = "h3 light m0 line-height-1";
+    const valueClasses = "h1 light m0 line-height-1";
 
     if (match) {
       return (

--- a/app/components/organization/Pipeline/index.js
+++ b/app/components/organization/Pipeline/index.js
@@ -54,7 +54,7 @@ class Pipeline extends React.Component {
 
         <a href={this.props.pipeline.url} className="flex flex-auto items-center px2 text-decoration-none color-inherit mr3">
           <div className="truncate">
-            <h2 className="inline h4 regular m0 line-height-2">{this.props.pipeline.name}</h2>
+            <h2 className="inline h3 regular m0 line-height-2">{this.props.pipeline.name}</h2>
             {this.renderDescription()}
           </div>
         </a>
@@ -74,7 +74,7 @@ class Pipeline extends React.Component {
     if (this.props.pipeline.description) {
       return (
         <div className="truncate dark-gray" style={{ marginTop: 3 }}>
-          <Emojify className="h5 regular" text={this.props.pipeline.description} />
+          <Emojify className="h4 regular" text={this.props.pipeline.description} />
         </div>
       );
     }

--- a/app/components/organization/Teams.js
+++ b/app/components/organization/Teams.js
@@ -24,7 +24,7 @@ class Teams extends React.Component {
   renderDropdown() {
     return (
       <Dropdown width={300} ref={(dropdownNode) => this.dropdownNode = dropdownNode}>
-        <button className="h4 px0 py1 m0 light dark-gray inline-block btn" style={{ fontSize: 16 }}>
+        <button className="h3 px0 py1 m0 light dark-gray inline-block btn" style={{ fontSize: 16 }}>
           <div className="flex">
             <span className="flex items-center">
               <span className="truncate">

--- a/app/components/organization/Welcome.js
+++ b/app/components/organization/Welcome.js
@@ -11,7 +11,7 @@ class Welcome extends React.Component {
     return (
       <div className="center p4">
         <PipelineIcon />
-        <h1 className="h3 m0 mt2 mb4">Create your first pipeline</h1>
+        <h1 className="h2 m0 mt2 mb4">Create your first pipeline</h1>
         <p className="mx-auto" style={{ maxWidth: "30em" }}>Pipelines define the tasks to be run on your agents. It’s best to keep each pipeline focussed on a single part of your delivery pipeline, such as testing, deployments or infrastructure. Once created, you can connect your pipeline with your source control or trigger it via the API.</p>
         <p className="dark-gray">Need inspiration? See the <a className="blue hover-navy text-decoration-none hover-underline" target="_blank" href="https://github.com/buildkite/example-pipelines">example pipelines</a> GitHub repo.</p>
         <p>

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -23,7 +23,7 @@ class Header extends React.Component {
     return (
       <div className="flex flex-wrap mb2">
         <div className="flex-auto mb1">
-          <h4 className="regular h4 line-height-2 m0">
+          <h4 className="regular h3 line-height-2 m0">
             <a className="color-inherit hover-color-inherit text-decoration-none hover-underline" href={this.props.pipeline.url}><Emojify text={this.props.pipeline.name} /></a>
           </h4>
           <div className="m0 truncate dark-gray" style={{ maxWidth: "25em", marginTop: 3 }}>

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -74,6 +74,7 @@
   --container-width: 100%;
 
   --h1: 25px;
+  --h2: 24px;
   --h3: 24px;
   --h4: 18px;
   --h5: 14px;

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -73,11 +73,11 @@
 
   --container-width: 100%;
 
-  --h1: 25px;
-  --h2: 24px;
-  --h3: 24px;
-  --h4: 18px;
-  --h5: 14px;
+  --h1: 24px;
+  --h2: 21px;
+  --h3: 18px;
+  --h4: 14px;
+  --h5: 13px;
   --h6: 12px;
 
   --space-1: 5px;

--- a/app/css/style-guide/index.js
+++ b/app/css/style-guide/index.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import Typography from './typography';
+
+const Section = function(props) {
+  return <div className="my4">{props.children}</div>;
+};
+Section.propTypes = {
+  children: React.PropTypes.node
+};
+
+// Useful when authoring our base CSS styles
+//
+// We don't yet have a static page/route to render this, so at the moment
+// you just have to insert it into pages as you need it.
+//
+// For example:
+//
+//   import CSSStyleGuide from '../../css/style-guide';
+//
+//   class SomeComponent extends React.Component {
+//     render() {
+//       return (
+//         <div>
+//           <CSSStyleGuide />
+//         </div>
+//       );
+//     }
+//   }
+export default class CSSStyleGuide extends React.PureComponent {
+  render() {
+    return (
+      <div>
+        <Section><Typography /></Section>
+      </div>
+    );
+  }
+}

--- a/app/css/style-guide/typography.js
+++ b/app/css/style-guide/typography.js
@@ -1,0 +1,105 @@
+import React from 'react';
+
+const Example = function(props) {
+  return <div className="my3 border-left border-gray pl4 py2">{props.children}</div>;
+};
+Example.propTypes = { children: React.PropTypes.node };
+
+const Section = function(props) {
+  return (
+    <div className="max-width-2 my4 pt1">
+      <hr className="col-1 ml0 mt2 border border-lime" />
+      <h2 className="h2 bold mt4 line-height-1">{props.title}</h2>
+      {props.children}
+    </div>
+  );
+};
+Section.propTypes = { title: React.PropTypes.string, children: React.PropTypes.node };
+
+export default class Typography extends React.PureComponent {
+  render() {
+    return (
+      <div>
+        <h1 className="h1 bold">Typography</h1>
+
+        <Section title="Size Classes">
+          <p className="h1 my2">.h1 — Lorem ipsum dolor sit amet</p>
+          <p className="h2 my2">.h2 — Lorem ipsum dolor sit amet</p>
+          <p className="h3 my2">.h3 — Lorem ipsum dolor sit amet</p>
+          <p className="h4 my2">.h4 — Lorem ipsum dolor sit amet — Regular text</p>
+          <p className="h5 my2">.h5 — Lorem ipsum dolor sit amet</p>
+          <p className="h6 my2">.h6 — Lorem ipsum dolor sit amet</p>
+        </Section>
+
+        <Section title="Weight Classes">
+          <p className="regular my2">.regular — Lorem ipsum dolor sit amet</p>
+          <p className="semi-bold my2">.semi-bold — Lorem ipsum dolor sit amet</p>
+          <p className="bold my2">.bold — Lorem ipsum dolor sit amet</p>
+        </Section>
+
+        <Section title="How to choose between sizes">
+          <p className="my3">You want enough contrast between type so that the hierarchy is clear. With our type scale, a good rule of thumb is to ensure text is at least two sizes different.</p>
+
+          <p className="mt4 mb3">For example, the following lacks typographic contrast:</p>
+          <Example>
+            <p className="h1 m0" title="h1">Pipeline Settings — h1</p>
+            <p className="h2 m0" title="h2">Manage your how your pipeline works — h2</p>
+          </Example>
+
+          <p className="mt4 mb3">You could increase the contrast by using weight:</p>
+          <Example>
+            <p className="h1 m0 bold">Pipeline Settings — h1</p>
+            <p className="h2 m0">Manage your how your pipeline works — h2</p>
+          </Example>
+
+          <p className="mt4 mb3">Colour:</p>
+          <Example>
+            <p className="h1 m0">Pipeline Settings — h1</p>
+            <p className="h2 m0 dark-gray">Manage your how your pipeline works — h2</p>
+          </Example>
+
+          <p className="mt4 mb3">Size:</p>
+          <Example>
+            <p className="h1 m0">Pipeline Settings — h1</p>
+            <p className="h3 m0">Manage your how your pipeline works — h3</p>
+          </Example>
+
+          <p className="mt4 mb3">Both colour and size:</p>
+          <Example>
+            <p className="h1 m0">Pipeline Settings — h1</p>
+            <p className="h3 m0 dark-gray">Manage your how your pipeline works — h3</p>
+          </Example>
+
+          <p className="my4">The general rule is to try to adjust font-size first, and then colour, and then weight.</p>
+        </Section>
+
+        <Section title="Examples of good contrast">
+          <Example>
+            <p className="h1 m0">Pipeline Settings — h1</p>
+            <p className="h3 m0">Manage your how your pipeline works — h3</p>
+          </Example>
+
+          <Example>
+            <p className="h2 m0">Pipeline Settings — h2</p>
+            <p className="h4 m0">Manage your how your pipeline works — h4</p>
+          </Example>
+
+          <Example>
+            <p className="h3 m0">Pipeline Settings — h3</p>
+            <p className="h5 m0">Manage your how your pipeline works — h5</p>
+          </Example>
+
+          <Example>
+            <p className="h4 m0">Pipeline Settings — h4</p>
+            <p className="h5 m0 dark-gray">Manage your how your pipeline works — h5</p>
+          </Example>
+
+          <Example>
+            <p className="h5 m0">Pipeline Settings — h5</p>
+            <p className="h6 m0 dark-gray">Manage your how your pipeline works — h6</p>
+          </Example>
+        </Section>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
As part of working on the new pipeline header updates, I updated these font-sizes. I'm breaking these sorts of changes out into their own PRs so we can ship them first.

This one updates our type scale to be more sane. `.h4` is now "regular sized text", and we actually define a `.h2` size.

Whilst working on the sizes I needed a style guide I could change and look at, and I left it in there with the idea that we'd mount it to `_styleguide` in development. I just gave up on making that actually work.