### PR TITLE
Give the YAML CodeMirror a min-height

### DIFF
--- a/app/css/codemirror-additions.css
+++ b/app/css/codemirror-additions.css
@@ -1,6 +1,11 @@
 .CodeMirror {
   /* https://codemirror.net/demo/resize.html */
   height: auto;
+  min-height: 150px;
+}
+
+.CodeMirror-scroll {
+  min-height: 150px;
 }
 
 .CodeMirror-gutters {


### PR DESCRIPTION
It's too small for tiny pipelines.