### PR TITLE
Fix menu button icon collapsing

### DIFF
--- a/app/components/organization/SettingsMenu.js
+++ b/app/components/organization/SettingsMenu.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Menu from '../shared/Menu';
-import Icon from '../shared/Icon';
 import permissions from '../../lib/permissions';
 
 class SettingsMenu extends React.Component {
@@ -54,7 +53,10 @@ class SettingsMenu extends React.Component {
         </Menu>
 
         <Menu>
-          <Menu.Button href={`/user/settings`}>Personal Settings</Menu.Button>
+          <Menu.Button
+            href={`/user/settings`}
+            label="Personal Settings"
+          />
         </Menu>
       </div>
     );
@@ -65,50 +67,70 @@ class SettingsMenu extends React.Component {
       {
         allowed: "organizationUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} href={`/organizations/${this.props.organization.slug}/settings`}>
-            <Icon icon="settings" className="icon-mr"/>Settings
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="settings"
+            href={`/organizations/${this.props.organization.slug}/settings`}
+            label="Settings"
+          />
         )
       },
       {
         always: true,
         render: (idx) => (
-          <Menu.Button key={idx} link={`/organizations/${this.props.organization.slug}/users`} badge={this.calculateUsersCount()}>
-            <Icon icon="users" className="icon-mr"/>Users
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="users"
+            link={`/organizations/${this.props.organization.slug}/users`}
+            badge={this.calculateUsersCount()}
+            label="Users"
+          />
         )
       },
       {
         allowed: "teamAdmin",
         render: (idx) => (
-          <Menu.Button key={idx} link={`/organizations/${this.props.organization.slug}/teams`} badge={this.props.organization.teams && this.props.organization.teams.count}>
-            <Icon icon="teams" className="icon-mr"/>Teams
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="teams"
+            link={`/organizations/${this.props.organization.slug}/teams`}
+            badge={this.props.organization.teams && this.props.organization.teams.count}
+            label="Teams"
+          />
         )
       },
       {
         allowed: "notificationServiceUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} href={`/organizations/${this.props.organization.slug}/services`}>
-            <Icon icon="notification-services" className="icon-mr"/>Notification Services
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="notification-services"
+            href={`/organizations/${this.props.organization.slug}/services`}
+            label="Notification Services"
+          />
         )
       },
       {
         allowed: "organizationUpdate",
         and: Features.SSOSettings,
         render: (idx) => (
-          <Menu.Button key={idx} link={`/organizations/${this.props.organization.slug}/sso`}>
-            <Icon icon="sso" className="icon-mr"/>Single Sign On
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="sso"
+            link={`/organizations/${this.props.organization.slug}/sso`}
+            label="Single Sign On"
+          />
         )
       },
       {
         allowed: "organizationBillingUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} href={`/organizations/${this.props.organization.slug}/billing`}>
-            <Icon icon="billing" className="icon-mr"/>Billing
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="billing"
+            href={`/organizations/${this.props.organization.slug}/billing`}
+            label="Billing"
+          />
         )
       }
     );

--- a/app/components/pipeline/SettingsMenu.js
+++ b/app/components/pipeline/SettingsMenu.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 import Menu from '../shared/Menu';
-import Icon from '../shared/Icon';
 
 import permissions from '../../lib/permissions';
 
@@ -27,9 +26,11 @@ class SettingsMenu extends React.Component {
         </Menu>
 
         <Menu>
-          <Menu.Button href={`${url}/email-preferences`}>
-            <Icon icon="emails" className="icon-mr"/>Personal Email Settings
-          </Menu.Button>
+          <Menu.Button
+            icon="emails"
+            href={`${url}/email-preferences`}
+            label="Personal Email Settings"
+          />
         </Menu>
       </div>
     );
