### PR TITLE
Restore build dialog deep-link functionality

### DIFF
--- a/app/components/pipeline/CreateBuildDialog.js
+++ b/app/components/pipeline/CreateBuildDialog.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay';
+import { parse } from 'query-string';
 
 import Button from '../shared/Button';
 import CollapsableArea from '../shared/CollapsableArea';
@@ -29,12 +30,12 @@ class CreateBuildDialog extends React.PureComponent {
   };
 
   componentWillMount() {
-    const bkUrl = new Buildkite.Url(window.location);
+    const [hashPath, hashQuery] = window.location.hash.split('?');
 
-    if (bkUrl.getAnchorPath() === 'new') {
+    if (hashPath === '#new') {
       const newState = {};
 
-      newState.defaultValues = bkUrl.getAnchorQueryParameters();
+      newState.defaultValues = parse(hashQuery);
 
       // expand expando area if values in expando area are non-default!
       if (newState.defaultValues.env || newState.defaultValues.clean_checkout) {

--- a/app/components/pipeline/CreateBuildDialog.js
+++ b/app/components/pipeline/CreateBuildDialog.js
@@ -17,8 +17,40 @@ class CreateBuildDialog extends React.PureComponent {
 
   state = {
     showingOptions: false,
-    creatingBuild: false
+    creatingBuild: false,
+    defaultValues: {
+      // putting these here so it's obvious they exist(!)
+      message: undefined,
+      commit: undefined,
+      branch: undefined,
+      env: undefined,
+      clean_checkout: undefined
+    }
   };
+
+  componentWillMount() {
+    const bkUrl = new Buildkite.Url(window.location);
+
+    if (bkUrl.getAnchorPath() === 'new') {
+      const newState = {};
+
+      newState.defaultValues = bkUrl.getAnchorQueryParameters();
+
+      // expand expando area if values in expando area are non-default!
+      if (newState.defaultValues.env || newState.defaultValues.clean_checkout) {
+        newState.showingOptions = true;
+      }
+
+      this.setState(newState);
+    }
+  }
+
+  componentDidMount() {
+    // Focus the build message input box if the dialog started life opened.
+    if (this.props.isOpen && this.buildMessageTextField) {
+      this.buildMessageTextField.focus();
+    }
+  }
 
   componentDidUpdate(prevProps) {
     if (!prevProps.isOpen && this.props.isOpen) {
@@ -57,6 +89,7 @@ class CreateBuildDialog extends React.PureComponent {
               label="Message"
               placeholder="Description of this build"
               required={true}
+              value={this.state.defaultValues.message}
               ref={(buildMessageTextField) => this.buildMessageTextField = buildMessageTextField}
             />
 
@@ -64,7 +97,7 @@ class CreateBuildDialog extends React.PureComponent {
               name="build[commit]"
               label="Commit"
               placeholder="HEAD"
-              value="HEAD"
+              value={this.state.defaultValues.commit || 'HEAD'}
               required={true}
             />
 
@@ -72,7 +105,7 @@ class CreateBuildDialog extends React.PureComponent {
               name="build[branch]"
               label="Branch"
               placeholder={this.props.pipeline.defaultBranch}
-              value={this.props.pipeline.defaultBranch}
+              value={this.state.defaultValues.branch || this.props.pipeline.defaultBranch}
               required={true}
             />
 
@@ -87,6 +120,7 @@ class CreateBuildDialog extends React.PureComponent {
                 label="Environment Variables"
                 help="Place each environment variable on a new line, in the format <code>KEY=value</code>"
                 rows={3}
+                value={this.state.defaultValues.env}
                 tabIndex={this.state.showingOptions ? 0 : -1}
               />
               <div className="relative">
@@ -97,6 +131,7 @@ class CreateBuildDialog extends React.PureComponent {
                     name="build[clean_checkout]"
                     type="checkbox"
                     value="1"
+                    defaultChecked={this.state.defaultValues.clean_checkout === 'true'}
                     tabIndex={this.state.showingOptions ? 0 : -1}
                   />
                   {' '}

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -54,7 +54,7 @@ class Header extends React.Component {
   };
 
   componentWillMount() {
-    if (new Buildkite.Url(window.location).getAnchorPath() === 'new') {
+    if (window.location.hash.split('?').shift() === '#new') {
       this.setState({
         showingCreateBuildDialog: true
       });

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -53,6 +53,14 @@ class Header extends React.Component {
     showingCreateBuildDialog: false
   };
 
+  componentWillMount() {
+    if (new Buildkite.Url(window.location).getAnchorPath() === 'new') {
+      this.setState({
+        showingCreateBuildDialog: true
+      });
+    }
+  }
+
   render() {
     const actions = this.getAvailableActions();
 


### PR DESCRIPTION
This was accidentally removed (read: not reimplemented!) after removing the feature flags in buildkite/buildkite#2089.

This restores the functionality to the new dialog!

Links like this will auto-fill the build dialog;

https://buildkite.com/buildkite/bash-example#new?message=Hi%20there%20this%20is%20a%20prefilled%20message&branch=develop&commit=ffffffff&env=BUILDKITE_ROCKS%3Dtrue

Supported parameters;
* `message`
* `commit`
* `branch`
* `env`
* `clean_checkout` (naming convention kept from previous Ruby/CoffeeScript handler for compatibility; `true` if `=== 'true'`)