### PR TITLE
Use the mutation API directly in the Team Pipeline Chooser dialog

### DIFF
--- a/app/components/team/Pipelines/chooser.js
+++ b/app/components/team/Pipelines/chooser.js
@@ -15,6 +15,7 @@ class Chooser extends React.Component {
 
   static propTypes = {
     team: PropTypes.shape({
+      id: PropTypes.string.isRequired,
       slug: PropTypes.string.isRequired,
       organization: PropTypes.shape({
         pipelines: PropTypes.shape({
@@ -127,9 +128,9 @@ class Chooser extends React.Component {
 
     const variables = {
       input: {
-	teamID: this.props.team.id,
-	pipelineID: pipeline.id
-      },
+        teamID: this.props.team.id,
+        pipelineID: pipeline.id
+      }
     };
 
     const mutation = new Relay.GraphQLMutation(query, variables, null, Relay.Store, {

--- a/app/components/team/Pipelines/chooser.js
+++ b/app/components/team/Pipelines/chooser.js
@@ -8,8 +8,6 @@ import permissions from '../../../lib/permissions';
 
 import FlashesStore from '../../../stores/FlashesStore';
 
-import TeamPipelineCreateMutation from '../../../mutations/TeamPipelineCreate';
-
 import Pipeline from './pipeline';
 
 class Chooser extends React.Component {
@@ -27,7 +25,8 @@ class Chooser extends React.Component {
         teamPipelineCreate: PropTypes.object.isRequired
       }).isRequired
     }).isRequired,
-    relay: PropTypes.object.isRequired
+    relay: PropTypes.object.isRequired,
+    onChoose: PropTypes.func.isRequired
   };
 
   state = {
@@ -116,10 +115,33 @@ class Chooser extends React.Component {
     this._autoCompletor.clear();
     this.props.relay.setVariables({ pipelineAddSearch: '' });
 
-    Relay.Store.commitUpdate(new TeamPipelineCreateMutation({
-      team: this.props.team,
-      pipeline: pipeline
-    }), { onFailure: this.handleMutationFailure });
+    const query = Relay.QL`mutation TeamPipelineCreateMutation {
+      teamPipelineCreate(input: $input) {
+        clientMutationId
+        pipeline {
+          id
+          name
+        }
+      }
+    }`;
+
+    const variables = {
+      input: {
+	teamID: this.props.team.id,
+	pipelineID: pipeline.id
+      },
+    };
+
+    const mutation = new Relay.GraphQLMutation(query, variables, null, Relay.Store, {
+      onFailure: this.handleMutationFailure,
+      onSuccess: this.handleMutationSuccess
+    });
+
+    mutation.commit();
+  };
+
+  handleMutationSuccess = (response) => {
+    this.props.onChoose(response.teamPipelineCreate.pipeline);
   };
 
   handleMutationFailure = (transaction) => {
@@ -137,8 +159,8 @@ export default Relay.createContainer(Chooser, {
   fragments: {
     team: () => Relay.QL`
       fragment on Team {
+        id
         slug
-        ${TeamPipelineCreateMutation.getFragment('team')}
 
         organization {
           pipelines(search: $pipelineAddSearch, first: 10, order: RELEVANCE, team: $teamSelector) @include (if: $isMounted) {
@@ -149,7 +171,6 @@ export default Relay.createContainer(Chooser, {
                 repository {
                   url
                 }
-                ${TeamPipelineCreateMutation.getFragment('pipeline')}
               }
             }
           }

--- a/app/components/team/Pipelines/index.js
+++ b/app/components/team/Pipelines/index.js
@@ -26,6 +26,9 @@ class Pipelines extends React.Component {
 
   static propTypes = {
     team: PropTypes.shape({
+      allPipelines: PropTypes.shape({
+        count: PropTypes.number.isRequired
+      }).isRequired,
       pipelines: PropTypes.shape({
         count: PropTypes.number.isRequired,
         pageInfo: PropTypes.shape({
@@ -48,7 +51,7 @@ class Pipelines extends React.Component {
       <div>
         <div className="flex items-center">
           <h2 className="h2 flex-auto">Pipelines {this.renderPipelineCount()}</h2>
-          <Chooser team={this.props.team} />
+          <Chooser team={this.props.team} onChoose={this.handleTeamPipelineChoose} />
         </div>
         <Panel className={this.props.className}>
           {this.renderPipelineSearch()}
@@ -66,7 +69,7 @@ class Pipelines extends React.Component {
     }
 
     return (
-      <Badge>{formatNumber(this.props.team.pipelines.count)}</Badge>
+      <Badge>{formatNumber(this.props.team.allPipelines.count)}</Badge>
     );
   }
 
@@ -146,6 +149,10 @@ class Pipelines extends React.Component {
     );
   }
 
+  handleTeamPipelineChoose = (pipeline) => {
+    this.props.relay.forceFetch();
+  };
+
   handlePipelineSearch = (pipelineSearch) => {
     this.setState({ searchingPipelines: true });
 
@@ -219,6 +226,10 @@ export default Relay.createContainer(Pipelines, {
     team: () => Relay.QL`
       fragment on Team {
         ${Chooser.getFragment('team')}
+
+        allPipelines: pipelines {
+          count
+        }
 
         pipelines(first: $pageSize, search: $pipelineSearch, order: NAME) {
           count

--- a/app/components/team/Pipelines/index.js
+++ b/app/components/team/Pipelines/index.js
@@ -149,7 +149,7 @@ class Pipelines extends React.Component {
     );
   }
 
-  handleTeamPipelineChoose = (pipeline) => {
+  handleTeamPipelineChoose = () => {
     this.props.relay.forceFetch();
   };
 


### PR DESCRIPTION
Relay.Mutation does totes weird things when you use the autocomplete on the team show a bunch. When ever you search for a pipeline, it internally creates a new "relay connection" it's cache. If you search for 5 different things, it'll create 5 different cache entires.

Now when you add a new pipeline a team, Relay will try to refresh those 5 relay connections, which results in invalid mutations.

This change bypasses the auto-magic Relay mutation gear and just use the underlying API which doesn't do auto-refreshing of cache connection blah blah stuff and things.