### PR TITLE
Fix long menu items being cut-off on small screens

### DIFF
--- a/app/components/shared/Menu/button.js
+++ b/app/components/shared/Menu/button.js
@@ -24,7 +24,7 @@ class Button extends React.Component {
         link={this.props.link}
       >
         <div className="flex">
-          <div className="flex-auto truncate">{this.props.children}</div>
+          <div className="flex-auto truncate flex items-center">{this.props.children}</div>
           <div className="flex-none">{this._renderBadge()}</div>
         </div>
       </BaseButton>

--- a/app/components/shared/Menu/button.js
+++ b/app/components/shared/Menu/button.js
@@ -24,7 +24,7 @@ class Button extends React.Component {
         link={this.props.link}
       >
         <div className="flex">
-          <div className="flex-auto">{this.props.children}</div>
+          <div className="flex-auto truncate">{this.props.children}</div>
           <div className="flex-none">{this._renderBadge()}</div>
         </div>
       </BaseButton>

--- a/app/components/shared/Menu/button.js
+++ b/app/components/shared/Menu/button.js
@@ -18,7 +18,7 @@ class Button extends React.Component {
 
   render() {
     return (
-      <BaseButton className={classNames(`block hover-lime focus-lime truncate`, { "lime": this._isActive() })}
+      <BaseButton className={classNames(`block hover-lime focus-lime`, { "lime": this._isActive() })}
         theme={false}
         href={this.props.href}
         link={this.props.link}


### PR DESCRIPTION
Fixes:

<img width="246" alt="before" src="https://cloud.githubusercontent.com/assets/153/25729817/3dc4866e-317b-11e7-8a84-5808c7df22bc.png">

To look like:

<img width="219" alt="after" src="https://cloud.githubusercontent.com/assets/153/25729818/3f5de376-317b-11e7-84a9-ff9ccf1a6e6c.png">