@@ -40,57 +41,77 @@ class SettingsMenu extends React.Component {
       {
         allowed: "pipelineUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} href={`${url}`} active={this.isPipelineButtonActive(url)}>
-            <Icon icon="pipeline" className="icon-mr"/>Pipeline
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="pipeline"
+            href={`${url}`}
+            active={this.isPipelineButtonActive(url)}
+            label="Pipeline"
+          />
         )
       },
       {
         allowed: "pipelineUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} href={`${url}/name-and-description`}>
-            <Icon icon="settings" className="icon-mr"/>Name &amp; Description
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="settings"
+            href={`${url}/name-and-description`}
+            label="Name &amp; Description"
+          />
         )
       },
       {
         allowed: "pipelineUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} href={`${url}/build-skipping`}>
-            <Icon icon="build-skipping" className="icon-mr"/>Build Skipping
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="build-skipping"
+            href={`${url}/build-skipping`}
+            label="Build Skipping"
+          />
         )
       },
       {
         allowed: "pipelineUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} href={`${url}/repository`}>
-            <Icon icon={this.repositoryProviderIcon()} className="icon-mr"/>{this.providerLabel()}
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon={this.repositoryProviderIcon()}
+            href={`${url}/repository`}
+            label={this.providerLabel()}
+          />
         )
       },
       {
         allowed: "pipelineUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} link={`${url}/teams`} badge={this.props.pipeline.teams.count}>
-            <Icon icon="teams" className="icon-mr"/>Teams
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="teams" link={`${url}/teams`}
+            badge={this.props.pipeline.teams.count}
+            label="Teams"
+          />
         )
       },
       {
         allowed: "pipelineUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} link={`${url}/schedules`} badge={this.props.pipeline.schedules.count}>
-            <Icon icon="schedules" className="icon-mr"/>Schedules
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="schedules" link={`${url}/schedules`} badge={this.props.pipeline.schedules.count}
+            label="Schedules"
+          />
         )
       },
       {
         allowed: "pipelineUpdate",
         render: (idx) => (
-          <Menu.Button key={idx} href={`${url}/badges`}>
-            <Icon icon="badges" className="icon-mr"/>Build Badges
-          </Menu.Button>
+          <Menu.Button
+            key={idx}
+            icon="badges" href={`${url}/badges`}
+            label="Build Badges"
+          />
         )
       }
     );

--- a/app/components/shared/Menu/button.js
+++ b/app/components/shared/Menu/button.js
@@ -4,12 +4,14 @@ import classNames from 'classnames';
 
 import Badge from '../Badge';
 import BaseButton from '../Button';
