### PR TITLE
Push a final image to 🐳 buildkite/frontend on master

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,7 +45,20 @@ steps:
 
   - wait
 
-  - name: ":rocket:"
+  - name: ":rocket: :docker:"
+    branches: "master"
+    concurrency: 1
+    concurrency_group: "deployer"
+    plugins:
+      docker-compose#v1.3.0:
+        push:
+          - app:index.docker.io/buildkite/frontend:build-${BUILDKITE_BUILD_NUMBER}
+          - app:index.docker.io/buildkite/frontend:commit-${BUILDKITE_COMMIT:0:6}
+          - app:index.docker.io/buildkite/frontend:latest
+
+  - wait
+
+  - name: ":rocket: :s3:"
     command: ".buildkite/steps/deploy.sh"
     branches: "master"
     artifact_paths: "tmp/verify/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,11 +46,9 @@ steps:
   - wait
 
   - name: ":rocket: :docker:"
-    branches:
-      - master
-      - push-docker-image
+    branches: "master"
     concurrency: 1
-    concurrency_group: "deployer"
+    concurrency_group: "docker-deployer"
     plugins:
       docker-compose#v1.3.1:
         push:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,8 @@
+env:
+  - FRONTEND_HOST=https://buildkiteassets.com/frontend/
+  - EMOJI_HOST=https://buildkiteassets.com/emojis
+  - S3_URL=s3://buildkiteassets.com/frontend/
+
 steps:
   - name: ":docker: :package:"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,9 +54,9 @@ steps:
     plugins:
       docker-compose#3e8810f:
         push:
-          - app:index.docker.io/buildkite/frontend:build-${BUILDKITE_BUILD_NUMBER}
-          - app:index.docker.io/buildkite/frontend:commit-${BUILDKITE_COMMIT:0:6}
-          - app:index.docker.io/buildkite/frontend:latest
+          - frontend:index.docker.io/buildkite/frontend:build-${BUILDKITE_BUILD_NUMBER}
+          - frontend:index.docker.io/buildkite/frontend:commit-${BUILDKITE_COMMIT:0:6}
+          - frontend:index.docker.io/buildkite/frontend:latest
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ env:
 steps:
   - name: ":docker: :package:"
     plugins:
-      docker-compose#3e8810f:
+      docker-compose#v1.3.1:
         build: frontend
         image-repository: index.docker.io/buildkiteci/frontend
     env:
@@ -19,28 +19,28 @@ steps:
   - name: ":eslint:"
     command: ".buildkite/steps/eslint.sh"
     plugins:
-      docker-compose#3e8810f:
+      docker-compose#v1.3.1:
         run: frontend
 
   - name: ":jest:"
     command: ".buildkite/steps/jest.sh"
     artifact_paths: "coverage/*"
     plugins:
-      docker-compose#3e8810f:
+      docker-compose#v1.3.1:
         run: frontend
 
   - name: ":package::mag:"
     command: ".buildkite/steps/bundle-analyze.sh"
     artifact_paths: "bundle-analysis/*"
     plugins:
-      docker-compose#3e8810f:
+      docker-compose#v1.3.1:
         run: frontend
 
   - name: ":webpack:"
     command: ".buildkite/steps/webpack.sh"
     artifact_paths: "dist/*"
     plugins:
-      docker-compose#3e8810f:
+      docker-compose#v1.3.1:
         run: frontend
 
   - wait
@@ -52,7 +52,7 @@ steps:
     concurrency: 1
     concurrency_group: "deployer"
     plugins:
-      docker-compose#3e8810f:
+      docker-compose#v1.3.1:
         push:
           - frontend:index.docker.io/buildkite/frontend:build-${BUILDKITE_BUILD_NUMBER}
           - frontend:index.docker.io/buildkite/frontend:commit-${BUILDKITE_COMMIT:0:6}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 env:
-  - FRONTEND_HOST=https://buildkiteassets.com/frontend/
-  - EMOJI_HOST=https://buildkiteassets.com/emojis
-  - S3_URL=s3://buildkiteassets.com/frontend/
+  FRONTEND_HOST: https://buildkiteassets.com/frontend/
+  EMOJI_HOST: https://buildkiteassets.com/emojis
+  S3_URL: s3://buildkiteassets.com/frontend/
 
 steps:
   - name: ":docker: :package:"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ env:
 steps:
   - name: ":docker: :package:"
     plugins:
-      docker-compose#v1.3.0:
+      docker-compose#3e8810f:
         build: frontend
         image-repository: index.docker.io/buildkiteci/frontend
     env:
@@ -19,28 +19,28 @@ steps:
   - name: ":eslint:"
     command: ".buildkite/steps/eslint.sh"
     plugins:
-      docker-compose#v1.3.0:
+      docker-compose#3e8810f:
         run: frontend
 
   - name: ":jest:"
     command: ".buildkite/steps/jest.sh"
     artifact_paths: "coverage/*"
     plugins:
