### PR TITLE
Bolder schedules icon

### DIFF
--- a/app/components/shared/Icon/schedules.svg
+++ b/app/components/shared/Icon/schedules.svg
@@ -1,1 +1,1 @@
-<polyline points="10 6 10 10 13 12" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:1.5px"/><path d="M10,4a6,6,0,1,1-6,6,6.0068,6.0068,0,0,1,6-6m0-3a9,9,0,1,0,9,9,9,9,0,0,0-9-9h0Z"/>
+<polyline points="10 6 10 10 13 12" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:2px"/><path d="M10,4a6,6,0,1,1-6,6,6.0068,6.0068,0,0,1,6-6m0-3a9,9,0,1,0,9,9,9,9,0,0,0-9-9h0Z"/>


### PR DESCRIPTION
Makes the schedules icon a similar darkness to the rest of the icons:

<img width="150" alt="schedules" src="https://cloud.githubusercontent.com/assets/153/25734011/31c01776-31a2-11e7-87e6-b7090d68fb2b.png">