+import Icon from '../Icon';
 
 class Button extends React.Component {
   static displayName = "Menu.Button";
 
   static propTypes = {
-    children: PropTypes.node.isRequired,
+    label: PropTypes.string.isRequired,
+    icon: PropTypes.string,
     badge: PropTypes.number,
     href: PropTypes.string,
     active: PropTypes.bool,
@@ -24,8 +26,11 @@ class Button extends React.Component {
         link={this.props.link}
       >
         <div className="flex">
-          <div className="flex-auto truncate flex items-center">{this.props.children}</div>
-          <div className="flex-none">{this._renderBadge()}</div>
+          <div className="flex-auto flex items-center">
+            {this._renderIcon()}
+            <div className="truncate">{this.props.label}</div>
+          </div>
+          {this._renderBadge()}
         </div>
       </BaseButton>
     );
@@ -40,12 +45,22 @@ class Button extends React.Component {
     }
   }
 
+  _renderIcon() {
+    if (this.props.icon) {
+      return (
+        <Icon className="flex-none icon-mr" icon={this.props.icon}/>
+      );
+    }
+  }
+
   _renderBadge() {
     if (this.props.badge) {
       return (
-        <Badge className={classNames(`hover-lime-child`, { "bg-lime": this._isActive() })}>
-          {this.props.badge}
-        </Badge>
+        <div className="flex-none">
+          <Badge className={classNames(`hover-lime-child`, { "bg-lime": this._isActive() })}>
+            {this.props.badge}
+          </Badge>
+        </div>
       );
     }
   }

--- a/app/components/user/SettingsMenu.js
+++ b/app/components/user/SettingsMenu.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Menu from '../shared/Menu';
-import Icon from '../shared/Icon';
 
 class SettingsMenu extends React.Component {
   static propTypes = {
@@ -19,7 +18,11 @@ class SettingsMenu extends React.Component {
     this.props.viewer.organizations.edges.forEach((organization) => {
       if (organization.node.permissions.organizationUpdate.allowed) {
         organizations.push(
-          <Menu.Button key={organization.node.slug} href={`/organizations/${organization.node.slug}/settings`}>{organization.node.name}</Menu.Button>
+          <Menu.Button
+            key={organization.node.slug}
+            href={`/organizations/${organization.node.slug}/settings`}
+            label={organization.node.name}
+          />
         );
       }
     });
@@ -39,21 +42,29 @@ class SettingsMenu extends React.Component {
         <Menu>
           <Menu.Header>Personal Settings</Menu.Header>
 
-          <Menu.Button href={`/user/settings`}>
-            <Icon icon="settings" className="icon-mr"/>Profile &amp; Password
-          </Menu.Button>
+          <Menu.Button
+            icon="settings"
+            href="/user/settings"
+            label="Profile & Password"
+          />
 
-          <Menu.Button href={`/user/emails`}>
-            <Icon icon="emails" className="icon-mr"/>Email Settings
-          </Menu.Button>
+          <Menu.Button
+            icon="emails"
+            href="/user/emails"
+            label="Email Settings"
+          />
 
-          <Menu.Button href={`/user/connected-apps`}>
-            <Icon icon="connected-apps" className="icon-mr"/>Connected Apps
-          </Menu.Button>
+          <Menu.Button
+            icon="connected-apps"
+            href="/user/connected-apps"
+            label="Connected Apps"
+          />
 
-          <Menu.Button href={`/user/api-access-tokens`}>
-            <Icon icon="api-tokens" className="icon-mr"/>API Access Tokens
-          </Menu.Button>
+          <Menu.Button
+            icon="api-tokens"
+            href="/user/api-access-tokens"
+            label="API Access Tokens"
+          />
         </Menu>
 
         {organizationsMenu}

--- a/app/css/icons.css
+++ b/app/css/icons.css
@@ -1,3 +1,3 @@
 .icon-mr {
-  margin-right: 10px;
+  margin-right: 8px;
 }

--- a/app/lib/permissions.js
+++ b/app/lib/permissions.js
@@ -59,15 +59,13 @@ class PermissionManager {
   check(config, args) {
     args = args || [];
 
-    // Along with checking a paticular permission, you can also pass an `and` config, i.e.
+    // Along with checking a particular permission, you can also pass an `and` config, i.e.
     //
     //      {
     //        allowed: "organizationUpdate",
     //        and: Features.SSOSettings,
     //        render: (idx) => (
-    //          <Menu.Button key={idx} link={`/organizations/${this.props.organization.slug}/sso`}>
-    //            <Icon icon="sso" className="icon-mr"/>SSO
-    //          </Menu.Button>
+    //          ...
     //        )
     //      },
     //


### PR DESCRIPTION
#248 introduced a bug where icons would be collapsed, and another where some menu items weren't properly truncated:

<img width="203" alt="boogs" src="https://cloud.githubusercontent.com/assets/153/25770165/bcf45008-3271-11e7-952a-b189f3d1717e.png">

This fixes the two bugs by fixing the `flex` definitions. Rather than copy+pasting class names to every `<Icon>` the label and icon have been moved to props of the `<Menu.Button>`

<img width="190" alt="fixed" src="https://cloud.githubusercontent.com/assets/153/25770191/20d622fe-3272-11e7-8412-494b3e0a6ec5.png">

This also removes the empty `flex-none` div in menu buttons without badges, and brings the icons a little closer to their labels.