### PR TITLE
Better Pusher connection handling

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -12,7 +12,6 @@ if (window.Bugsnag && window._bugsnag) {
   window.Bugsnag.appVersion = window._bugsnag.appVersion;
   window.Bugsnag.user = window._bugsnag.user;
   window.Bugsnag.releaseStage = window._bugsnag.releaseStage;
-  window.Bugsnag.notifyReleaseStages = window._bugsnag.notifyReleaseStages;
 }
 
 // Toggle on development features

--- a/app/app.js
+++ b/app/app.js
@@ -15,6 +15,14 @@ if (window.Bugsnag && window._bugsnag) {
   window.Bugsnag.notifyReleaseStages = window._bugsnag.notifyReleaseStages;
 }
 
+// Toggle on development features
+if (process.env.NODE_ENV === "development") {
+  require('react-type-snob').default(React);
+  require('./lib/Logger').default.enable();
+  require('react-relay/lib/RelayNetworkDebug').init();
+  window.Perf = require('react-addons-perf');
+}
+
 // Allows old sprockets and inline-javascript to access webpack modules
 window["Webpack"] = {
   modules: {
@@ -116,14 +124,6 @@ if (window._pusher) {
   for (const channel of window._pusher["channels"]) {
     PusherStore.listen(channel);
   }
-}
-
-// Toggle on development features
-if (process.env.NODE_ENV === "development") {
-  require('react-type-snob').default(React);
-  require('./lib/Logger').default.enable();
-  require('react-relay/lib/RelayNetworkDebug').init();
-  window.Perf = require('react-addons-perf');
 }
 
 // Only do the react-router gear on pages we've designated

--- a/app/components/layout/Flashes/flash.js
+++ b/app/components/layout/Flashes/flash.js
@@ -8,7 +8,7 @@ class Flash extends React.PureComponent {
   static propTypes = {
     flash: PropTypes.shape({
       type: PropTypes.string.isRequired,
-      message: PropTypes.string.isRequired
+      message: PropTypes.node.isRequired
     }),
     onRemoveClick: PropTypes.func.isRequired
   };

--- a/app/components/layout/Flashes/flash.js
+++ b/app/components/layout/Flashes/flash.js
@@ -4,10 +4,9 @@ import classNames from 'classnames';
 
 import FlashesStore from '../../../stores/FlashesStore';
 
-class Flash extends React.Component {
+class Flash extends React.PureComponent {
   static propTypes = {
     flash: PropTypes.shape({
-      id: PropTypes.number.isRequired,
       type: PropTypes.string.isRequired,
       message: PropTypes.string.isRequired
     }),
@@ -21,7 +20,7 @@ class Flash extends React.Component {
     });
 
     return (
-      <div key={this.props.flash.id} className={classes}>
+      <div className={classes}>
         <div className="flex-auto px4 py3" data-flash-message={true}>{this.props.flash.message}</div>
         <button className="btn px4 py3" onClick={this.handleCloseClick} data-flash-close={true}>Close</button>
       </div>

--- a/app/components/layout/Flashes/index.js
+++ b/app/components/layout/Flashes/index.js
@@ -1,10 +1,13 @@
 import React from 'react';
 
 import FlashesStore from '../../../stores/FlashesStore';
+import PusherStore from '../../../stores/PusherStore';
 
 import Flash from './flash';
 
-class Flashes extends React.Component {
+const FLASH_CONN_ERROR_ID = 'FLASH_CONN_ERROR';
+
+class Flashes extends React.PureComponent {
   state = {
     flashes: []
   };
@@ -16,18 +19,57 @@ class Flashes extends React.Component {
   }
 
   componentDidMount() {
-    FlashesStore.on("flash", this.handleStoreChange);
+    FlashesStore.on('flash', this.handleStoreChange);
+    PusherStore.on('unavailable', this.handleConnectionError);
+    PusherStore.on('connected', this.handleConnectionSuccess);
   }
 
   componentWillUnmount() {
-    FlashesStore.off("flash", this.handleStoreChange);
+    FlashesStore.off('flash', this.handleStoreChange);
+    PusherStore.off('unavailable', this.handleConnectionError);
+    PusherStore.off('connected', this.handleConnectionSuccess);
   }
+
+  handleStoreChange = (payload) => {
+    this.setState({ flashes: this.state.flashes.concat(payload) });
+  };
+
+  // show a flash when there's a push connection issue
+  handleConnectionError = () => {
+    const connectionFlash = {
+      id: FLASH_CONN_ERROR_ID,
+      type: FlashesStore.ERROR,
+      message: 'Push events have been disconnected. Real-time updates won’t work for now. We’ll try to reconnect soon!'
+    };
+
+    // prepend the flash
+    this.setState({
+      flashes: [connectionFlash].concat(this.state.flashes)
+    });
+  };
+
+  // hide connection error flash (if it exists!) when reconnected
+  handleConnectionSuccess = () => {
+    // as the flash is always prepended (and no other flash is),
+    // we can slice from the front rather than filter or find index
+    if (this.state.flashes.length > 0 && this.state.flashes[0].id === FLASH_CONN_ERROR_ID) {
+      this.setState({
+        flashes: this.state.flashes.slice(1)
+      });
+    }
+  };
 
   render() {
     if (this.state.flashes.length > 0) {
       return (
         <div className="container mb4">
-          {this.state.flashes.map((flash) => <Flash key={flash.id} flash={flash} onRemoveClick={this.handleFlashRemove} />)}
+          {this.state.flashes.map((flash) => (
+            <Flash
+              key={flash.id}
+              flash={flash}
+              onRemoveClick={this.handleFlashRemove}
+            />
+          ))}
         </div>
       );
     } else {
@@ -45,10 +87,6 @@ class Flashes extends React.Component {
     }
 
     this.setState({ flashes: flashes });
-  };
-
-  handleStoreChange = (payload) => {
-    this.setState({ flashes: this.state.flashes.concat(payload) });
   };
 }
 

--- a/app/components/layout/Flashes/index.js
+++ b/app/components/layout/Flashes/index.js
@@ -40,6 +40,11 @@ class Flashes extends React.PureComponent {
   }
 
   // show a flash when there's a push connection issue
+  //
+  // NOTE: Pusher only sends this event if the following conditions are met;
+  //        1. The websocket timed out (30 seconds by default)
+  //        2. Reconnecting the websocket (after 10 seconds) failed
+  //       Thus, this can only happen once in a given 40 second period.
   handleConnectionError = () => {
     if (this.hasConnectionErrorFlash() || !this.state.lastConnected) {
       // try not to be irritating; don't add a new flash when

--- a/app/components/layout/Flashes/index.js
+++ b/app/components/layout/Flashes/index.js
@@ -54,7 +54,7 @@ class Flashes extends React.PureComponent {
     const connectionFlash = {
       id: FLASH_CONN_ERROR_ID,
       type: FlashesStore.ERROR,
-      message: 'Push events have been disconnected. Real-time updates won’t work for now. We’ll try to reconnect soon!'
+      message: <span><span className="semi-bold">Couldn’t connect to Buildkite for push updates.</span> We’ll try to reconnect! Information won’t update automatically for now.</span>
     };
 
     // prepend the flash

--- a/app/lib/Logger.js
+++ b/app/lib/Logger.js
@@ -6,7 +6,7 @@ class Logger {
     this.console = window['console'];
 
     // Tell the world that logging has been turned on!
-    this.info("[Logger]", "Enabled...");
+    this.info("[Logger] Enabled...");
   }
 
   info() {

--- a/app/routes.js
+++ b/app/routes.js
@@ -74,8 +74,13 @@ const renderMain = (route) => {
   }
 };
 
+// Reset Bugsnag on route changes if it's loaded
+const onRouterUpdate = window.Bugsnag
+  ? () => (window.Bugsnag.refresh())
+  : undefined;
+
 export default (
-  <Router history={browserHistory} render={applyRouterMiddleware(useRelay)} environment={Relay.Store}>
+  <Router history={browserHistory} onUpdate={onRouterUpdate} render={applyRouterMiddleware(useRelay)} environment={Relay.Store}>
     <Route path="/:organization/:pipeline/builds/:number" component={BuildCommentsList} queries={{ viewer: ViewerQuery.query, build: BuildQuery.query }} prepareParams={BuildQuery.prepareParams} />
 
     <Route path="/" component={Main} getQueries={getMainQueries} render={renderMain}>

--- a/app/stores/PusherStore.js
+++ b/app/stores/PusherStore.js
@@ -6,7 +6,14 @@ class PusherStore extends EventEmitter {
   configure(key, options) {
     this.pusher = new Pusher(key, options);
 
-    this.pusher.connection.bind("connected", () => this.emit("connected"));
+    this.pusher.connection.bind(
+      'state_change',
+      ({ current, ...context }) => {
+        Logger.info("[PusherStore]", current, context);
+
+        this.emit(current, context);
+      }
+    );
   }
 
   isConfigured() {

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -138,7 +138,7 @@ if (IS_PRODUCTION) {
 
 if (IS_PRODUCTION || process.env['BUGSNAG_JS_API_KEY']) {
   // Only load Bugsnag if configured, or we're in Production
-  vendor_modules.push("bugsnag-js");
+  vendor_modules.unshift("bugsnag-js");
 }
 
 module.exports = {


### PR DESCRIPTION
This pull request includes a couple of little quality of life improvements for our push events.

1. When Pusher is disconnected, we’ll show the user a notice that things won’t live-update. In the past the page would just silently not update. Hopefully this’ll make it easier to tell the difference between a connection blip and a real showstopper!
   <img width="394" alt="screen shot 2017-05-11 at 1 33 41 pm" src="https://cloud.githubusercontent.com/assets/282113/25970725/7b4f3ba0-364e-11e7-8ba9-6545182bd3bf.png">
   The notice is automatically dismissed when the connection is restored, and the user may dismiss it. Additionally, dismissing the notice will mean no new notification is created until the connection is restored at least once (this prevents notices _re_-appearing when going from `unavailable` -> `connecting` -> `unavailable`)
2. `NODE_ENV=development` Pusher logging is improved. Previously some logs were not shown as the logger wasn’t initialised in time. This is fixed, and we’re also logging more (read: all) Pusher connection state transitions.