-      docker-compose#v1.3.0:
+      docker-compose#3e8810f:
         run: frontend
 
   - name: ":package::mag:"
     command: ".buildkite/steps/bundle-analyze.sh"
     artifact_paths: "bundle-analysis/*"
     plugins:
-      docker-compose#v1.3.0:
+      docker-compose#3e8810f:
         run: frontend
 
   - name: ":webpack:"
     command: ".buildkite/steps/webpack.sh"
     artifact_paths: "dist/*"
     plugins:
-      docker-compose#v1.3.0:
+      docker-compose#3e8810f:
         run: frontend
 
   - wait
@@ -52,7 +52,7 @@ steps:
     concurrency: 1
     concurrency_group: "deployer"
     plugins:
-      docker-compose#v1.3.0:
+      docker-compose#3e8810f:
         push:
           - app:index.docker.io/buildkite/frontend:build-${BUILDKITE_BUILD_NUMBER}
           - app:index.docker.io/buildkite/frontend:commit-${BUILDKITE_COMMIT:0:6}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,7 +46,9 @@ steps:
   - wait
 
   - name: ":rocket: :docker:"
-    branches: "master"
+    branches:
+      - master
+      - push-docker-image
     concurrency: 1
     concurrency_group: "deployer"
     plugins:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM node:6
 
+EXPOSE 4890
 WORKDIR /frontend
 
 ADD package.json yarn.lock /frontend/
-RUN echo "--- :yarn: Installing application deps" \
-    && yarn
+RUN yarn install
 
 ADD . /frontend/
-
-EXPOSE 4890
-
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,7 @@ RUN echo "--- :yarn: Installing application deps" \
     && yarn
 
 ADD . /frontend/
+
+EXPOSE 4890
+
+CMD ["npm", "start"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,5 +2,11 @@ version: '2'
 
 services:
   frontend:
+    volumes:
+      - ".:/frontend:cached,ro"
+      - "./bundle-analysis:/frontend/bundle-analysis"
+      - "./dist:/frontend/dist"
+      - "./coverage:/frontend/coverage"
+      - /frontend/node_modules
     ports:
       - "4890:4890"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  frontend:
+    ports:
+      - "4890:4890"
+    environment:
+      FRONTEND_HOST: http://localhost:4890/
+

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,3 @@ services:
   frontend:
     ports:
       - "4890:4890"
-    environment:
-      FRONTEND_HOST: http://localhost:4890/
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,9 @@ services:
   frontend:
     image: index.docker.io/buildkite/frontend
     build: .
-    volumes:
-      - "./bundle-analysis:/frontend/bundle-analysis"
-      - "./dist:/frontend/dist"
-      - "./coverage:/frontend/coverage"
     environment:
-      BUILDKITE:
-      BUILDKITE_COMMIT:
-      BUILDKITE_ORGANIZATION_SLUG:
-      BUILDKITE_PIPELINE_SLUG:
-      CI:
-      EMOJI_HOST:
+      - EMOJI_HOST
+      - FRONTEND_HOST
+    volumes:
+      - ".:/frontend:cached"
+      - /frontend/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
     environment:
       - EMOJI_HOST
       - FRONTEND_HOST
+      - BUILDKITE
+      - BUILDKITE_COMMIT
+      - BUILDKITE_ORGANIZATION_SLUG
+      - BUILDKITE_PIPELINE_SLUG
+      - CI
     volumes:
       - ".:/frontend:cached"
       - /frontend/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 
 services:
   frontend:
+    image: index.docker.io/buildkite/frontend
     build: .
     volumes:
       - "./bundle-analysis:/frontend/bundle-analysis"
@@ -14,4 +15,3 @@ services:
       BUILDKITE_PIPELINE_SLUG:
       CI:
       EMOJI_HOST:
-      FRONTEND_HOST:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
   frontend:
     image: index.docker.io/buildkite/frontend
     build: .
+    volumes:
+      - "./bundle-analysis:/frontend/bundle-analysis"
+      - "./dist:/frontend/dist"
+      - "./coverage:/frontend/coverage"
     environment:
       - EMOJI_HOST
       - FRONTEND_HOST
@@ -12,6 +16,3 @@ services:
       - BUILDKITE_ORGANIZATION_SLUG
       - BUILDKITE_PIPELINE_SLUG
       - CI
-    volumes:
-      - ".:/frontend:cached"
-      - /frontend/node_modules


### PR DESCRIPTION
Currently a docker image gets built for frontend, but only pushed to [`buildkiteci/frontend`](https://hub.docker.com/r/buildkiteci/frontend/), which I view as ephemeral build artifacts and prone to being deleted. 

This change adds a push step at the end that deploys a passing image to the more official [`buildkite/frontend`](https://hub.docker.com/r/buildkite/frontend/) with tags that indicate what git commit they contain. For now, this will have no practical impact on anything, but it provides public runnable images of our frontend that we can also possibly consume in our development environments.

This also adds a `docker-compose.override.yml` which is only read in development (specifically, when no config files are specified). This mounts in the project for actually development using the new [`cached` directive](https://docs.docker.com/docker-for-mac/osxfs-caching/) which is much faster for Docker for Mac. 