### PR TITLE
Update to use prop-types directly

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -24,6 +24,7 @@ window["Webpack"] = {
     "eventemitter3": require("eventemitter3"),
     "moment": require("moment"),
     "object-assign": require("object-assign"),
+    "prop-types": require("prop-types"),
     "react": require("react"),
     "react-dom": require("react-dom"),
     "react-relay": require("react-relay"),

--- a/app/components/Main.js
+++ b/app/components/Main.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -8,9 +9,9 @@ import Flashes from './layout/Flashes';
 
 class Main extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    viewer: React.PropTypes.object.isRequired,
-    organization: React.PropTypes.object
+    children: PropTypes.node.isRequired,
+    viewer: PropTypes.object.isRequired,
+    organization: PropTypes.object
   };
 
   render() {

--- a/app/components/agent/Index/agent-tokens.js
+++ b/app/components/agent/Index/agent-tokens.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Panel from '../../shared/Panel';
@@ -7,19 +8,19 @@ import RevealButton from '../../shared/RevealButton';
 
 class AgentTokens extends React.Component {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      agentTokens: React.PropTypes.shape({
-        edges: React.PropTypes.array.isRequired
+    organization: PropTypes.shape({
+      agentTokens: PropTypes.shape({
+        edges: PropTypes.array.isRequired
       }),
-      permissions: React.PropTypes.shape({
-        agentTokenView: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+      permissions: PropTypes.shape({
+        agentTokenView: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired
       })
     }).isRequired,
-    relay: React.PropTypes.object.isRequired,
-    title: React.PropTypes.string.isRequired,
-    setupMode: React.PropTypes.bool
+    relay: PropTypes.object.isRequired,
+    title: PropTypes.string.isRequired,
+    setupMode: PropTypes.bool
   };
 
   static defaultProps = {

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import { second, seconds } from 'metrick/duration';
 import throttle from 'throttleit';
@@ -17,19 +18,19 @@ const PAGE_SIZE = 100;
 
 class Agents extends React.PureComponent {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      allAgents: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired
+    organization: PropTypes.shape({
+      allAgents: PropTypes.shape({
+        count: PropTypes.number.isRequired
       }),
-      agents: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired,
-        pageInfo: React.PropTypes.shape({
-          hasNextPage: React.PropTypes.bool.isRequired
+      agents: PropTypes.shape({
+        count: PropTypes.number.isRequired,
+        pageInfo: PropTypes.shape({
+          hasNextPage: PropTypes.bool.isRequired
         }).isRequired,
-        edges: React.PropTypes.array.isRequired
+        edges: PropTypes.array.isRequired
       })
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/agent/Index/index.js
+++ b/app/components/agent/Index/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -11,13 +12,13 @@ import QuickStart from './quick-start';
 
 class AgentIndex extends React.Component {
   static propTypes = {
-    location: React.PropTypes.shape({
-      query: React.PropTypes.object
+    location: PropTypes.shape({
+      query: PropTypes.object
     }).isRequired,
-    organization: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired
+    organization: PropTypes.shape({
+      name: PropTypes.string.isRequired
     }).isRequired,
-    viewer: React.PropTypes.object.isRequired
+    viewer: PropTypes.object.isRequired
   };
 
   render() {

--- a/app/components/agent/Index/installation.js
+++ b/app/components/agent/Index/installation.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import { seconds } from 'metrick/duration';
 import Confetti from 'react-confetti';
@@ -10,13 +11,13 @@ import Panel from '../../shared/Panel';
 
 class AgentInstallation extends React.PureComponent {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      agents: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired,
-        edges: React.PropTypes.array.isRequired
+    organization: PropTypes.shape({
+      agents: PropTypes.shape({
+        count: PropTypes.number.isRequired,
+        edges: PropTypes.array.isRequired
       })
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/agent/Index/quick-start.js
+++ b/app/components/agent/Index/quick-start.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import { Link } from 'react-router';
 import classNames from 'classnames';
@@ -24,25 +25,25 @@ const getSlugForGuide = ({ slug, title }) => slug || encodeURIComponent(title.to
 
 class QuickStart extends React.PureComponent {
   static propTypes = {
-    center: React.PropTypes.bool.isRequired,
-    location: React.PropTypes.shape({
-      hash: React.PropTypes.string.isRequired,
-      pathname: React.PropTypes.string.isRequired,
-      search: React.PropTypes.string.isRequired
+    center: PropTypes.bool.isRequired,
+    location: PropTypes.shape({
+      hash: PropTypes.string.isRequired,
+      pathname: PropTypes.string.isRequired,
+      search: PropTypes.string.isRequired
     }).isRequired,
-    organization: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired,
-      uuid: React.PropTypes.string,
-      agentTokens: React.PropTypes.shape({
-        edges: React.PropTypes.array.isRequired
+    organization: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      uuid: PropTypes.string,
+      agentTokens: PropTypes.shape({
+        edges: PropTypes.array.isRequired
       })
     }).isRequired,
-    relay: React.PropTypes.object.isRequired,
-    title: React.PropTypes.string.isRequired,
-    viewer: React.PropTypes.shape({
-      apiAccessTokens: React.PropTypes.shape({
-        edges: React.PropTypes.array.isRequired
+    relay: PropTypes.object.isRequired,
+    title: PropTypes.string.isRequired,
+    viewer: PropTypes.shape({
+      apiAccessTokens: PropTypes.shape({
+        edges: PropTypes.array.isRequired
       })
     })
   };

--- a/app/components/agent/Index/row.js
+++ b/app/components/agent/Index/row.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import { Link } from 'react-router';
 
@@ -8,20 +9,20 @@ import JobLink from '../../shared/JobLink';
 
 class AgentRow extends React.Component {
   static propTypes = {
-    agent: React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      connectionState: React.PropTypes.string.isRequired,
-      hostname: React.PropTypes.string.isRequired,
-      job: React.PropTypes.shape({
-        state: React.PropTypes.string
+    agent: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      connectionState: PropTypes.string.isRequired,
+      hostname: PropTypes.string.isRequired,
+      job: PropTypes.shape({
+        state: PropTypes.string
       }),
-      metaData: React.PropTypes.array.isRequired,
-      name: React.PropTypes.string.isRequired,
-      organization: React.PropTypes.shape({
-        slug: React.PropTypes.string.isRequired
+      metaData: PropTypes.array.isRequired,
+      name: PropTypes.string.isRequired,
+      organization: PropTypes.shape({
+        slug: PropTypes.string.isRequired
       }).isRequired,
-      uuid: React.PropTypes.string.isRequired,
-      version: React.PropTypes.string.isRequired
+      uuid: PropTypes.string.isRequired,
+      version: PropTypes.string.isRequired
     })
   };
 

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 import { seconds } from 'metrick/duration';
@@ -6,7 +7,7 @@ import { seconds } from 'metrick/duration';
 import StateIcon from './state-icon';
 import Button from '../shared/Button';
 import FlashesStore from '../../stores/FlashesStore';
-import FriendlyTime from "../shared/FriendlyTime";
+import FriendlyTime from '../shared/FriendlyTime';
 import JobLink from '../shared/JobLink';
 import PageWithContainer from '../shared/PageWithContainer';
 import Panel from '../shared/Panel';
@@ -17,22 +18,22 @@ import AgentStopMutation from '../../mutations/AgentStop';
 
 class AgentShow extends React.Component {
   static propTypes = {
-    agent: React.PropTypes.shape({
-      id: React.PropTypes.string,
-      name: React.PropTypes.string,
-      connectionState: React.PropTypes.string,
-      job: React.PropTypes.object,
-      permissions: React.PropTypes.shape({
-        agentStop: React.PropTypes.shape({
-          allowed: React.PropTypes.bool
+    agent: PropTypes.shape({
+      id: PropTypes.string,
+      name: PropTypes.string,
+      connectionState: PropTypes.string,
+      job: PropTypes.object,
+      permissions: PropTypes.shape({
+        agentStop: PropTypes.shape({
+          allowed: PropTypes.bool
         })
       }),
-      organization: React.PropTypes.shape({
-        name: React.PropTypes.string,
-        slug: React.PropTypes.string
+      organization: PropTypes.shape({
+        name: PropTypes.string,
+        slug: PropTypes.string
       })
     }),
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/agent/state-icon.js
+++ b/app/components/agent/state-icon.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import BuildState from '../icons/BuildState';
@@ -35,9 +36,9 @@ export default function StateIcon(props) {
 }
 
 StateIcon.propTypes = {
-  className: React.PropTypes.string,
-  agent: React.PropTypes.shape({
-    connectionState: React.PropTypes.string.isRequired,
-    job: React.PropTypes.object
+  className: PropTypes.string,
+  agent: PropTypes.shape({
+    connectionState: PropTypes.string.isRequired,
+    job: PropTypes.object
   })
 };

--- a/app/components/api_access_token_code/APIAccessTokenCodeAuthorize.js
+++ b/app/components/api_access_token_code/APIAccessTokenCodeAuthorize.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -12,10 +13,10 @@ import FlashesStore from '../../stores/FlashesStore';
 
 class APIAccessTokenCodeAuthorize extends React.Component {
   static propTypes = {
-    apiAccessTokenCode: React.PropTypes.shape({
-      authorizedAt: React.PropTypes.string,
-      application: React.PropTypes.shape({
-        name: React.PropTypes.string.isRequired
+    apiAccessTokenCode: PropTypes.shape({
+      authorizedAt: PropTypes.string,
+      application: PropTypes.shape({
+        name: PropTypes.string.isRequired
       }).isRequired
     })
   };

--- a/app/components/build/AvatarWithUnknownEmailPrompt.js
+++ b/app/components/build/AvatarWithUnknownEmailPrompt.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Dropdown from '../shared/Dropdown';
@@ -13,29 +14,29 @@ import NoticeDismissMutation from '../../mutations/NoticeDismiss';
 
 class AvatarWithUnknownEmailPrompt extends React.PureComponent {
   static propTypes = {
-    build: React.PropTypes.shape({
-      createdBy: React.PropTypes.shape({
-        email: React.PropTypes.string,
-        name: React.PropTypes.string
+    build: PropTypes.shape({
+      createdBy: PropTypes.shape({
+        email: PropTypes.string,
+        name: PropTypes.string
       })
     }).isRequired,
-    viewer: React.PropTypes.shape({
-      emails: React.PropTypes.shape({
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.shape({
-              id: React.PropTypes.string,
-              address: React.PropTypes.string,
-              verified: React.PropTypes.bool
+    viewer: PropTypes.shape({
+      emails: PropTypes.shape({
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.shape({
+              id: PropTypes.string,
+              address: PropTypes.string,
+              verified: PropTypes.bool
             })
           })
         )
       }).isRequired,
-      notice: React.PropTypes.shape({
-        dismissedAt: React.PropTypes.string
+      notice: PropTypes.shape({
+        dismissedAt: PropTypes.string
       })
     }).isRequired,
-    relay: React.PropTypes.object
+    relay: PropTypes.object
   };
 
   state = {

--- a/app/components/build/StateSwitcher.js
+++ b/app/components/build/StateSwitcher.js
@@ -1,15 +1,16 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { formatNumber } from '../../lib/number';
 
 class StateSwitcher extends React.PureComponent {
   static propTypes = {
-    buildsCount: React.PropTypes.number,
-    runningBuildsCount: React.PropTypes.number,
-    scheduledBuildsCount: React.PropTypes.number,
-    state: React.PropTypes.string,
-    path: React.PropTypes.string
+    buildsCount: PropTypes.number,
+    runningBuildsCount: PropTypes.number,
+    scheduledBuildsCount: PropTypes.number,
+    state: PropTypes.string,
+    path: PropTypes.string
   };
 
   renderLink(label, state, count) {

--- a/app/components/docs/09-aws/parameter-table.js
+++ b/app/components/docs/09-aws/parameter-table.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { stringify } from 'query-string';
 
 const newTokenForOrgLink = (props) => {
@@ -22,8 +23,8 @@ const newTokenForOrgLink = (props) => {
 };
 
 AWSTableRow.propTypes = {
-  title: React.PropTypes.node.isRequired,
-  children: React.PropTypes.node.isRequired
+  title: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired
 };
 
 function AWSTableRow(props) {
@@ -40,17 +41,17 @@ function AWSTableRow(props) {
 }
 
 AWSParameterTable.propTypes = {
-  token: React.PropTypes.string,
-  organization: React.PropTypes.shape({
-    name: React.PropTypes.string,
-    slug: React.PropTypes.string,
-    uuid: React.PropTypes.string
+  token: PropTypes.string,
+  organization: PropTypes.shape({
+    name: PropTypes.string,
+    slug: PropTypes.string,
+    uuid: PropTypes.string
   }).isRequired,
-  apiAccessTokens: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      token: React.PropTypes.string.isRequired,
-      uuid: React.PropTypes.string.isRequired,
-      description: React.PropTypes.string.isRequired
+  apiAccessTokens: PropTypes.arrayOf(
+    PropTypes.shape({
+      token: PropTypes.string.isRequired,
+      uuid: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired
     })
   ).isRequired
 };

--- a/app/components/icons/BuildState.js
+++ b/app/components/icons/BuildState.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { v4 as uuid } from 'uuid';
 
 import BuildStates from '../../constants/BuildStates';
@@ -33,11 +34,11 @@ const STATE_COLORS = {
 
 class BuildState extends React.PureComponent {
   static propTypes = {
-    className: React.PropTypes.string,
-    size: React.PropTypes.number.isRequired,
-    state: React.PropTypes.oneOf(Object.keys(STATE_COLORS)),
-    strokeWidth: React.PropTypes.number.isRequired,
-    style: React.PropTypes.object
+    className: PropTypes.string,
+    size: PropTypes.number.isRequired,
+    state: PropTypes.oneOf(Object.keys(STATE_COLORS)),
+    strokeWidth: PropTypes.number.isRequired,
+    style: PropTypes.object
   };
 
   state = {

--- a/app/components/icons/Favorite.js
+++ b/app/components/icons/Favorite.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const starColor = "#f8cc1c";
@@ -20,7 +21,7 @@ const StarSVG = styled.svg`
 
 class Favorite extends React.PureComponent {
   static propTypes = {
-    favorite: React.PropTypes.bool.isRequired
+    favorite: PropTypes.bool.isRequired
   };
 
   render() {

--- a/app/components/job/Index/index.js
+++ b/app/components/job/Index/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Panel from '../../shared/Panel';
@@ -11,12 +12,12 @@ import SearchInput from './search-input';
 
 class JobIndex extends React.Component {
   static propTypes = {
-    organization: React.PropTypes.object.isRequired,
-    location: React.PropTypes.object
+    organization: PropTypes.object.isRequired,
+    location: PropTypes.object
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   constructor(initialProps) {

--- a/app/components/job/Index/jobs.js
+++ b/app/components/job/Index/jobs.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import searchQuery from 'search-query-parser';
 
@@ -13,10 +14,10 @@ const SEARCH_KEYWORDS = ['state', 'concurrency-group'];
 
 class Jobs extends React.PureComponent {
   static propTypes = {
-    organization: React.PropTypes.object.isRequired,
-    relay: React.PropTypes.object.isRequired,
-    query: React.PropTypes.string,
-    onSuggestionClick: React.PropTypes.func
+    organization: PropTypes.object.isRequired,
+    relay: PropTypes.object.isRequired,
+    query: PropTypes.string,
+    onSuggestionClick: PropTypes.func
   };
 
   state = {

--- a/app/components/job/Index/row.js
+++ b/app/components/job/Index/row.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Panel from '../../shared/Panel';
@@ -7,9 +8,9 @@ import FriendlyTime from '../../shared/FriendlyTime';
 
 class Row extends React.PureComponent {
   static propTypes = {
-    job: React.PropTypes.object.isRequired,
-    onConcurrencyGroupClick: React.PropTypes.func,
-    onAgentQueryRuleClick: React.PropTypes.func
+    job: PropTypes.object.isRequired,
+    onConcurrencyGroupClick: PropTypes.func,
+    onAgentQueryRuleClick: PropTypes.func
   };
 
   render() {

--- a/app/components/job/Index/search-input.js
+++ b/app/components/job/Index/search-input.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Icon from '../../shared/Icon';
 
 export default class SearchInput extends React.PureComponent {
   static propTypes = {
-    value: React.PropTypes.string,
-    onChange: React.PropTypes.func
+    value: PropTypes.string,
+    onChange: PropTypes.func
   };
 
   render() {

--- a/app/components/layout/Flashes/flash.js
+++ b/app/components/layout/Flashes/flash.js
@@ -1,16 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import FlashesStore from '../../../stores/FlashesStore';
 
 class Flash extends React.Component {
   static propTypes = {
-    flash: React.PropTypes.shape({
-      id: React.PropTypes.number.isRequired,
-      type: React.PropTypes.string.isRequired,
-      message: React.PropTypes.string.isRequired
+    flash: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      type: PropTypes.string.isRequired,
+      message: PropTypes.string.isRequired
     }),
-    onRemoveClick: React.PropTypes.func.isRequired
+    onRemoveClick: PropTypes.func.isRequired
   };
 
   render() {

--- a/app/components/layout/Footer/index.js
+++ b/app/components/layout/Footer/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Link from './link';
@@ -6,12 +7,12 @@ import Icon from '../../shared/Icon';
 
 class Footer extends React.Component {
   static propTypes = {
-    viewer: React.PropTypes.shape({
-      unreadChangelogs: React.PropTypes.shape({
-        count: React.PropTypes.number
+    viewer: PropTypes.shape({
+      unreadChangelogs: PropTypes.shape({
+        count: PropTypes.number
       })
     }),
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   componentDidMount() {

--- a/app/components/layout/Footer/link.js
+++ b/app/components/layout/Footer/link.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Link extends React.Component {
   static displayName = "Footer.Link";
 
   static propTypes = {
-    href: React.PropTypes.string.isRequired,
-    children: React.PropTypes.node.isRequired
+    href: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/layout/Navigation/MyBuilds/build.js
+++ b/app/components/layout/Navigation/MyBuilds/build.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import styled from 'styled-components';
 
@@ -24,8 +25,8 @@ BuildLink.defaultProps = {
 
 class BuildsDropdownBuild extends React.PureComponent {
   static propTypes = {
-    build: React.PropTypes.object,
-    relay: React.PropTypes.object.isRequired
+    build: PropTypes.object,
+    relay: PropTypes.object.isRequired
   }
 
   componentDidMount() {

--- a/app/components/layout/Navigation/MyBuilds/index.js
+++ b/app/components/layout/Navigation/MyBuilds/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import classNames from 'classnames';
@@ -17,8 +18,8 @@ import DropdownButton from './../dropdown-button';
 
 class MyBuilds extends React.Component {
   static propTypes = {
-    viewer: React.PropTypes.object,
-    relay: React.PropTypes.object.isRequired
+    viewer: PropTypes.object,
+    relay: PropTypes.object.isRequired
   }
 
   state = {

--- a/app/components/layout/Navigation/dropdown-button.js
+++ b/app/components/layout/Navigation/dropdown-button.js
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 class DropdownButton extends React.Component {
   static displayName = "Navigation.DropdownButton";
 
   static propTypes = {
-    style: React.PropTypes.object,
-    className: React.PropTypes.string,
-    children: React.PropTypes.node,
-    onMouseEnter: React.PropTypes.func
+    style: PropTypes.object,
+    className: PropTypes.string,
+    children: PropTypes.node,
+    onMouseEnter: PropTypes.func
   };
 
   render() {

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import classNames from 'classnames';
 
@@ -20,9 +21,9 @@ import MyBuilds from './MyBuilds';
 
 class Navigation extends React.PureComponent {
   static propTypes = {
-    organization: React.PropTypes.object,
-    viewer: React.PropTypes.object,
-    relay: React.PropTypes.object.isRequired
+    organization: PropTypes.object,
+    viewer: PropTypes.object,
+    relay: PropTypes.object.isRequired
   };
 
   componentDidMount() {

--- a/app/components/layout/Navigation/navigation-button.js
+++ b/app/components/layout/Navigation/navigation-button.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Link } from 'react-router';
 
@@ -6,12 +7,12 @@ class NavigationButton extends React.Component {
   static displayName = "Navigation.NavigationButton";
 
   static propTypes = {
-    style: React.PropTypes.object,
-    className: React.PropTypes.string,
-    linkIf: React.PropTypes.bool,
-    href: React.PropTypes.string,
-    children: React.PropTypes.node,
-    onClick: React.PropTypes.func
+    style: PropTypes.object,
+    className: PropTypes.string,
+    linkIf: PropTypes.bool,
+    href: PropTypes.string,
+    children: PropTypes.node,
+    onClick: PropTypes.func
   };
 
   static defaultProps = {
@@ -19,7 +20,7 @@ class NavigationButton extends React.Component {
   };
 
   static contextTypes = {
-    router: React.PropTypes.object
+    router: PropTypes.object
   };
 
   render() {

--- a/app/components/layout/Navigation/support-dialog.js
+++ b/app/components/layout/Navigation/support-dialog.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import shuffle from 'shuffle-array';
 import styled, { keyframes } from 'styled-components';
 
@@ -52,8 +53,8 @@ class SupportDialog extends React.PureComponent {
   static displayName = "Navigation.SupportDialog";
 
   static propTypes = {
-    isOpen: React.PropTypes.bool,
-    onRequestClose: React.PropTypes.func
+    isOpen: PropTypes.bool,
+    onRequestClose: PropTypes.func
   };
 
   render() {

--- a/app/components/member/Edit.js
+++ b/app/components/member/Edit.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -19,28 +20,28 @@ const AVATAR_SIZE = 50;
 
 class MemberEdit extends React.PureComponent {
   static propTypes = {
-    viewer: React.PropTypes.shape({
-      user: React.PropTypes.shape({
-        id: React.PropTypes.string.isRequired
+    viewer: PropTypes.shape({
+      user: PropTypes.shape({
+        id: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
-    organizationMember: React.PropTypes.shape({
-      uuid: React.PropTypes.string.isRequired,
-      role: React.PropTypes.string.isRequired,
-      permissions: React.PropTypes.object.isRequired,
-      user: React.PropTypes.shape({
-        id: React.PropTypes.string.isRequired,
-        name: React.PropTypes.string.isRequired,
-        email: React.PropTypes.string.isRequired,
-        avatar: React.PropTypes.shape({
-          url: React.PropTypes.string.isRequired
+    organizationMember: PropTypes.shape({
+      uuid: PropTypes.string.isRequired,
+      role: PropTypes.string.isRequired,
+      permissions: PropTypes.object.isRequired,
+      user: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
+        email: PropTypes.string.isRequired,
+        avatar: PropTypes.shape({
+          url: PropTypes.string.isRequired
         }).isRequired
       }).isRequired
     })
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/member/Index.js
+++ b/app/components/member/Index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import { second } from 'metrick/duration';
 import DocumentTitle from 'react-document-title';
@@ -27,33 +28,33 @@ const PAGE_SIZE = 10;
 
 class MemberIndex extends React.PureComponent {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired,
-      permissions: React.PropTypes.object.isRequired,
-      members: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired,
-        pageInfo: React.PropTypes.shape({
-          hasNextPage: React.PropTypes.bool.isRequired
+    organization: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      permissions: PropTypes.object.isRequired,
+      members: PropTypes.shape({
+        count: PropTypes.number.isRequired,
+        pageInfo: PropTypes.shape({
+          hasNextPage: PropTypes.bool.isRequired
         }).isRequired,
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.object.isRequired
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.object.isRequired
           }).isRequired
         ).isRequired
       }),
-      invitations: React.PropTypes.shape({
-        pageInfo: React.PropTypes.shape({
-          hasNextPage: React.PropTypes.bool.isRequired
+      invitations: PropTypes.shape({
+        pageInfo: PropTypes.shape({
+          hasNextPage: PropTypes.bool.isRequired
         }).isRequired,
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.object.isRequired
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.object.isRequired
           })
         ).isRequired
       })
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/member/InvitationRow.js
+++ b/app/components/member/InvitationRow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Button from '../shared/Button';
@@ -13,10 +14,10 @@ import OrganizationMemberRoleConstants from '../../constants/OrganizationMemberR
 
 class InvitationRow extends React.PureComponent {
   static propTypes = {
-    organizationInvitation: React.PropTypes.shape({
-      uuid: React.PropTypes.string.isRequired,
-      email: React.PropTypes.string.isRequired,
-      role: React.PropTypes.string.isRequired
+    organizationInvitation: PropTypes.shape({
+      uuid: PropTypes.string.isRequired,
+      email: PropTypes.string.isRequired,
+      role: PropTypes.string.isRequired
     }).isRequired
   };
 

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -22,24 +23,24 @@ import TeamMemberRoleConstants from '../../constants/TeamMemberRoleConstants';
 
 class MemberNew extends React.PureComponent {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired,
-      teams: React.PropTypes.shape({
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.shape({
-              id: React.PropTypes.string.isRequired
+    organization: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      teams: PropTypes.shape({
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.shape({
+              id: PropTypes.string.isRequired
             }).isRequired
           })
         ).isRequired
       })
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   static contextTypes = {
-    router: React.PropTypes.object
+    router: PropTypes.object
   };
 
   state = {

--- a/app/components/member/Row.js
+++ b/app/components/member/Row.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Panel from '../shared/Panel';
@@ -10,17 +11,17 @@ const AVATAR_SIZE = 40;
 
 class MemberRow extends React.PureComponent {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      slug: React.PropTypes.string.isRequired
+    organization: PropTypes.shape({
+      slug: PropTypes.string.isRequired
     }).isRequired,
-    organizationMember: React.PropTypes.shape({
-      uuid: React.PropTypes.string.isRequired,
-      role: React.PropTypes.string.isRequired,
-      user: React.PropTypes.shape({
-        name: React.PropTypes.string.isRequired,
-        email: React.PropTypes.string.isRequired,
-        avatar: React.PropTypes.shape({
-          url: React.PropTypes.string.isRequired
+    organizationMember: PropTypes.shape({
+      uuid: PropTypes.string.isRequired,
+      role: PropTypes.string.isRequired,
+      user: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        email: PropTypes.string.isRequired,
+        avatar: PropTypes.shape({
+          url: PropTypes.string.isRequired
         }).isRequired
       }).isRequired
     }).isRequired

--- a/app/components/member/TeamRow.js
+++ b/app/components/member/TeamRow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import styled from 'styled-components';
 
@@ -23,13 +24,13 @@ const Label = styled.label`
 
 class TeamRow extends React.Component {
   static propTypes = {
-    team: React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      name: React.PropTypes.string.isRequired,
-      description: React.PropTypes.string
+    team: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string
     }).isRequired,
-    checked: React.PropTypes.bool.isRequired,
-    onChange: React.PropTypes.func.isRequired
+    checked: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired
   };
 
   render() {

--- a/app/components/organization/AgentsCount.js
+++ b/app/components/organization/AgentsCount.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import throttle from 'throttleit';
 import { seconds } from 'metrick/duration';
@@ -14,12 +15,12 @@ const requestUpdate = throttle((callback) => callback(), 3::seconds);
 
 class AgentsCount extends React.PureComponent {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      agents: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired
+    organization: PropTypes.shape({
+      agents: PropTypes.shape({
+        count: PropTypes.number.isRequired
       })
     }),
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/organization/Pipeline/Metrics/index.js
+++ b/app/components/organization/Pipeline/Metrics/index.js
@@ -1,16 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
-import Metric from "./metric";
+import Metric from './metric';
 
 class Metrics extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.shape({
-      metrics: React.PropTypes.shape({
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.shape({
-              label: React.PropTypes.string.isRequired
+    pipeline: PropTypes.shape({
+      metrics: PropTypes.shape({
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.shape({
+              label: PropTypes.string.isRequired
             }).isRequired
           }).isRequired
         )

--- a/app/components/organization/Pipeline/Metrics/metric.js
+++ b/app/components/organization/Pipeline/Metrics/metric.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import classNames from 'classnames';
 
 class Metric extends React.Component {
   static propTypes = {
-    pipelineMetric: React.PropTypes.shape({
-      label: React.PropTypes.string.isRequired,
-      value: React.PropTypes.string,
-      url: React.PropTypes.string
+    pipelineMetric: PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string,
+      url: PropTypes.string
     }).isRequired
   };
 

--- a/app/components/organization/Pipeline/bar.js
+++ b/app/components/organization/Pipeline/bar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import BuildTooltip from './build-tooltip';
@@ -8,16 +9,16 @@ import { BAR_HEIGHT_MINIMUM, BAR_WIDTH, BAR_WIDTH_WITH_SEPERATOR, GRAPH_HEIGHT }
 
 class Bar extends React.PureComponent {
   static propTypes = {
-    href: React.PropTypes.string,
-    color: React.PropTypes.string.isRequired,
-    hoverColor: React.PropTypes.string.isRequired,
-    duration: React.PropTypes.number,
-    graph: React.PropTypes.shape({
-      maximumDuration: React.PropTypes.number
+    href: PropTypes.string,
+    color: PropTypes.string.isRequired,
+    hoverColor: PropTypes.string.isRequired,
+    duration: PropTypes.number,
+    graph: PropTypes.shape({
+      maximumDuration: PropTypes.number
     }).isRequired,
-    left: React.PropTypes.number.isRequired,
-    build: React.PropTypes.object,
-    showFullGraph: React.PropTypes.bool.isRequired
+    left: PropTypes.number.isRequired,
+    build: PropTypes.object,
+    showFullGraph: PropTypes.bool.isRequired
   };
 
   static defaultProps = {

--- a/app/components/organization/Pipeline/build-tooltip.js
+++ b/app/components/organization/Pipeline/build-tooltip.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import BuildStatusDescription from '../../shared/BuildStatusDescription';
@@ -11,17 +12,17 @@ import { shortMessage, shortCommit } from '../../../lib/commits';
 
 class BuildTooltip extends React.PureComponent {
   static propTypes = {
-    build: React.PropTypes.shape({
-      commit: React.PropTypes.string,
-      createdBy: React.PropTypes.shape({
-        name: React.PropTypes.string.isRequired,
-        avatar: React.PropTypes.shape({
-          url: React.PropTypes.string
+    build: PropTypes.shape({
+      commit: PropTypes.string,
+      createdBy: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        avatar: PropTypes.shape({
+          url: PropTypes.string
         }).isRequired
       }),
-      message: React.PropTypes.string,
-      startedAt: React.PropTypes.string,
-      finishedAt: React.PropTypes.string
+      message: PropTypes.string,
+      startedAt: PropTypes.string,
+      finishedAt: PropTypes.string
     }).isRequired
   };
 

--- a/app/components/organization/Pipeline/graph.js
+++ b/app/components/organization/Pipeline/graph.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import moment from 'moment';
 import classNames from 'classnames';
@@ -29,18 +30,18 @@ const NOT_RUN_COLOR_HOVER = SKIPPED_COLOR_HOVER;
 
 class Graph extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      builds: React.PropTypes.shape({
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.shape({
-              state: React.PropTypes.string.isRequired,
-              url: React.PropTypes.string.isRequired,
-              startedAt: React.PropTypes.string,
-              finishedAt: React.PropTypes.string,
-              canceledAt: React.PropTypes.string,
-              scheduledAt: React.PropTypes.string
+    pipeline: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      builds: PropTypes.shape({
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.shape({
+              state: PropTypes.string.isRequired,
+              url: PropTypes.string.isRequired,
+              startedAt: PropTypes.string,
+              finishedAt: PropTypes.string,
+              canceledAt: PropTypes.string,
+              scheduledAt: PropTypes.string
             }).isRequired
           }).isRequired
         )

--- a/app/components/organization/Pipeline/index.js
+++ b/app/components/organization/Pipeline/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Favorite from '../../icons/Favorite';
@@ -16,21 +17,21 @@ import Graph from './graph';
 
 class Pipeline extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      name: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired,
-      description: React.PropTypes.string,
-      defaultBranch: React.PropTypes.string.isRequired,
-      favorite: React.PropTypes.bool.isRequired,
-      url: React.PropTypes.string.isRequired,
-      permissions: React.PropTypes.shape({
-        pipelineFavorite: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+    pipeline: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      defaultBranch: PropTypes.string.isRequired,
+      favorite: PropTypes.bool.isRequired,
+      url: PropTypes.string.isRequired,
+      permissions: PropTypes.shape({
+        pipelineFavorite: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired
       })
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/organization/Pipeline/status.js
+++ b/app/components/organization/Pipeline/status.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import AnchoredPopover from '../../shared/Popover/anchored';
@@ -8,14 +9,14 @@ import BuildTooltip from './build-tooltip';
 
 class Status extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      builds: React.PropTypes.shape({
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.shape({
-              state: React.PropTypes.string.isRequired,
-              url: React.PropTypes.string.isRequired
+    pipeline: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      builds: PropTypes.shape({
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.shape({
+              state: PropTypes.string.isRequired,
+              url: PropTypes.string.isRequired
             }).isRequired
           }).isRequired
         )

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import SectionLoader from '../shared/SectionLoader';
@@ -11,25 +12,25 @@ import Welcome from './Welcome';
 
 class OrganizationPipelines extends React.Component {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired,
-      pipelines: React.PropTypes.shape({
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.shape({
-              id: React.PropTypes.string.isRequired
+    organization: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      pipelines: PropTypes.shape({
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.shape({
+              id: PropTypes.string.isRequired
             }).isRequired
           }).isRequired
         )
       })
     }),
-    relay: React.PropTypes.object.isRequired,
-    team: React.PropTypes.string
+    relay: PropTypes.object.isRequired,
+    team: PropTypes.string
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/organization/SettingsMenu.js
+++ b/app/components/organization/SettingsMenu.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Menu from '../shared/Menu';
@@ -7,37 +8,37 @@ import permissions from '../../lib/permissions';
 
 class SettingsMenu extends React.Component {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired,
-      members: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired
+    organization: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      members: PropTypes.shape({
+        count: PropTypes.number.isRequired
       }),
-      invitations: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired
+      invitations: PropTypes.shape({
+        count: PropTypes.number.isRequired
       }),
-      teams: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired
+      teams: PropTypes.shape({
+        count: PropTypes.number.isRequired
       }),
-      permissions: React.PropTypes.shape({
-        organizationUpdate: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+      permissions: PropTypes.shape({
+        organizationUpdate: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired,
-        organizationInvitationCreate: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+        organizationInvitationCreate: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired,
-        teamAdmin: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+        teamAdmin: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired,
-        notificationServiceUpdate: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+        notificationServiceUpdate: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired,
-        organizationBillingUpdate: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+        organizationBillingUpdate: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired
       })
     }),
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   componentDidMount() {

--- a/app/components/organization/SettingsSection.js
+++ b/app/components/organization/SettingsSection.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import PageWithMenu from '../shared/PageWithMenu';
@@ -6,8 +7,8 @@ import SettingsMenu from './SettingsMenu';
 
 class SettingsSection extends React.Component {
   static propTypes = {
-    organization: React.PropTypes.object.isRequired,
-    children: React.PropTypes.node.isRequired
+    organization: PropTypes.object.isRequired,
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/organization/Show.js
+++ b/app/components/organization/Show.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -11,18 +12,18 @@ import Teams from './Teams';
 
 class OrganizationShow extends React.Component {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      name: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired
+    organization: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired
     }).isRequired,
-    relay: React.PropTypes.object.isRequired,
-    location: React.PropTypes.object.isRequired,
-    team: React.PropTypes.string
+    relay: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
+    team: PropTypes.string
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   componentDidMount() {

--- a/app/components/organization/Teams.js
+++ b/app/components/organization/Teams.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Dropdown from '../shared/Dropdown';
@@ -8,9 +9,9 @@ import Icon from '../shared/Icon';
 
 class Teams extends React.Component {
   static propTypes = {
-    selected: React.PropTypes.string,
-    organization: React.PropTypes.object.isRequired,
-    onTeamChange: React.PropTypes.func.isRequired
+    selected: PropTypes.string,
+    organization: PropTypes.object.isRequired,
+    onTeamChange: PropTypes.func.isRequired
   };
 
   render() {

--- a/app/components/organization/Welcome.js
+++ b/app/components/organization/Welcome.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import PipelineIcon from '../icons/Pipeline';
 
 class Welcome extends React.Component {
   static propTypes = {
-    organization: React.PropTypes.string.isRequired
+    organization: PropTypes.string.isRequired
   }
 
   render() {

--- a/app/components/pipeline/CreateBuildDialog.js
+++ b/app/components/pipeline/CreateBuildDialog.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Button from '../shared/Button';
@@ -9,9 +10,9 @@ import FormTextarea from '../shared/FormTextarea';
 
 class CreateBuildDialog extends React.PureComponent {
   static propTypes = {
-    pipeline: React.PropTypes.object.isRequired,
-    isOpen: React.PropTypes.bool,
-    onRequestClose: React.PropTypes.func
+    pipeline: PropTypes.object.isRequired,
+    isOpen: PropTypes.bool,
+    onRequestClose: PropTypes.func
   };
 
   state = {

--- a/app/components/pipeline/Header/builds.js
+++ b/app/components/pipeline/Header/builds.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import BuildStateSwitcher from '../../build/StateSwitcher';
@@ -7,9 +8,9 @@ import PusherStore from '../../../stores/PusherStore';
 
 class Builds extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.object.isRequired,
-    relay: React.PropTypes.object.isRequired,
-    buildState: React.PropTypes.string
+    pipeline: PropTypes.object.isRequired,
+    relay: PropTypes.object.isRequired,
+    buildState: PropTypes.string
   };
 
   componentDidMount() {

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Emojify from '../../shared/Emojify';
@@ -11,8 +12,8 @@ import permissions from '../../../lib/permissions';
 
 class Header extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.object.isRequired,
-    buildState: React.PropTypes.string
+    pipeline: PropTypes.object.isRequired,
+    buildState: PropTypes.string
   };
 
   state = {

--- a/app/components/pipeline/SettingsMenu.js
+++ b/app/components/pipeline/SettingsMenu.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Menu from '../shared/Menu';
@@ -8,7 +9,7 @@ import permissions from '../../lib/permissions';
 
 class SettingsMenu extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.object.isRequired
+    pipeline: PropTypes.object.isRequired
   };
 
   get provider() {

--- a/app/components/pipeline/SettingsSection.js
+++ b/app/components/pipeline/SettingsSection.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Header from './Header';
@@ -6,8 +7,8 @@ import SettingsMenu from './SettingsMenu';
 
 class SettingsSection extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.object.isRequired,
-    children: React.PropTypes.node.isRequired
+    pipeline: PropTypes.object.isRequired,
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/pipeline/Teams.js
+++ b/app/components/pipeline/Teams.js
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Chooser from '../shared/Chooser';
 import Emojify from '../shared/Emojify';
 
 class PipelineTeams extends React.Component {
   static propTypes = {
-    organization: React.PropTypes.object.isRequired,
-    selected: React.PropTypes.array.isRequired,
-    onTeamSelect: React.PropTypes.func.isRequired,
-    onTeamDeselect: React.PropTypes.func.isRequired
+    organization: PropTypes.object.isRequired,
+    selected: PropTypes.array.isRequired,
+    onTeamSelect: PropTypes.func.isRequired,
+    onTeamDeselect: PropTypes.func.isRequired
   };
 
   state = {

--- a/app/components/pipeline/schedules/Edit.js
+++ b/app/components/pipeline/schedules/Edit.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -9,29 +10,29 @@ import PageHeader from '../../shared/PageHeader';
 import Panel from '../../shared/Panel';
 import Button from '../../shared/Button';
 
-import Form from "./Form";
+import Form from './Form';
 
 class Edit extends React.Component {
   static propTypes = {
-    pipelineSchedule: React.PropTypes.shape({
-      uuid: React.PropTypes.string.isRequired,
-      cronline: React.PropTypes.string.isRequired,
-      label: React.PropTypes.string,
-      commit: React.PropTypes.string,
-      branch: React.PropTypes.string,
-      message: React.PropTypes.string,
-      env: React.PropTypes.arrayOf(React.PropTypes.string),
-      pipeline: React.PropTypes.shape({
-        slug: React.PropTypes.string.isRequired,
-        organization: React.PropTypes.shape({
-          slug: React.PropTypes.string.isRequired
+    pipelineSchedule: PropTypes.shape({
+      uuid: PropTypes.string.isRequired,
+      cronline: PropTypes.string.isRequired,
+      label: PropTypes.string,
+      commit: PropTypes.string,
+      branch: PropTypes.string,
+      message: PropTypes.string,
+      env: PropTypes.arrayOf(PropTypes.string),
+      pipeline: PropTypes.shape({
+        slug: PropTypes.string.isRequired,
+        organization: PropTypes.shape({
+          slug: PropTypes.string.isRequired
         }).isRequired
       }).isRequired
     }).isRequired
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/pipeline/schedules/Form.js
+++ b/app/components/pipeline/schedules/Form.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import FormTextField from '../../shared/FormTextField';
@@ -7,15 +8,15 @@ import ValidationErrors from '../../../lib/ValidationErrors';
 
 class Form extends React.Component {
   static propTypes = {
-    cronline: React.PropTypes.string,
-    label: React.PropTypes.string,
-    commit: React.PropTypes.string,
-    branch: React.PropTypes.string,
-    message: React.PropTypes.string,
-    env: React.PropTypes.string,
-    errors: React.PropTypes.array,
-    pipeline: React.PropTypes.shape({
-      defaultBranch: React.PropTypes.string.isRequired
+    cronline: PropTypes.string,
+    label: PropTypes.string,
+    commit: PropTypes.string,
+    branch: PropTypes.string,
+    message: PropTypes.string,
+    env: PropTypes.string,
+    errors: PropTypes.array,
+    pipeline: PropTypes.shape({
+      defaultBranch: PropTypes.string.isRequired
     }).isRequired
   };
 

--- a/app/components/pipeline/schedules/Index/index.js
+++ b/app/components/pipeline/schedules/Index/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -7,30 +8,30 @@ import Button from '../../../shared/Button';
 import permissions from '../../../../lib/permissions';
 import Emojify from '../../../shared/Emojify';
 
-import Row from "./row";
+import Row from './row';
 
 class Index extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      schedules: React.PropTypes.shape({
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.shape({
-              id: React.PropTypes.string.isRequired
+    pipeline: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      schedules: PropTypes.shape({
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.shape({
+              id: PropTypes.string.isRequired
             }).isRequired
           }).isRequired
         )
       }).isRequired,
-      permissions: React.PropTypes.shape({
-        pipelineScheduleCreate: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+      permissions: PropTypes.shape({
+        pipelineScheduleCreate: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired
       }).isRequired
     }).isRequired,
-    params: React.PropTypes.shape({
-      organization: React.PropTypes.string.isRequired,
-      pipeline: React.PropTypes.string.isRequired
+    params: PropTypes.shape({
+      organization: PropTypes.string.isRequired,
+      pipeline: PropTypes.string.isRequired
     }).isRequired
   };
 

--- a/app/components/pipeline/schedules/Index/row.js
+++ b/app/components/pipeline/schedules/Index/row.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Panel from '../../../shared/Panel';
@@ -6,16 +7,16 @@ import Emojify from '../../../shared/Emojify';
 
 class Row extends React.Component {
   static propTypes = {
-    pipelineSchedule: React.PropTypes.shape({
-      uuid: React.PropTypes.string.isRequired,
-      cronline: React.PropTypes.string.isRequired,
-      label: React.PropTypes.string,
-      commit: React.PropTypes.string,
-      branch: React.PropTypes.string,
-      pipeline: React.PropTypes.shape({
-        slug: React.PropTypes.string.isRequired,
-        organization: React.PropTypes.shape({
-          slug: React.PropTypes.string.isRequired
+    pipelineSchedule: PropTypes.shape({
+      uuid: PropTypes.string.isRequired,
+      cronline: PropTypes.string.isRequired,
+      label: PropTypes.string,
+      commit: PropTypes.string,
+      branch: PropTypes.string,
+      pipeline: PropTypes.shape({
+        slug: PropTypes.string.isRequired,
+        organization: PropTypes.shape({
+          slug: PropTypes.string.isRequired
         }).isRequired
       }).isRequired
     }).isRequired

--- a/app/components/pipeline/schedules/New.js
+++ b/app/components/pipeline/schedules/New.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -8,21 +9,21 @@ import GraphQLErrors from '../../../constants/GraphQLErrors';
 import Panel from '../../shared/Panel';
 import Button from '../../shared/Button';
 
-import Form from "./Form";
+import Form from './Form';
 
 class New extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired
+    pipeline: PropTypes.shape({
+      name: PropTypes.string.isRequired
     }).isRequired,
-    params: React.PropTypes.shape({
-      organization: React.PropTypes.string.isRequired,
-      pipeline: React.PropTypes.string.isRequired
+    params: PropTypes.shape({
+      organization: PropTypes.string.isRequired,
+      pipeline: PropTypes.string.isRequired
     }).isRequired
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/pipeline/schedules/Show/build.js
+++ b/app/components/pipeline/schedules/Show/build.js
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Panel from '../../../shared/Panel';
 
 class Build extends React.Component {
   static propTypes = {
-    build: React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      url: React.PropTypes.string.isRequired,
-      number: React.PropTypes.number.isRequired
+    build: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+      number: PropTypes.number.isRequired
     }).isRequired
   };
 

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -15,46 +16,46 @@ import Build from './build';
 
 class Show extends React.Component {
   static propTypes = {
-    pipelineSchedule: React.PropTypes.shape({
-      uuid: React.PropTypes.string.isRequired,
-      cronline: React.PropTypes.string.isRequired,
-      label: React.PropTypes.string,
-      commit: React.PropTypes.string,
-      branch: React.PropTypes.string,
-      message: React.PropTypes.string,
-      env: React.PropTypes.arrayOf(React.PropTypes.string),
-      nextBuildAt: React.PropTypes.string,
-      pipeline: React.PropTypes.shape({
-        slug: React.PropTypes.string.isRequired,
-        organization: React.PropTypes.shape({
-          slug: React.PropTypes.string.isRequired
+    pipelineSchedule: PropTypes.shape({
+      uuid: PropTypes.string.isRequired,
+      cronline: PropTypes.string.isRequired,
+      label: PropTypes.string,
+      commit: PropTypes.string,
+      branch: PropTypes.string,
+      message: PropTypes.string,
+      env: PropTypes.arrayOf(PropTypes.string),
+      nextBuildAt: PropTypes.string,
+      pipeline: PropTypes.shape({
+        slug: PropTypes.string.isRequired,
+        organization: PropTypes.shape({
+          slug: PropTypes.string.isRequired
         }).isRequired
       }).isRequired,
-      builds: React.PropTypes.shape({
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.shape({
-              id: React.PropTypes.string.isRequired
+      builds: PropTypes.shape({
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.shape({
+              id: PropTypes.string.isRequired
             }).isRequired
           }).isRequired
         )
       }).isRequired,
-      createdBy: React.PropTypes.shape({
-        name: React.PropTypes.string.isRequired
+      createdBy: PropTypes.shape({
+        name: PropTypes.string.isRequired
       }).isRequired,
-      permissions: React.PropTypes.shape({
-        pipelineScheduleUpdate: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+      permissions: PropTypes.shape({
+        pipelineScheduleUpdate: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired,
-        pipelineScheduleDelete: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+        pipelineScheduleDelete: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired
       }).isRequired
     }).isRequired
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/pipeline/teams/Index/index.js
+++ b/app/components/pipeline/teams/Index/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -15,30 +16,30 @@ import TeamSuggestion from '../../../team/Suggestion';
 
 class Index extends React.Component {
   static propTypes = {
-    pipeline: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      organization: React.PropTypes.shape({
-        teams: React.PropTypes.shape({
-          edges: React.PropTypes.arrayOf(
-            React.PropTypes.shape({
-              node: React.PropTypes.shape({
-                id: React.PropTypes.string.isRequired
+    pipeline: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      organization: PropTypes.shape({
+        teams: PropTypes.shape({
+          edges: PropTypes.arrayOf(
+            PropTypes.shape({
+              node: PropTypes.shape({
+                id: PropTypes.string.isRequired
               }).isRequired
             }).isRequired
           )
         })
       }),
-      teams: React.PropTypes.shape({
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.shape({
-              id: React.PropTypes.string.isRequired
+      teams: PropTypes.shape({
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.shape({
+              id: PropTypes.string.isRequired
             }).isRequired
           }).isRequired
         )
       }).isRequired
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   render() {

--- a/app/components/pipeline/teams/Index/row.js
+++ b/app/components/pipeline/teams/Index/row.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import { Link } from 'react-router';
 
@@ -17,31 +18,31 @@ import TeamPipelineDeleteMutation from '../../../../mutations/TeamPipelineDelete
 
 class Row extends React.Component {
   static propTypes = {
-    teamPipeline: React.PropTypes.shape({
-      team: React.PropTypes.shape({
-        name: React.PropTypes.string.isRequired,
-        slug: React.PropTypes.string.isRequired,
-        description: React.PropTypes.string,
-        members: React.PropTypes.shape({
-          count: React.PropTypes.number
+    teamPipeline: PropTypes.shape({
+      team: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        slug: PropTypes.string.isRequired,
+        description: PropTypes.string,
+        members: PropTypes.shape({
+          count: PropTypes.number
         }),
-        pipelines: React.PropTypes.shape({
-          count: React.PropTypes.number
+        pipelines: PropTypes.shape({
+          count: PropTypes.number
         })
       }).isRequired,
-      permissions: React.PropTypes.shape({
-        teamPipelineUpdate: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+      permissions: PropTypes.shape({
+        teamPipelineUpdate: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired,
-        teamPipelineDelete: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+        teamPipelineDelete: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired
       })
     }).isRequired,
-    organization: React.PropTypes.shape({
-      slug: React.PropTypes.string.isRequired
+    organization: PropTypes.shape({
+      slug: PropTypes.string.isRequired
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/shared/Autocomplete/Dialog/index.js
+++ b/app/components/shared/Autocomplete/Dialog/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Dialog from '../../Dialog';
 import SearchField from '../../SearchField';
@@ -7,14 +8,14 @@ import ErrorMessage from '../error-message';
 
 class AutocompleteDialog extends React.PureComponent {
   static propTypes = {
-    isOpen: React.PropTypes.bool.isRequired,
-    onRequestClose: React.PropTypes.func.isRequired,
-    width: React.PropTypes.number,
-    onSelect: React.PropTypes.func.isRequired,
-    onSearch: React.PropTypes.func.isRequired,
-    placeholder: React.PropTypes.string,
-    selectLabel: React.PropTypes.string,
-    items: React.PropTypes.array
+    isOpen: PropTypes.bool.isRequired,
+    onRequestClose: PropTypes.func.isRequired,
+    width: PropTypes.number,
+    onSelect: PropTypes.func.isRequired,
+    onSearch: PropTypes.func.isRequired,
+    placeholder: PropTypes.string,
+    selectLabel: PropTypes.string,
+    items: PropTypes.array
   };
 
   state = {

--- a/app/components/shared/Autocomplete/Dialog/suggestion.js
+++ b/app/components/shared/Autocomplete/Dialog/suggestion.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Button from '../../Button';
@@ -7,11 +8,11 @@ export default class Suggestion extends React.PureComponent {
   static displayName = "AutocompleteDialog.Suggestion";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    suggestion: React.PropTypes.object.isRequired,
-    onSelect: React.PropTypes.func.isRequired,
-    selectLabel: React.PropTypes.string.isRequired,
-    className: React.PropTypes.string
+    children: PropTypes.node.isRequired,
+    suggestion: PropTypes.object.isRequired,
+    onSelect: PropTypes.func.isRequired,
+    selectLabel: PropTypes.string.isRequired,
+    className: PropTypes.string
   };
 
   defaultProps = {

--- a/app/components/shared/Autocomplete/Field/index.js
+++ b/app/components/shared/Autocomplete/Field/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import SearchField from '../../SearchField';
 import Suggestion from './suggestion';
@@ -10,10 +11,10 @@ const KEYCODE_ENTER = 13;
 
 class AutocompleteField extends React.PureComponent {
   static propTypes = {
-    onSelect: React.PropTypes.func.isRequired,
-    onSearch: React.PropTypes.func.isRequired,
-    placeholder: React.PropTypes.string,
-    items: React.PropTypes.array
+    onSelect: PropTypes.func.isRequired,
+    onSearch: PropTypes.func.isRequired,
+    placeholder: PropTypes.string,
+    items: PropTypes.array
   };
 
   state = {

--- a/app/components/shared/Autocomplete/Field/suggestion.js
+++ b/app/components/shared/Autocomplete/Field/suggestion.js
@@ -1,20 +1,21 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 class Suggestion extends React.Component {
   static displayName = "AutocompleteField.Suggestion";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    selected: React.PropTypes.bool.isRequired,
-    suggestion: React.PropTypes.object.isRequired,
-    onMouseOver: React.PropTypes.func.isRequired,
-    onMouseDown: React.PropTypes.func.isRequired,
-    className: React.PropTypes.string
+    children: PropTypes.node.isRequired,
+    selected: PropTypes.bool.isRequired,
+    suggestion: PropTypes.object.isRequired,
+    onMouseOver: PropTypes.func.isRequired,
+    onMouseDown: PropTypes.func.isRequired,
+    className: PropTypes.string
   };
 
   static childContextTypes = {
-    autoCompletorSuggestion: React.PropTypes.object
+    autoCompletorSuggestion: PropTypes.object
   };
 
   // Pass suggestion information down to the children of this component so they

--- a/app/components/shared/Autocomplete/error-message.js
+++ b/app/components/shared/Autocomplete/error-message.js
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 export default class ErrorMessage extends React.PureComponent {
   static displayName = "Autocomplete.ErrorMessage";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    className: React.PropTypes.string
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
   };
 
   render() {

--- a/app/components/shared/Badge.js
+++ b/app/components/shared/Badge.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 class Badge extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-    className: React.PropTypes.string
+    children: PropTypes.node,
+    className: PropTypes.string
   };
 
   render() {

--- a/app/components/shared/BuildStatusDescription.js
+++ b/app/components/shared/BuildStatusDescription.js
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { minute } from 'metrick/duration';
 import { getDateString, getRelativeDateString } from '../../lib/date';
 import { buildStatus } from '../../lib/builds';
 
 class BuildStatusDescription extends React.PureComponent {
   static propTypes = {
-    build: React.PropTypes.object.isRequired,
-    updateFrequency: React.PropTypes.number.isRequired
+    build: PropTypes.object.isRequired,
+    updateFrequency: PropTypes.number.isRequired
   };
 
   static defaultProps = {

--- a/app/components/shared/Button.js
+++ b/app/components/shared/Button.js
@@ -1,5 +1,6 @@
-import React from "react";
-import classNames from "classnames";
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Link } from 'react-router';
 
 const NORMAL_THEMES = {
@@ -20,20 +21,20 @@ const OUTLINE_THEMES = {
 
 class Button extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-    className: React.PropTypes.string,
-    link: React.PropTypes.string,
-    href: React.PropTypes.string,
-    outline: React.PropTypes.bool,
-    style: React.PropTypes.object,
-    onClick: React.PropTypes.func,
-    tabIndex: React.PropTypes.number,
-    type: React.PropTypes.string,
-    loading: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.bool
+    children: PropTypes.node,
+    className: PropTypes.string,
+    link: PropTypes.string,
+    href: PropTypes.string,
+    outline: PropTypes.bool,
+    style: PropTypes.object,
+    onClick: PropTypes.func,
+    tabIndex: PropTypes.number,
+    type: PropTypes.string,
+    loading: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.bool
     ]),
-    theme: React.PropTypes.oneOf([
+    theme: PropTypes.oneOf([
       'default',
       'primary',
       'success',
@@ -48,7 +49,7 @@ class Button extends React.Component {
   };
 
   static contextTypes = {
-    router: React.PropTypes.object
+    router: PropTypes.object
   };
 
   render() {

--- a/app/components/shared/Chooser/index.js
+++ b/app/components/shared/Chooser/index.js
@@ -1,19 +1,20 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
-import Option from "./option";
-import SelectOption from "./select-option";
+import Option from './option';
+import SelectOption from './select-option';
 
 class Chooser extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    className: React.PropTypes.string,
-    multiple: React.PropTypes.bool,
-    selected: React.PropTypes.any,
-    onSelect: React.PropTypes.func.isRequired
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    multiple: PropTypes.bool,
+    selected: PropTypes.any,
+    onSelect: PropTypes.func.isRequired
   };
 
   static childContextTypes = {
-    chooser: React.PropTypes.object.isRequired
+    chooser: PropTypes.object.isRequired
   };
 
   getChildContext() {

--- a/app/components/shared/Chooser/option.js
+++ b/app/components/shared/Chooser/option.js
@@ -1,21 +1,22 @@
-import React from "react";
-import classNames from "classnames";
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 class Option extends React.Component {
   static displayName = "Chooser.Option";
 
   static propTypes = {
-    tag: React.PropTypes.string.isRequired,
-    children: React.PropTypes.node.isRequired,
-    className: React.PropTypes.string,
-    unselectedClassName: React.PropTypes.string,
-    selectedClassName: React.PropTypes.string,
-    value: React.PropTypes.any.isRequired,
-    data: React.PropTypes.any
+    tag: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    unselectedClassName: PropTypes.string,
+    selectedClassName: PropTypes.string,
+    value: PropTypes.any.isRequired,
+    data: PropTypes.any
   };
 
   static contextTypes = {
-    chooser: React.PropTypes.object.isRequired
+    chooser: PropTypes.object.isRequired
   };
 
   static defaultProps = {

--- a/app/components/shared/Chooser/select-option.js
+++ b/app/components/shared/Chooser/select-option.js
@@ -1,8 +1,9 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Spinner from '../../shared/Spinner';
 
-import Option from "./option";
+import Option from './option';
 
 function SelectOption(props) {
   return (
@@ -23,11 +24,11 @@ function SelectOption(props) {
 SelectOption.displayName = "Chooser.SelectOption";
 
 SelectOption.propTypes = {
-  value: React.PropTypes.string.isRequired,
-  label: React.PropTypes.string.isRequired,
-  description: React.PropTypes.string.isRequired,
-  saving: React.PropTypes.bool,
-  selected: React.PropTypes.bool
+  value: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  saving: PropTypes.bool,
+  selected: PropTypes.bool
 };
 
 function Icon(props) {
@@ -49,8 +50,8 @@ function Icon(props) {
 }
 
 Icon.propTypes = {
-  saving: React.PropTypes.bool.isRequired,
-  selected: React.PropTypes.bool.isRequired
+  saving: PropTypes.bool.isRequired,
+  selected: PropTypes.bool.isRequired
 };
 
 export default SelectOption;

--- a/app/components/shared/CollapsableArea.js
+++ b/app/components/shared/CollapsableArea.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { v4 as uuid } from 'uuid';
 
@@ -20,14 +21,14 @@ const RotatableIcon = styled(Icon)`
 // any focusable elements (such as text inputs) when the area is collapsed
 export default class CollapsableArea extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    collapsed: React.PropTypes.bool,
-    label: React.PropTypes.string.isRequired,
-    onToggle: React.PropTypes.func.isRequired,
+    children: PropTypes.node.isRequired,
+    collapsed: PropTypes.bool,
+    label: PropTypes.string.isRequired,
+    onToggle: PropTypes.func.isRequired,
     // TODO: maxHeight is a bit of a hack, and might break for responsive
     // pages. We could instead use JS to calculate the height, and remove this
     // property altogether.
-    maxHeight: React.PropTypes.number.isRequired
+    maxHeight: PropTypes.number.isRequired
   };
 
   constructor(props) {

--- a/app/components/shared/CollapsableFormField.js
+++ b/app/components/shared/CollapsableFormField.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 let _collapsableFormFieldCounter = 0;
@@ -8,9 +9,9 @@ let _collapsableFormFieldCounter = 0;
 // This should be replaced with something more akin to CollapsableArea
 class CollapsableFormField extends React.Component {
   static propTypes = {
-    label: React.PropTypes.string.isRequired,
-    collapsed: React.PropTypes.bool.isRequired,
-    children: React.PropTypes.node.isRequired
+    label: PropTypes.string.isRequired,
+    collapsed: PropTypes.bool.isRequired,
+    children: PropTypes.node.isRequired
   };
 
   state = {

--- a/app/components/shared/Dialog.js
+++ b/app/components/shared/Dialog.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import styled from 'styled-components';
 
@@ -80,11 +81,11 @@ DialogWrapper.defaultProps = {
 
 class Dialog extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-    closeable: React.PropTypes.bool,
-    isOpen: React.PropTypes.bool,
-    onRequestClose: React.PropTypes.func,
-    width: React.PropTypes.number
+    children: PropTypes.node,
+    closeable: PropTypes.bool,
+    isOpen: PropTypes.bool,
+    onRequestClose: PropTypes.func,
+    width: PropTypes.number
   };
 
   static defaultProps = {

--- a/app/components/shared/Dropdown.js
+++ b/app/components/shared/Dropdown.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import classNames from 'classnames';
 
@@ -6,12 +7,12 @@ import Popover, { calculateViewportOffsets } from './Popover';
 
 export default class Dropdown extends React.PureComponent {
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    width: React.PropTypes.number.isRequired,
-    className: React.PropTypes.string,
-    onToggle: React.PropTypes.func,
-    nibOffsetX: React.PropTypes.number.isRequired,
-    offsetY: React.PropTypes.number.isRequired
+    children: PropTypes.node.isRequired,
+    width: PropTypes.number.isRequired,
+    className: PropTypes.string,
+    onToggle: PropTypes.func,
+    nibOffsetX: PropTypes.number.isRequired,
+    offsetY: PropTypes.number.isRequired
   };
 
   static defaultProps = {

--- a/app/components/shared/Duration.js
+++ b/app/components/shared/Duration.js
@@ -1,25 +1,26 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { second } from 'metrick/duration';
 import { getDurationString } from '../../lib/date';
 
 class Duration extends React.PureComponent {
   static propTypes = {
-    from: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.instanceOf(Date)
+    from: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Date)
     ]),
-    to: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.instanceOf(Date)
+    to: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Date)
     ]),
-    className: React.PropTypes.string,
-    tabularNumerals: React.PropTypes.bool.isRequired,
-    format: React.PropTypes.oneOf(getDurationString.formats),
-    overrides: React.PropTypes.object,
-    updateFrequency: React.PropTypes.number
+    className: PropTypes.string,
+    tabularNumerals: PropTypes.bool.isRequired,
+    format: PropTypes.oneOf(getDurationString.formats),
+    overrides: PropTypes.object,
+    updateFrequency: PropTypes.number
   };
 
   static defaultProps = {

--- a/app/components/shared/Emojify.js
+++ b/app/components/shared/Emojify.js
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Emoji from '../../lib/Emoji';
 
 class Emojify extends React.PureComponent {
   static propTypes = {
-    text: React.PropTypes.string,
-    className: React.PropTypes.string,
-    style: React.PropTypes.object
+    text: PropTypes.string,
+    className: PropTypes.string,
+    style: PropTypes.object
   };
 
   render() {

--- a/app/components/shared/FormCheckbox.js
+++ b/app/components/shared/FormCheckbox.js
@@ -1,17 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import FormInputErrors from './FormInputErrors';
 
 export default class FormCheckbox extends React.PureComponent {
   static propTypes = {
-    label: React.PropTypes.node.isRequired,
-    name: React.PropTypes.string,
-    checked: React.PropTypes.bool,
-    help: React.PropTypes.node,
-    disabled: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
-    errors: React.PropTypes.array
+    label: PropTypes.node.isRequired,
+    name: PropTypes.string,
+    checked: PropTypes.bool,
+    help: PropTypes.node,
+    disabled: PropTypes.bool,
+    onChange: PropTypes.func,
+    errors: PropTypes.array
   };
 
   render() {

--- a/app/components/shared/FormInputErrors.js
+++ b/app/components/shared/FormInputErrors.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class FormInputErrors extends React.Component {
   static propTypes = {
-    errors: React.PropTypes.array.isRequired
+    errors: PropTypes.array.isRequired
   };
 
   render() {

--- a/app/components/shared/FormInputHelp.js
+++ b/app/components/shared/FormInputHelp.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class FormInputHelp extends React.Component {
   static propTypes = {
-    html: React.PropTypes.string.isRequired
+    html: PropTypes.string.isRequired
   };
 
   render() {

--- a/app/components/shared/FormInputLabel.js
+++ b/app/components/shared/FormInputLabel.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 class FormInputLabel extends React.PureComponent {
   static propTypes = {
-    label: React.PropTypes.node.isRequired,
-    children: React.PropTypes.node,
-    errors: React.PropTypes.bool
+    label: PropTypes.node.isRequired,
+    children: PropTypes.node,
+    errors: PropTypes.bool
   };
 
   render() {

--- a/app/components/shared/FormMarkdownEditorField.js
+++ b/app/components/shared/FormMarkdownEditorField.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import autosize from 'autosize';
 import MarkdownEditor from '../../lib/MarkdownEditor';
@@ -7,11 +8,11 @@ import Button from '../shared/Button';
 
 class FormMarkdownEdtiorField extends React.Component {
   static propTypes = {
-    id: React.PropTypes.string,
-    name: React.PropTypes.string,
-    value: React.PropTypes.string,
-    placeholder: React.PropTypes.string,
-    rows: React.PropTypes.number
+    id: PropTypes.string,
+    name: PropTypes.string,
+    value: PropTypes.string,
+    placeholder: PropTypes.string,
+    rows: PropTypes.number
   };
 
   state = {

--- a/app/components/shared/FormRadioGroup.js
+++ b/app/components/shared/FormRadioGroup.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import FormInputHelp from './FormInputHelp';
@@ -6,26 +7,26 @@ import FormInputErrors from './FormInputErrors';
 
 class FormRadioGroup extends React.Component {
   static propTypes = {
-    options: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        className: React.PropTypes.string,
-        label: React.PropTypes.string.isRequired,
-        help: React.PropTypes.string,
-        value: React.PropTypes.oneOfType([
-          React.PropTypes.bool,
-          React.PropTypes.string
+    options: PropTypes.arrayOf(
+      PropTypes.shape({
+        className: PropTypes.string,
+        label: PropTypes.string.isRequired,
+        help: PropTypes.string,
+        value: PropTypes.oneOfType([
+          PropTypes.bool,
+          PropTypes.string
         ]).isRequired
       })
     ).isRequired,
-    value: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string
+    value: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string
     ]),
-    label: React.PropTypes.string,
-    name: React.PropTypes.string,
-    className: React.PropTypes.string,
-    onChange: React.PropTypes.func,
-    errors: React.PropTypes.array
+    label: PropTypes.string,
+    name: PropTypes.string,
+    className: PropTypes.string,
+    onChange: PropTypes.func,
+    errors: PropTypes.array
   };
 
   inputs = []

--- a/app/components/shared/FormTextField.js
+++ b/app/components/shared/FormTextField.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import CollapsableFormField from './CollapsableFormField';
@@ -8,17 +9,17 @@ import FormInputLabel from './FormInputLabel';
 
 class FormTextField extends React.Component {
   static propTypes = {
-    label: React.PropTypes.string.isRequired,
-    className: React.PropTypes.string,
-    name: React.PropTypes.string,
-    value: React.PropTypes.string,
-    placeholder: React.PropTypes.string,
-    help: React.PropTypes.string,
-    spellCheck: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
-    collapsable: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-    required: React.PropTypes.bool
+    label: PropTypes.string.isRequired,
+    className: PropTypes.string,
+    name: PropTypes.string,
+    value: PropTypes.string,
+    placeholder: PropTypes.string,
+    help: PropTypes.string,
+    spellCheck: PropTypes.bool,
+    onChange: PropTypes.func,
+    collapsable: PropTypes.bool,
+    errors: PropTypes.array,
+    required: PropTypes.bool
   };
 
   static defaultProps = {

--- a/app/components/shared/FormTextarea.js
+++ b/app/components/shared/FormTextarea.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import autosize from 'autosize';
 
@@ -9,20 +10,20 @@ import FormInputLabel from './FormInputLabel';
 
 class FormTextarea extends React.Component {
   static propTypes = {
-    label: React.PropTypes.string.isRequired,
-    rows: React.PropTypes.number.isRequired,
-    name: React.PropTypes.string,
-    value: React.PropTypes.string,
-    placeholder: React.PropTypes.string,
-    help: React.PropTypes.string,
-    spellCheck: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
-    collapsable: React.PropTypes.bool,
-    resizable: React.PropTypes.string,
-    autoresize: React.PropTypes.bool,
-    className: React.PropTypes.string,
-    errors: React.PropTypes.array,
-    tabIndex: React.PropTypes.number
+    label: PropTypes.string.isRequired,
+    rows: PropTypes.number.isRequired,
+    name: PropTypes.string,
+    value: PropTypes.string,
+    placeholder: PropTypes.string,
+    help: PropTypes.string,
+    spellCheck: PropTypes.bool,
+    onChange: PropTypes.func,
+    collapsable: PropTypes.bool,
+    resizable: PropTypes.string,
+    autoresize: PropTypes.bool,
+    className: PropTypes.string,
+    errors: PropTypes.array,
+    tabIndex: PropTypes.number
   };
 
   static defaultProps = {

--- a/app/components/shared/FormYAMLEditorField.js
+++ b/app/components/shared/FormYAMLEditorField.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class FormYAMLEdtiorField extends React.Component {
   static propTypes = {
-    name: React.PropTypes.string,
-    value: React.PropTypes.string
+    name: PropTypes.string,
+    value: PropTypes.string
   };
 
   componentDidMount() {

--- a/app/components/shared/FriendlyTime.js
+++ b/app/components/shared/FriendlyTime.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { minute } from 'metrick/duration';
 import { getDateString, getRelativeDateString } from '../../lib/date';
 
 class FriendlyTime extends React.PureComponent {
   static propTypes = {
-    value: React.PropTypes.string.isRequired,
-    updateFrequency: React.PropTypes.number.isRequired,
-    capitalized: React.PropTypes.bool.isRequired,
-    seconds: React.PropTypes.bool.isRequired
+    value: PropTypes.string.isRequired,
+    updateFrequency: PropTypes.number.isRequired,
+    capitalized: PropTypes.bool.isRequired,
+    seconds: PropTypes.bool.isRequired
   };
 
   static defaultProps = {

--- a/app/components/shared/Icon/index.js
+++ b/app/components/shared/Icon/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import update from "react-addons-update";
+import PropTypes from 'prop-types';
+import update from 'react-addons-update';
 
 import Logger from '../../../lib/Logger';
 
@@ -42,10 +43,10 @@ function Icon(props) {
 }
 
 Icon.propTypes = {
-  icon: React.PropTypes.string.isRequired,
-  title: React.PropTypes.string,
-  className: React.PropTypes.string,
-  style: React.PropTypes.object
+  icon: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  className: PropTypes.string,
+  style: PropTypes.object
 };
 
 export default Icon;

--- a/app/components/shared/JobLink.js
+++ b/app/components/shared/JobLink.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import classNames from 'classnames';
 
@@ -6,19 +7,19 @@ import Emojify from './Emojify';
 
 class JobLink extends React.Component {
   static propTypes = {
-    job: React.PropTypes.shape({
-      label: React.PropTypes.string,
-      command: React.PropTypes.string,
-      url: React.PropTypes.string,
-      build: React.PropTypes.shape({
-        number: React.PropTypes.number,
-        pipeline: React.PropTypes.shape({
-          name: React.PropTypes.string
+    job: PropTypes.shape({
+      label: PropTypes.string,
+      command: PropTypes.string,
+      url: PropTypes.string,
+      build: PropTypes.shape({
+        number: PropTypes.number,
+        pipeline: PropTypes.shape({
+          name: PropTypes.string
         })
       })
     }),
-    className: React.PropTypes.string,
-    style: React.PropTypes.object
+    className: PropTypes.string,
+    style: PropTypes.object
   };
 
   render() {

--- a/app/components/shared/Menu/button.js
+++ b/app/components/shared/Menu/button.js
@@ -1,18 +1,19 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import Badge from "../Badge";
-import BaseButton from "../Button";
+import Badge from '../Badge';
+import BaseButton from '../Button';
 
 class Button extends React.Component {
   static displayName = "Menu.Button";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    badge: React.PropTypes.number,
-    href: React.PropTypes.string,
-    active: React.PropTypes.bool,
-    link: React.PropTypes.string
+    children: PropTypes.node.isRequired,
+    badge: PropTypes.number,
+    href: PropTypes.string,
+    active: PropTypes.bool,
+    link: PropTypes.string
   };
 
   render() {

--- a/app/components/shared/Menu/header.js
+++ b/app/components/shared/Menu/header.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class Header extends React.Component {
   static displayName = "Menu.Header";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/Menu/index.js
+++ b/app/components/shared/Menu/index.js
@@ -1,12 +1,13 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import Header from "./header";
-import Button from "./button";
+import Header from './header';
+import Button from './button';
 
 class Menu extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/PageHeader/button.js
+++ b/app/components/shared/PageHeader/button.js
@@ -1,12 +1,13 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
-import BaseButton from "../Button";
+import BaseButton from '../Button';
 
 class Button extends React.Component {
   static displayName = "PageHeader.Button";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/PageHeader/description.js
+++ b/app/components/shared/PageHeader/description.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class Description extends React.Component {
   static displayName = "PageHeader.Description";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/PageHeader/index.js
+++ b/app/components/shared/PageHeader/index.js
@@ -1,13 +1,14 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
-import Title from "./title";
-import Description from "./description";
-import Menu from "./menu";
-import Button from "./button";
+import Title from './title';
+import Description from './description';
+import Menu from './menu';
+import Button from './button';
 
 class PageHeader extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/PageHeader/menu.js
+++ b/app/components/shared/PageHeader/menu.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class Menu extends React.Component {
   static displayName = "PageHeader.Menu";
 
   static propTypes = {
-    children: React.PropTypes.node
+    children: PropTypes.node
   };
 
   render() {

--- a/app/components/shared/PageHeader/title.js
+++ b/app/components/shared/PageHeader/title.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class Title extends React.Component {
   static displayName = "PageHeader.Title";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/PageWithContainer.js
+++ b/app/components/shared/PageWithContainer.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class PageWithContainer extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/PageWithMenu.js
+++ b/app/components/shared/PageWithMenu.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class PageWithMenu extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/Panel/index.js
+++ b/app/components/shared/Panel/index.js
@@ -1,15 +1,16 @@
-import React from "react";
-import classNames from "classnames";
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-import IntroWithButton from "./intro-with-button";
-import Row from "./row";
-import RowActions from "./row-actions";
-import RowLink from "./row-link";
+import IntroWithButton from './intro-with-button';
+import Row from './row';
+import RowActions from './row-actions';
+import RowLink from './row-link';
 
 class Panel extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    className: React.PropTypes.string
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
   };
 
   render() {
@@ -56,8 +57,8 @@ Object.keys(SIMPLE_COMPONENTS).forEach((componentName) => {
 
   Component.displayName = `Panel.${componentName}`;
   Component.propTypes = {
-    children: React.PropTypes.node.isRequired,
-    className: React.PropTypes.string
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
   };
 
   Panel[componentName] = Component;

--- a/app/components/shared/Panel/intro-with-button.js
+++ b/app/components/shared/Panel/intro-with-button.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class IntroWithButton extends React.Component {
   static displayName = "Panel.IntroWithButton";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/Panel/row-actions.js
+++ b/app/components/shared/Panel/row-actions.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import shallowCompare from 'react-addons-shallow-compare';
 
@@ -6,8 +7,8 @@ export default class RowActions extends React.Component {
   static displayName = "Panel.RowActions";
 
   static propTypes = {
-    children: React.PropTypes.node,
-    className: React.PropTypes.string
+    children: PropTypes.node,
+    className: PropTypes.string
   };
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/app/components/shared/Panel/row-link.js
+++ b/app/components/shared/Panel/row-link.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 import Icon from '../../shared/Icon';
@@ -7,9 +8,9 @@ export default class RowLink extends React.PureComponent {
   static displayName = "Panel.RowLink";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    to: React.PropTypes.string,
-    href: React.PropTypes.string
+    children: PropTypes.node.isRequired,
+    to: PropTypes.string,
+    href: PropTypes.string
   };
 
   render() {

--- a/app/components/shared/Panel/row.js
+++ b/app/components/shared/Panel/row.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class Row extends React.Component {
   static displayName = "Panel.Row";
 
   static propTypes = {
-    children: React.PropTypes.node.isRequired
+    children: PropTypes.node.isRequired
   };
 
   render() {

--- a/app/components/shared/Popover/anchored.js
+++ b/app/components/shared/Popover/anchored.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Popover from '.';
@@ -6,12 +7,12 @@ import calculateViewportOffsets from './calculate-viewport-offsets';
 
 export default class AnchoredPopover extends React.PureComponent {
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    className: React.PropTypes.string,
-    nibOffsetX: React.PropTypes.number.isRequired,
-    position: React.PropTypes.oneOf(['relative', 'absolute']).isRequired,
-    style: React.PropTypes.object,
-    width: React.PropTypes.number.isRequired
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    nibOffsetX: PropTypes.number.isRequired,
+    position: PropTypes.oneOf(['relative', 'absolute']).isRequired,
+    style: PropTypes.object,
+    width: PropTypes.number.isRequired
   };
 
   static defaultProps = {

--- a/app/components/shared/Popover/index.js
+++ b/app/components/shared/Popover/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const NIB_WIDTH = 32;
@@ -22,13 +23,13 @@ Nib.defaultProps = {
 
 export default class Popover extends React.PureComponent {
   static propTypes = {
-    children: React.PropTypes.node.isRequired,
-    nibOffsetX: React.PropTypes.number.isRequired,
-    offsetX: React.PropTypes.number.isRequired,
-    offsetY: React.PropTypes.number.isRequired,
-    style: React.PropTypes.object.isRequired,
-    innerRef: React.PropTypes.func.isRequired,
-    width: React.PropTypes.number.isRequired
+    children: PropTypes.node.isRequired,
+    nibOffsetX: PropTypes.number.isRequired,
+    offsetX: PropTypes.number.isRequired,
+    offsetY: PropTypes.number.isRequired,
+    style: PropTypes.object.isRequired,
+    innerRef: PropTypes.func.isRequired,
+    width: PropTypes.number.isRequired
   };
 
   static defaultProps = {

--- a/app/components/shared/RevealButton.js
+++ b/app/components/shared/RevealButton.js
@@ -1,11 +1,12 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Button from './Button';
 
 class RevealButton extends React.Component {
   static propTypes = {
-    caption: React.PropTypes.node,
-    children: React.PropTypes.node
+    caption: PropTypes.node,
+    children: PropTypes.node
   };
 
   static defaultProps = {

--- a/app/components/shared/SearchField.js
+++ b/app/components/shared/SearchField.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Icon from './Icon';
@@ -6,13 +7,13 @@ import Spinner from './Spinner';
 
 export default class SearchField extends React.PureComponent {
   static propTypes = {
-    className: React.PropTypes.string,
-    onChange: React.PropTypes.func.isRequired,
-    onKeyDown: React.PropTypes.func,
-    onFocus: React.PropTypes.func,
-    onBlur: React.PropTypes.func,
-    placeholder: React.PropTypes.string.isRequired,
-    searching: React.PropTypes.bool.isRequired
+    className: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    onKeyDown: PropTypes.func,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+    placeholder: PropTypes.string.isRequired,
+    searching: PropTypes.bool.isRequired
   };
 
   defaultProps = {

--- a/app/components/shared/Spinner.js
+++ b/app/components/shared/Spinner.js
@@ -1,14 +1,15 @@
 import React from 'react';
-import update from "react-addons-update";
-import classNames from "classnames";
+import PropTypes from 'prop-types';
+import update from 'react-addons-update';
+import classNames from 'classnames';
 
 class Spinner extends React.Component {
   static propTypes = {
-    size: React.PropTypes.number,
-    className: React.PropTypes.string,
-    style: React.PropTypes.object,
-    color: React.PropTypes.bool,
-    fadeIn: React.PropTypes.bool
+    size: PropTypes.number,
+    className: PropTypes.string,
+    style: PropTypes.object,
+    color: PropTypes.bool,
+    fadeIn: PropTypes.bool
   };
 
   static defaultProps = {

--- a/app/components/shared/UserAvatar.js
+++ b/app/components/shared/UserAvatar.js
@@ -1,16 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 export default class UserAvatar extends React.Component {
   static propTypes = {
-    user: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      avatar: React.PropTypes.shape({
-        url: React.PropTypes.string.isRequired
+    user: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      avatar: PropTypes.shape({
+        url: PropTypes.string.isRequired
       })
     }).isRequired,
-    className: React.PropTypes.string,
-    style: React.PropTypes.object
+    className: PropTypes.string,
+    style: PropTypes.object
   };
 
   render() {

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -13,20 +14,20 @@ import FlashesStore from '../../stores/FlashesStore';
 
 class TeamEdit extends React.Component {
   static propTypes = {
-    team: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired,
-      description: React.PropTypes.string,
-      privacy: React.PropTypes.string.isRequired,
-      organization: React.PropTypes.shape({
-        name: React.PropTypes.string.isRequired,
-        slug: React.PropTypes.string.isRequired
+    team: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      privacy: PropTypes.string.isRequired,
+      organization: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        slug: PropTypes.string.isRequired
       }).isRequired
     }).isRequired
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/team/Form.js
+++ b/app/components/team/Form.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import FormTextField from '../shared/FormTextField';
 import FormRadioGroup from '../shared/FormRadioGroup';
@@ -7,11 +8,11 @@ import TeamPrivacyConstants from '../../constants/TeamPrivacyConstants';
 
 class TeamForm extends React.Component {
   static propTypes = {
-    name: React.PropTypes.string,
-    description: React.PropTypes.string,
-    privacy: React.PropTypes.oneOf(Object.keys(TeamPrivacyConstants)),
-    errors: React.PropTypes.array,
-    onChange: React.PropTypes.func
+    name: PropTypes.string,
+    description: PropTypes.string,
+    privacy: PropTypes.oneOf(Object.keys(TeamPrivacyConstants)),
+    errors: PropTypes.array,
+    onChange: PropTypes.func
   };
 
   componentDidMount() {

--- a/app/components/team/Index.js
+++ b/app/components/team/Index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import { second } from 'metrick/duration';
 import DocumentTitle from 'react-document-title';
@@ -27,23 +28,23 @@ const PAGE_SIZE = 10;
 
 class TeamIndex extends React.PureComponent {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired,
-      permissions: React.PropTypes.object.isRequired,
-      teams: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired,
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.object.isRequired
+    organization: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      permissions: PropTypes.object.isRequired,
+      teams: PropTypes.shape({
+        count: PropTypes.number.isRequired,
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.object.isRequired
           }).isRequired
         ).isRequired,
-        pageInfo: React.PropTypes.shape({
-          hasNextPage: React.PropTypes.bool.isRequired
+        pageInfo: PropTypes.shape({
+          hasNextPage: PropTypes.bool.isRequired
         }).isRequired
       })
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/team/Members/chooser.js
+++ b/app/components/team/Members/chooser.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import AutocompleteDialog from '../../shared/Autocomplete/Dialog';
@@ -17,18 +18,18 @@ class Chooser extends React.Component {
   static displayName = "Team.Members.Chooser";
 
   static propTypes = {
-    team: React.PropTypes.shape({
-      slug: React.PropTypes.string.isRequired,
-      organization: React.PropTypes.shape({
-        members: React.PropTypes.shape({
-          edges: React.PropTypes.array.isRequired
+    team: PropTypes.shape({
+      slug: PropTypes.string.isRequired,
+      organization: PropTypes.shape({
+        members: PropTypes.shape({
+          edges: PropTypes.array.isRequired
         })
       }),
-      permissions: React.PropTypes.shape({
-        teamMemberCreate: React.PropTypes.object.isRequired
+      permissions: PropTypes.shape({
+        teamMemberCreate: PropTypes.object.isRequired
       }).isRequired
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/team/Members/index.js
+++ b/app/components/team/Members/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import { second } from 'metrick/duration';
 
@@ -21,16 +22,16 @@ class Members extends React.Component {
   static displayName = "Team.Members";
 
   static propTypes = {
-    team: React.PropTypes.shape({
-      members: React.PropTypes.shape({
-        pageInfo: React.PropTypes.shape({
-          hasNextPage: React.PropTypes.bool.isRequired
+    team: PropTypes.shape({
+      members: PropTypes.shape({
+        pageInfo: PropTypes.shape({
+          hasNextPage: PropTypes.bool.isRequired
         }).isRequired,
-        edges: React.PropTypes.array.isRequired
+        edges: PropTypes.array.isRequired
       }).isRequired
     }).isRequired,
-    relay: React.PropTypes.object.isRequired,
-    className: React.PropTypes.string
+    relay: PropTypes.object.isRequired,
+    className: PropTypes.string
   };
 
   state = {

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Chooser from '../../shared/Chooser';
 import Dropdown from '../../shared/Dropdown';
@@ -9,11 +10,11 @@ export default class MemberRole extends React.PureComponent {
   static displayName = "Team.Pipelines.Role";
 
   static propTypes = {
-    teamMember: React.PropTypes.shape({
-      role: React.PropTypes.string.isRequired
+    teamMember: PropTypes.shape({
+      role: PropTypes.string.isRequired
     }).isRequired,
-    onRoleChange: React.PropTypes.func.isRequired,
-    savingNewRole: React.PropTypes.string
+    onRoleChange: PropTypes.func.isRequired,
+    savingNewRole: PropTypes.string
   };
 
   render() {

--- a/app/components/team/Members/row.js
+++ b/app/components/team/Members/row.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Panel from '../../shared/Panel';
 import Button from '../../shared/Button';
@@ -14,21 +15,21 @@ export default class Row extends React.PureComponent {
   static displayName = "Team.Members.Row";
 
   static propTypes = {
-    teamMember: React.PropTypes.shape({
-      user: React.PropTypes.object.isRequired,
-      role: React.PropTypes.string.isRequired,
-      permissions: React.PropTypes.shape({
-        teamMemberUpdate: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+    teamMember: PropTypes.shape({
+      user: PropTypes.object.isRequired,
+      role: PropTypes.string.isRequired,
+      permissions: PropTypes.shape({
+        teamMemberUpdate: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired,
-        teamMemberDelete: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+        teamMemberDelete: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired
       })
     }).isRequired,
-    onRemoveClick: React.PropTypes.func.isRequired,
-    onRoleChange: React.PropTypes.func.isRequired,
-    relay: React.PropTypes.object.isRequired
+    onRemoveClick: PropTypes.func.isRequired,
+    onRoleChange: PropTypes.func.isRequired,
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/team/Members/user.js
+++ b/app/components/team/Members/user.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import UserAvatar from '../../shared/UserAvatar';
 
@@ -6,11 +7,11 @@ export default class User extends React.PureComponent {
   static displayName = "Team.Members.User";
 
   static propTypes = {
-    user: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      email: React.PropTypes.string.isRequired,
-      avatar: React.PropTypes.shape({
-        url: React.PropTypes.string.isRequired
+    user: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      email: PropTypes.string.isRequired,
+      avatar: PropTypes.shape({
+        url: PropTypes.string.isRequired
       }).isRequired
     }).isRequired
   };

--- a/app/components/team/New.js
+++ b/app/components/team/New.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -13,14 +14,14 @@ import TeamPrivacyConstants from '../../constants/TeamPrivacyConstants';
 
 class TeamNew extends React.Component {
   static propTypes = {
-    organization: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired
+    organization: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired
     }).isRequired
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/team/Pipelines/access-level.js
+++ b/app/components/team/Pipelines/access-level.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Chooser from '../../shared/Chooser';
 import Dropdown from '../../shared/Dropdown';
@@ -11,11 +12,11 @@ export default class AccessLevel extends React.PureComponent {
   static displayName = "Team.Pipelines.AccessLevel";
 
   static propTypes = {
-    teamPipeline: React.PropTypes.shape({
-      accessLevel: React.PropTypes.string.isRequired
+    teamPipeline: PropTypes.shape({
+      accessLevel: PropTypes.string.isRequired
     }).isRequired,
-    onAccessLevelChange: React.PropTypes.func.isRequired,
-    saving: React.PropTypes.string
+    onAccessLevelChange: PropTypes.func.isRequired,
+    saving: PropTypes.string
   };
 
   render() {

--- a/app/components/team/Pipelines/chooser.js
+++ b/app/components/team/Pipelines/chooser.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import AutocompleteDialog from '../../shared/Autocomplete/Dialog';
@@ -15,18 +16,18 @@ class Chooser extends React.Component {
   static displayName = "Team.Pipelines.Chooser";
 
   static propTypes = {
-    team: React.PropTypes.shape({
-      slug: React.PropTypes.string.isRequired,
-      organization: React.PropTypes.shape({
-        pipelines: React.PropTypes.shape({
-          edges: React.PropTypes.array.isRequired
+    team: PropTypes.shape({
+      slug: PropTypes.string.isRequired,
+      organization: PropTypes.shape({
+        pipelines: PropTypes.shape({
+          edges: PropTypes.array.isRequired
         })
       }),
-      permissions: React.PropTypes.shape({
-        teamPipelineCreate: React.PropTypes.object.isRequired
+      permissions: PropTypes.shape({
+        teamPipelineCreate: PropTypes.object.isRequired
       }).isRequired
     }).isRequired,
-    relay: React.PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/team/Pipelines/index.js
+++ b/app/components/team/Pipelines/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import { second } from 'metrick/duration';
 
@@ -23,16 +24,16 @@ class Pipelines extends React.Component {
   static displayName = "Team.Pipelines";
 
   static propTypes = {
-    team: React.PropTypes.shape({
-      pipelines: React.PropTypes.shape({
-        pageInfo: React.PropTypes.shape({
-          hasNextPage: React.PropTypes.bool.isRequired
+    team: PropTypes.shape({
+      pipelines: PropTypes.shape({
+        pageInfo: PropTypes.shape({
+          hasNextPage: PropTypes.bool.isRequired
         }).isRequired,
-        edges: React.PropTypes.array.isRequired
+        edges: PropTypes.array.isRequired
       }).isRequired
     }).isRequired,
-    relay: React.PropTypes.object.isRequired,
-    className: React.PropTypes.string
+    relay: PropTypes.object.isRequired,
+    className: PropTypes.string
   };
 
   state = {

--- a/app/components/team/Pipelines/pipeline.js
+++ b/app/components/team/Pipelines/pipeline.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class Pipeline extends React.PureComponent {
   static displayName = "Team.Pipelines.Pipeline";
 
   static propTypes = {
-    pipeline: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      repository: React.PropTypes.shape({
-        url: React.PropTypes.string.isRequired
+    pipeline: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      repository: PropTypes.shape({
+        url: PropTypes.string.isRequired
       }).isRequired
     }).isRequired
   };

--- a/app/components/team/Pipelines/row.js
+++ b/app/components/team/Pipelines/row.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Panel from '../../shared/Panel';
 import Button from '../../shared/Button';
@@ -14,18 +15,18 @@ export default class Row extends React.PureComponent {
   static displayName = "Team.Pipelines.Row";
 
   static propTypes = {
-    teamPipeline: React.PropTypes.shape({
-      accessLevel: React.PropTypes.string,
-      pipeline: React.PropTypes.object.isRequired,
-      permissions: React.PropTypes.shape({
-        teamPipelineDelete: React.PropTypes.shape({
-          allowed: React.PropTypes.bool.isRequired
+    teamPipeline: PropTypes.shape({
+      accessLevel: PropTypes.string,
+      pipeline: PropTypes.object.isRequired,
+      permissions: PropTypes.shape({
+        teamPipelineDelete: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
         }).isRequired
       })
     }).isRequired,
-    onAccessLevelChange: React.PropTypes.func.isRequired,
-    onRemoveClick: React.PropTypes.func.isRequired,
-    relay: React.PropTypes.object.isRequired
+    onAccessLevelChange: PropTypes.func.isRequired,
+    onRemoveClick: PropTypes.func.isRequired,
+    relay: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/team/Row.js
+++ b/app/components/team/Row.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import { formatNumber } from '../../lib/number';
@@ -12,25 +13,25 @@ const avatarSize = 30;
 
 class TeamRow extends React.PureComponent {
   static propTypes = {
-    team: React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      name: React.PropTypes.string.isRequired,
-      description: React.PropTypes.string,
-      slug: React.PropTypes.string.isRequired,
-      privacy: React.PropTypes.string.isRequired,
-      organization: React.PropTypes.shape({
-        slug: React.PropTypes.string.isRequired
+    team: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      slug: PropTypes.string.isRequired,
+      privacy: PropTypes.string.isRequired,
+      organization: PropTypes.shape({
+        slug: PropTypes.string.isRequired
       }).isRequired,
-      members: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired,
-        edges: React.PropTypes.arrayOf(
-          React.PropTypes.shape({
-            node: React.PropTypes.object.isRequired
+      members: PropTypes.shape({
+        count: PropTypes.number.isRequired,
+        edges: PropTypes.arrayOf(
+          PropTypes.shape({
+            node: PropTypes.object.isRequired
           }).isRequired
         ).isRequired
       }).isRequired,
-      pipelines: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired
+      pipelines: PropTypes.shape({
+        count: PropTypes.number.isRequired
       }).isRequired
     }).isRequired
   };

--- a/app/components/team/Show.js
+++ b/app/components/team/Show.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import DocumentTitle from 'react-document-title';
 
@@ -14,25 +15,25 @@ import TeamDeleteMutation from '../../mutations/TeamDelete';
 
 class TeamShow extends React.Component {
   static propTypes = {
-    teamSlug: React.PropTypes.string.isRequired,
-    team: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      description: React.PropTypes.string,
-      slug: React.PropTypes.string.isRequired,
-      privacy: React.PropTypes.string.isRequired,
-      organization: React.PropTypes.shape({
-        name: React.PropTypes.string.isRequired,
-        slug: React.PropTypes.string.isRequired
+    teamSlug: PropTypes.string.isRequired,
+    team: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      slug: PropTypes.string.isRequired,
+      privacy: PropTypes.string.isRequired,
+      organization: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        slug: PropTypes.string.isRequired
       }).isRequired,
-      permissions: React.PropTypes.shape({
-        teamUpdate: React.PropTypes.object.isRequired,
-        teamDelete: React.PropTypes.object.isRequired
+      permissions: PropTypes.shape({
+        teamUpdate: PropTypes.object.isRequired,
+        teamDelete: PropTypes.object.isRequired
       }).isRequired
     })
   };
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/components/team/Suggestion.js
+++ b/app/components/team/Suggestion.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import classNames from 'classnames';
 
@@ -6,14 +7,14 @@ import Emojify from '../shared/Emojify';
 
 class TeamSuggestion extends React.PureComponent {
   static propTypes = {
-    team: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      description: React.PropTypes.string
+    team: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string
     }).isRequired
   };
 
   static contextTypes = {
-    autoCompletorSuggestion: React.PropTypes.object
+    autoCompletorSuggestion: PropTypes.object
   };
 
   render() {

--- a/app/components/user/BuildCountsBreakdown.js
+++ b/app/components/user/BuildCountsBreakdown.js
@@ -1,22 +1,23 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import PusherStore from '../../stores/PusherStore';
 import StateSwitcher from '../build/StateSwitcher';
 
 class BuildCountsBreakdown extends React.Component {
   static propTypes = {
-    viewer: React.PropTypes.shape({
-      builds: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired
+    viewer: PropTypes.shape({
+      builds: PropTypes.shape({
+        count: PropTypes.number.isRequired
       }),
-      scheduledBuilds: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired
+      scheduledBuilds: PropTypes.shape({
+        count: PropTypes.number.isRequired
       }),
-      runningBuilds: React.PropTypes.shape({
-        count: React.PropTypes.number.isRequired
+      runningBuilds: PropTypes.shape({
+        count: PropTypes.number.isRequired
       })
     }),
-    state: React.PropTypes.string
+    state: PropTypes.string
   };
 
   state = {

--- a/app/components/user/NewChangelogsBadge.js
+++ b/app/components/user/NewChangelogsBadge.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import classNames from 'classnames';
@@ -7,12 +8,12 @@ import PusherStore from '../../stores/PusherStore';
 
 class NewChangelogsBadge extends React.PureComponent {
   static propTypes = {
-    className: React.PropTypes.string,
-    relay: React.PropTypes.object.isRequired,
-    style: React.PropTypes.object,
-    viewer: React.PropTypes.shape({
-      unreadChangelogs: React.PropTypes.shape({
-        count: React.PropTypes.number
+    className: PropTypes.string,
+    relay: PropTypes.object.isRequired,
+    style: PropTypes.object,
+    viewer: PropTypes.shape({
+      unreadChangelogs: PropTypes.shape({
+        count: PropTypes.number
       })
     })
   };

--- a/app/components/user/SettingsMenu.js
+++ b/app/components/user/SettingsMenu.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Menu from '../shared/Menu';
 import Icon from '../shared/Icon';
 
 class SettingsMenu extends React.Component {
   static propTypes = {
-    viewer: React.PropTypes.shape({
-      organizations: React.PropTypes.shape({
-        edges: React.PropTypes.array
+    viewer: PropTypes.shape({
+      organizations: PropTypes.shape({
+        edges: PropTypes.array
       }).isRequired
     }).isRequired
   };

--- a/app/css/style-guide/index.js
+++ b/app/css/style-guide/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Typography from './typography';
 
@@ -6,7 +7,7 @@ const Section = function(props) {
   return <div className="my4">{props.children}</div>;
 };
 Section.propTypes = {
-  children: React.PropTypes.node
+  children: PropTypes.node
 };
 
 // Useful when authoring our base CSS styles

--- a/app/css/style-guide/typography.js
+++ b/app/css/style-guide/typography.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const Example = function(props) {
   return <div className="my3 border-left border-gray pl4 py2">{props.children}</div>;
 };
-Example.propTypes = { children: React.PropTypes.node };
+Example.propTypes = { children: PropTypes.node };
 
 const Section = function(props) {
   return (
@@ -14,7 +15,7 @@ const Section = function(props) {
     </div>
   );
 };
-Section.propTypes = { title: React.PropTypes.string, children: React.PropTypes.node };
+Section.propTypes = { title: PropTypes.string, children: PropTypes.node };
 
 export default class Typography extends React.PureComponent {
   render() {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "metrick": "^0.2.0",
     "moment": "^2.15.0",
     "object-assign": "^4.1.0",
+    "prop-types": "^15.5.8",
     "pusher-js": "^4.0.0",
     "query-string": "^4.2.3",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-addons-pure-render-mixin": "^15.3.2",
     "react-addons-shallow-compare": "^15.3.2",
     "react-addons-update": "^15.3.2",
-    "react-confetti": "^1.1.2",
+    "react-confetti": "^1.1.4",
     "react-document-title": "^2.0.2",
     "react-dom": "^15.3.2",
     "react-relay": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6062,9 +6062,9 @@ react-addons-update@^15.3.2:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react-confetti@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-confetti/-/react-confetti-1.1.2.tgz#571d9bbc490c061927c94c2cecc6313cd06c0b38"
+react-confetti@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/react-confetti/-/react-confetti-1.1.4.tgz#9659f9091dea5b46da30456372fe2f43935a6c88"
 
 react-deep-force-update@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3380,9 +3380,9 @@ html-entities@^1.2.0:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
-"htmltojsx@git+https://github.com/reactjs/react-magic.git#e63dabeefb87d4ce1e74ac2ddb73b0164c344219":
+"htmltojsx@https://github.com/reactjs/react-magic#e63dabeefb87d4ce1e74ac2ddb73b0164c344219":
   version "0.2.6-dev"
-  resolved "git+https://github.com/reactjs/react-magic.git#e63dabeefb87d4ce1e74ac2ddb73b0164c344219"
+  resolved "https://github.com/reactjs/react-magic#e63dabeefb87d4ce1e74ac2ddb73b0164c344219"
   dependencies:
     jsdom-no-contextify "~3.1.0"
     react "~0.14.6"
@@ -5911,7 +5911,7 @@ promise@^7.0.3, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:


### PR DESCRIPTION
This fixes a warning about using it via `React.PropTypes` which was added in the newer versions of React.