### PR TITLE
Improve Dialog behaviour

### DIFF
--- a/app/components/layout/Navigation/support-dialog.js
+++ b/app/components/layout/Navigation/support-dialog.js
@@ -59,7 +59,7 @@ class SupportDialog extends React.PureComponent {
   render() {
     return (
       <Dialog isOpen={this.props.isOpen} onRequestClose={this.props.onRequestClose}>
-        <div className="center" style={{ padding: "50px 10px" }}>
+        <div className="center" style={{ padding: "10% 2%" }}>
           {/* fyi the h1 class here is only necessary so this doesn't break on Bootstrap pages */}
           <h1 className="bold h1 mt0 mt2 mb4">
             <WavingEmoji className="inline-block" text=":wave::skin-tone-3:" />

--- a/app/components/shared/Dialog.js
+++ b/app/components/shared/Dialog.js
@@ -27,24 +27,35 @@ const DialogBackdrop = styled.div`
   bottom: 0;
   right: 0;
   opacity: 0.9;
-  z-index: 1002;
 `;
 
 DialogBackdrop.defaultProps = {
   className: 'absolute bg-white'
 };
 
+const DialogContainer = styled.div`
+  width: 100vw;
+  maxWidth: 100%;
+  height: 100%;
+  padding: 25px 25px 40px;
+  overflow-y: auto;
+`;
+
+DialogContainer.defaultProps = {
+  className: 'flex'
+};
+
 const DialogBox = styled.div`
-  width: ${(props) => props.width}px;
-  zIndex: 1004;
-  maxWidth: 90vw;
+  width: 100%;
+  maxWidth: ${(props) => props.width}px;
+  margin: auto;
 `;
 
 DialogBox.defaultProps = {
-  className: 'background bg-white transition-popup rounded-3 shadow-subtle relative mx4'
+  className: 'background bg-white rounded-3 shadow-subtle relative'
 };
 
-const DialogContainer = styled.span`
+const DialogWrapper = styled.div`
   top: 0;
   left: 0;
   bottom: 0;
@@ -52,8 +63,8 @@ const DialogContainer = styled.span`
   z-index: 1000;
 `;
 
-DialogContainer.defaultProps = {
-  className: 'block fixed flex items-center justify-center'
+DialogWrapper.defaultProps = {
+  className: 'fixed'
 };
 
 class Dialog extends React.Component {
@@ -159,10 +170,12 @@ class Dialog extends React.Component {
     }
 
     return (
-      <DialogBox width={this.props.width}>
-        {this.renderCloseButton()}
-        {this.props.children}
-      </DialogBox>
+      <DialogContainer>
+        <DialogBox width={this.props.width}>
+          {this.renderCloseButton()}
+          {this.props.children}
+        </DialogBox>
+      </DialogContainer>
     );
   }
 
@@ -172,12 +185,12 @@ class Dialog extends React.Component {
     }
 
     return (
-      <DialogContainer>
+      <DialogWrapper>
+        {this.renderBackdrop()}
         <ReactCSSTransitionGroup transitionName="transition-slide-up" transitionEnterTimeout={150} transitionLeaveTimeout={300}>
           {this.renderDialog()}
         </ReactCSSTransitionGroup>
-        {this.renderBackdrop()}
-      </DialogContainer>
+      </DialogWrapper>
     );
   }
 }

--- a/app/components/shared/Dialog.js
+++ b/app/components/shared/Dialog.js
@@ -137,6 +137,12 @@ class Dialog extends React.Component {
     }
   }
 
+  componentDidUpdate() {
+    // This locks the body's scrolling whenever the dialog is _rendered_
+    const action = this.state.rendered ? 'add' : 'remove';
+    document.body.classList[action]('overflow-hidden');
+  }
+
   maybeClose = (event) => {
     event.preventDefault();
     if (typeof this.props.onRequestClose === 'function') {

--- a/app/components/shared/Dialog.js
+++ b/app/components/shared/Dialog.js
@@ -37,12 +37,23 @@ const DialogContainer = styled.div`
   width: 100vw;
   maxWidth: 100%;
   height: 100%;
-  padding: 25px 25px 40px;
+  padding: 25px;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+
+  &:after {
+    display: block;
+    flex: 0 0 auto;
+    height: 40px;
+    content: '';
+  }
 `;
+// NOTE: DialogContainer:after is a substitute for padding
+// which would otherwise be applied, but is ignored by both
+// Firefox and Safari!
 
 DialogContainer.defaultProps = {
-  className: 'flex'
+  className: 'flex flex-column'
 };
 
 const DialogBox = styled.div`


### PR DESCRIPTION
This allows the dialog to scroll. What it does is rearrange the dialog to allow the entire dialog to appear partially offscreen, and the rest to scroll into view.

<img width="320" alt="animated 2017-05-01 at 13 38 54" src="https://cloud.githubusercontent.com/assets/282113/25593945/a709138e-2e73-11e7-86d1-1e69cbee9f51.gif">

This has a couple of caveats, which might be acceptable or might need working around.

In any case, this is intended in support of #222, which can in some cases create dialogs which appear partially offscreen, and currently can't be scrolled to.

The caveats;
* Scrolling the dialog requires the cursor to be over the dialog, not the dialog backdrop
  * This is because the scroll container is transparent so the scroll event is passed to the backdrop, which is not part of a scroll container, and thus passed to the page.
  * We can work around this by putting the backdrop in the scroll container, but we need to think more about how we manage the transition animations if we do that.
* Firefox collapses the padding at the bottom of the flex container.

The easiest way to check out this behaviour is to open the Support dialog and shrink the window to ~320px wide and ~very smol high!