### PR TITLE
Make Panel.Header use a h2

### DIFF
--- a/app/components/shared/Panel/header.js
+++ b/app/components/shared/Panel/header.js
@@ -1,0 +1,18 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+
+export default class Header extends PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
+  };
+
+  render() {
+    return (
+      <h2 className={classNames('h4 m0 bg-silver py2 px3 semi-bold', this.props.className)}>
+        {this.props.children}
+      </h2>
+    );
+  }
+}

--- a/app/components/shared/Panel/index.js
+++ b/app/components/shared/Panel/index.js
@@ -6,6 +6,7 @@ import IntroWithButton from './intro-with-button';
 import Row from './row';
 import RowActions from './row-actions';
 import RowLink from './row-link';
+import Header from './header';
 
 class Panel extends React.Component {
   static propTypes = {
@@ -39,9 +40,9 @@ Panel.IntroWithButton = IntroWithButton;
 Panel.Row = Row;
 Panel.RowActions = RowActions;
 Panel.RowLink = RowLink;
+Panel.Header = Header;
 
 const SIMPLE_COMPONENTS = {
-  Header: 'bg-silver py2 px3 semi-bold',
   Footer: 'py2 px3',
   Section: 'm3'
 };


### PR DESCRIPTION
In general it's good to use semantic tags for accessibility, but not for styling, so let's use a h2 here for panel headers.