### PR TITLE
Limit job listing to a much smaller subset of jobs

### DIFF
--- a/app/components/job/Index/index.js
+++ b/app/components/job/Index/index.js
@@ -8,6 +8,8 @@ import Panel from '../../shared/Panel';
 import Button from '../../shared/Button';
 import PageWithContainer from '../../shared/PageWithContainer';
 
+import JobStatesConstants from '../../../constants/JobStates';
+
 import JobRow from './job-row';
 import StateSelector from './state-selector';
 
@@ -20,9 +22,10 @@ class AgentIndex extends React.Component {
   };
 
   state = {
+    searching: false,
     loadingMore: false,
     switchingStates: false,
-    selectedJobState: null
+    selectedJobState: JobStatesConstants.SCHEDULED
   };
 
   componentDidMount() {
@@ -40,6 +43,7 @@ class AgentIndex extends React.Component {
                 className="flex-auto"
                 placeholder="Search by agent query rules…"
                 onChange={this.handleAgentQueryRuleSearch}
+                searching={this.state.searching}
               />
 
               <div className="flex-none pl3 flex">
@@ -87,7 +91,9 @@ class AgentIndex extends React.Component {
       if (jobs.edges.length === 0) {
         return (
           <Panel.Section className="center">
-            <div>No jobs here!</div>
+            <div>
+              There are no {this.state.selectedJobState.toLowerCase()} jobs
+            </div>
           </Panel.Section>
         );
       } else {
@@ -147,7 +153,7 @@ class AgentIndex extends React.Component {
 export default Relay.createContainer(AgentIndex, {
   initialVariables: {
     isMounted: false,
-    state: null,
+    state: JobStatesConstants.SCHEDULED,
     agentQueryRules: null,
     pageSize: PAGE_SIZE
   },

--- a/app/components/job/Index/state-selector.js
+++ b/app/components/job/Index/state-selector.js
@@ -4,38 +4,6 @@ import Dropdown from '../../shared/Dropdown';
 import JobStatesConstants from '../../../constants/JobStates';
 
 const STATES = {
-  [null]: {
-    label: "All"
-  },
-
-  [JobStatesConstants.PENDING]: {
-    label: "Pending"
-  },
-
-  [JobStatesConstants.WAITING]: {
-    label: "Waiting"
-  },
-
-  [JobStatesConstants.WAITING_FAILED]: {
-    label: "Waiting Failed"
-  },
-
-  [JobStatesConstants.BLOCKED]: {
-    label: "Blocked"
-  },
-
-  [JobStatesConstants.BLOCKED_FAILED]: {
-    label: "Blocked Failed"
-  },
-
-  [JobStatesConstants.UNBLOCKED]: {
-    label: "Unblocked"
-  },
-
-  [JobStatesConstants.UNBLOCKED_FAILED]: {
-    label: "Unblocked Failed"
-  },
-
   [JobStatesConstants.SCHEDULED]: {
     label: "Scheduled"
   },
@@ -52,28 +20,12 @@ const STATES = {
     label: "Running"
   },
 
-  [JobStatesConstants.FINISHED]: {
-    label: "Finished"
-  },
-
   [JobStatesConstants.CANCELING]: {
     label: "Canceling"
   },
 
-  [JobStatesConstants.CANCELED]: {
-    label: "Canceled"
-  },
-
   [JobStatesConstants.TIMING_OUT]: {
     label: "Timing Out"
-  },
-
-  [JobStatesConstants.TIMED_OUT]: {
-    label: "Timed Out"
-  },
-
-  [JobStatesConstants.SKIPPED]: {
-    label: "Skipped"
   }
 };
 
@@ -95,11 +47,17 @@ class StateSelector extends React.Component {
   renderOptions() {
     return Object.keys(STATES).map((state) => {
       return (
-        <div key={state} className="btn block hover-bg-silver" onClick={() => { this.dropdownNode.setShowing(false); this.props.onSelect(state); }}>
+        <div key={state} className="btn block hover-bg-silver" onClick={() => this.setState(state)}>
           <span className="block">{STATES[state].label}</span>
         </div>
       );
     });
+  }
+
+  setState(state) {
+    this.dropdownNode.setShowing(false);
+
+    this.props.onSelect(state);
   }
 }
 


### PR DESCRIPTION
Currently the "all" query kills the DB, so we'll restrict the state list to active jobs (a much-smaller subset than all historical jobs") and we'll default it to show "scheduled" jobs. If we fix the performance problems, we can revert this back