### PR TITLE
Improve Schedules Build form labels and layouts

### DIFF
--- a/app/components/pipeline/schedules/Edit.js
+++ b/app/components/pipeline/schedules/Edit.js
@@ -6,7 +6,6 @@ import DocumentTitle from 'react-document-title';
 import PipelineScheduleUpdateMutation from '../../../mutations/PipelineScheduleUpdate';
 import GraphQLErrors from '../../../constants/GraphQLErrors';
 
-import PageHeader from '../../shared/PageHeader';
 import Panel from '../../shared/Panel';
 import Button from '../../shared/Button';
 

--- a/app/components/pipeline/schedules/Edit.js
+++ b/app/components/pipeline/schedules/Edit.js
@@ -44,11 +44,9 @@ class Edit extends React.Component {
     return (
       <DocumentTitle title={`Update`}>
         <form onSubmit={this.handleFormSubmit}>
-          <PageHeader>
-            <PageHeader.Title>Update Schedule</PageHeader.Title>
-          </PageHeader>
-
           <Panel>
+            <Panel.Header>Update Schedule</Panel.Header>
+
             <Panel.Section>
               <Form
                 pipeline={this.props.pipelineSchedule.pipeline}

--- a/app/components/pipeline/schedules/Form.js
+++ b/app/components/pipeline/schedules/Form.js
@@ -49,25 +49,28 @@ class Form extends React.Component {
 
         <FormTextField
           label="Message"
-          help="The message to use for the build. Default: “Scheduled Build for (Pipeline Name)”"
+          help="The message to use for the build."
           errors={errors.findForField("message")}
           value={this.props.message}
+          placeholder="Scheduled build"
           ref={(messageTextField) => this.messageTextField = messageTextField}
         />
 
         <FormTextField
           label="Commit"
-          help="The commit to use for the build. Default: “HEAD”"
+          help="The commit ref to use for the build."
           errors={errors.findForField("commit")}
           value={this.props.commit}
+          placeholder="HEAD"
           ref={(commitTextField) => this.commitTextField = commitTextField}
         />
 
         <FormTextField
           label="Branch"
-          help={`The branch to use for the build. Default: the pipeline’s default branch (currently “${this.props.pipeline.defaultBranch}”)`}
+          help="The branch to use for the build. Defaults to the pipeline’s default branch."
           errors={errors.findForField("branch")}
           value={this.props.branch}
+          placeholder={this.props.pipeline.defaultBranch}
           ref={(branchTextField) => this.branchTextField = branchTextField}
         />
 

--- a/app/components/pipeline/schedules/Form.js
+++ b/app/components/pipeline/schedules/Form.js
@@ -21,7 +21,7 @@ class Form extends React.Component {
   };
 
   componentDidMount() {
-    this.cronlineTextField.focus();
+    this.labelTextField.focus();
   }
 
   render() {

--- a/app/components/pipeline/schedules/Form.js
+++ b/app/components/pipeline/schedules/Form.js
@@ -65,7 +65,7 @@ class Form extends React.Component {
 
         <FormTextField
           label="Branch"
-          help={`The branch to use for the build. Default: the pipeline’s default branch (“${this.props.pipeline.defaultBranch}”)`}
+          help={`The branch to use for the build. Default: the pipeline’s default branch (currently “${this.props.pipeline.defaultBranch}”)`}
           errors={errors.findForField("branch")}
           value={this.props.branch}
           ref={(branchTextField) => this.branchTextField = branchTextField}

--- a/app/components/pipeline/schedules/Form.js
+++ b/app/components/pipeline/schedules/Form.js
@@ -48,34 +48,34 @@ class Form extends React.Component {
         />
 
         <FormTextField
-          label="Message"
+          label="Build Message"
           help="The message to use for the build."
           errors={errors.findForField("message")}
-          value={this.props.message}
-          placeholder="Scheduled build"
+          value={this.props.message || "Scheduled build"}
+          required={true}
           ref={(messageTextField) => this.messageTextField = messageTextField}
         />
 
         <FormTextField
-          label="Commit"
+          label="Build Commit"
           help="The commit ref to use for the build."
           errors={errors.findForField("commit")}
-          value={this.props.commit}
-          placeholder="HEAD"
+          value={this.props.commit || "HEAD"}
+          required={true}
           ref={(commitTextField) => this.commitTextField = commitTextField}
         />
 
         <FormTextField
-          label="Branch"
-          help="The branch to use for the build. Defaults to the pipeline’s default branch."
+          label="Build Branch"
+          help="The branch to use for the build."
           errors={errors.findForField("branch")}
-          value={this.props.branch}
-          placeholder={this.props.pipeline.defaultBranch}
+          value={this.props.branch || this.props.pipeline.defaultBranch}
+          required={true}
           ref={(branchTextField) => this.branchTextField = branchTextField}
         />
 
         <FormTextarea
-          label="Environment Variables"
+          label="Build Environment Variables"
           help="The environment variables to use for the build, each on a new line. e.g. <code>FOO=bar</code>"
           className="input"
           rows={2}

--- a/app/components/pipeline/schedules/Form.js
+++ b/app/components/pipeline/schedules/Form.js
@@ -30,24 +30,26 @@ class Form extends React.Component {
     return (
       <div>
         <FormTextField
-          label="Cron Interval"
-          help="The interval or time that this schedule should run using cron syntax, e.g (<code>30 * * * *</code> or <code>@midnight</code>). These times should be in UTC."
-          errors={errors.findForField("cronline")}
-          value={this.props.cronline}
-          ref={(cronlineTextField) => this.cronlineTextField = cronlineTextField}
-        />
-
-        <FormTextField
-          label="Label"
-          help="Describe what this schedule is all about (you can even use :emoji:)"
+          label="Description"
+          help="The description for the schedule (supports :emoji:)"
+          required={true}
           errors={errors.findForField("label")}
           value={this.props.label}
           ref={(labelTextField) => this.labelTextField = labelTextField}
         />
 
         <FormTextField
+          label="Cron Interval"
+          help={"The interval for when builds will be created, in UTC, using <a class=\"lime\" target=\"_blank\" rel=\"noopener\" href=\"https://crontab.guru\">cron format</a>. Also supports <code>@monthly</code>, <code>@weekly</code>, <code>@daily</code>, <code>@midnight</code>, and <code>@hourly</code>. For example, <code>30 * * * *</code> creates a build on the 30th minute of every hour."}
+          required={true}
+          errors={errors.findForField("cronline")}
+          value={this.props.cronline}
+          ref={(cronlineTextField) => this.cronlineTextField = cronlineTextField}
+        />
+
+        <FormTextField
           label="Message"
-          help="The message to use for the created build"
+          help="The message to use for the build. Default: “Scheduled Build for (Pipeline Name)”"
           errors={errors.findForField("message")}
           value={this.props.message}
           ref={(messageTextField) => this.messageTextField = messageTextField}
@@ -55,25 +57,23 @@ class Form extends React.Component {
 
         <FormTextField
           label="Commit"
-          help="The commit to use for the created build"
+          help="The commit to use for the build. Default: “HEAD”"
           errors={errors.findForField("commit")}
           value={this.props.commit}
-          placeholder={"HEAD"}
           ref={(commitTextField) => this.commitTextField = commitTextField}
         />
 
         <FormTextField
           label="Branch"
-          help="The branch to use for the created build"
+          help={`The branch to use for the build. Default: the pipeline’s default branch (“${this.props.pipeline.defaultBranch}”)`}
           errors={errors.findForField("branch")}
           value={this.props.branch}
-          placeholder={this.props.pipeline.defaultBranch}
           ref={(branchTextField) => this.branchTextField = branchTextField}
         />
 
         <FormTextarea
           label="Environment Variables"
-          help="Environment variables to be set, each on a new line. e.g. <code>FOO=bar</code>"
+          help="The environment variables to use for the build, each on a new line. e.g. <code>FOO=bar</code>"
           className="input"
           rows={2}
           autoresize={true}

--- a/app/components/pipeline/schedules/Index/index.js
+++ b/app/components/pipeline/schedules/Index/index.js
@@ -41,7 +41,7 @@ class Index extends React.Component {
           <Panel.Header>Schedules</Panel.Header>
 
           <Panel.IntroWithButton>
-            <span>Schedules allow you to automatically create builds at regular times.</span>
+            <span>Build schedules automatically create builds at a specified interval.</span>
             {this.renderNewScheduleButton()}
           </Panel.IntroWithButton>
           {this.renderScheduleRows()}

--- a/app/components/pipeline/schedules/Index/index.js
+++ b/app/components/pipeline/schedules/Index/index.js
@@ -54,7 +54,7 @@ class Index extends React.Component {
     return permissions(this.props.pipeline.permissions).check(
       {
         allowed: "pipelineScheduleCreate",
-        render: () => <Button link={`/${this.props.params.organization}/${this.props.params.pipeline}/settings/schedules/new`} theme={"default"} outline={true}>Create Schedule</Button>
+        render: () => <Button link={`/${this.props.params.organization}/${this.props.params.pipeline}/settings/schedules/new`} theme={"default"} outline={true}>New Schedule</Button>
       }
     );
   }

--- a/app/components/pipeline/schedules/Index/row.js
+++ b/app/components/pipeline/schedules/Index/row.js
@@ -30,11 +30,13 @@ class Row extends React.Component {
       <Panel.RowLink to={`/${organization.slug}/${pipeline.slug}/settings/schedules/${this.props.pipelineSchedule.uuid}`}>
         <div className="flex flex-stretch items-center line-height-1" style={{ minHeight: '3em' }}>
           <div className="flex-auto">
-            <div className="m0 semi-bold">{this.props.pipelineSchedule.cronline}</div>
             {this.renderLabel()}
+            <span className="dark-gray regular">{this.props.pipelineSchedule.cronline}</span>
           </div>
-          <div className="flex flex-none flex-stretch items-center my1 pr3">
-            <code className="dark-gray">{this.props.pipelineSchedule.branch} | {this.props.pipelineSchedule.commit}</code>
+          <div className="flex flex-none flex-stretch items-center my1 pr3 dark-gray">
+            <code className="dark-gray">{this.props.pipelineSchedule.commit}</code>
+            <span>&nbsp;/&nbsp;</span>
+            {this.props.pipelineSchedule.branch}
           </div>
         </div>
       </Panel.RowLink>
@@ -44,7 +46,7 @@ class Row extends React.Component {
   renderLabel() {
     if (this.props.pipelineSchedule.label) {
       return (
-        <div className="regular dark-gray mt1"><Emojify text={this.props.pipelineSchedule.label} /></div>
+        <div className="m0 semi-bold mt1 mb1"><Emojify text={this.props.pipelineSchedule.label} /></div>
       );
     }
   }

--- a/app/components/pipeline/schedules/Index/row.js
+++ b/app/components/pipeline/schedules/Index/row.js
@@ -46,7 +46,7 @@ class Row extends React.Component {
   renderLabel() {
     if (this.props.pipelineSchedule.label) {
       return (
-        <div className="m0 semi-bold mt1 mb1"><Emojify text={this.props.pipelineSchedule.label} /></div>
+        <div className="m0 semi-bold mb1"><Emojify text={this.props.pipelineSchedule.label} /></div>
       );
     }
   }

--- a/app/components/pipeline/schedules/New.js
+++ b/app/components/pipeline/schedules/New.js
@@ -36,7 +36,7 @@ class New extends React.Component {
       <DocumentTitle title={`Schedules · ${this.props.pipeline.name}`}>
         <form onSubmit={this.handleFormSubmit}>
           <Panel>
-            <Panel.Header>Create New Schedule</Panel.Header>
+            <Panel.Header>New Schedule</Panel.Header>
 
             <Panel.Section>
               <Form pipeline={this.props.pipeline} errors={this.state.errors} ref={(form) => this.form = form} />

--- a/app/components/pipeline/schedules/Show/build.js
+++ b/app/components/pipeline/schedules/Show/build.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
+import FriendlyTime from '../../../shared/FriendlyTime';
 import Panel from '../../../shared/Panel';
 
 class Build extends React.Component {
@@ -9,7 +10,8 @@ class Build extends React.Component {
     build: PropTypes.shape({
       id: PropTypes.string.isRequired,
       url: PropTypes.string.isRequired,
-      number: PropTypes.number.isRequired
+      number: PropTypes.number.isRequired,
+      createdAt: PropTypes.string.isRequired
     }).isRequired
   };
 
@@ -17,7 +19,8 @@ class Build extends React.Component {
     return (
       <Panel.RowLink key={this.props.build.id} href={this.props.build.url}>
         <div className="flex flex-stretch items-center line-height-1" style={{ minHeight: '3em' }}>
-          #{this.props.build.number}
+          <span className="mr-auto">Build #{this.props.build.number}</span>
+          <span className="dark-gray regular mr2 flex-none"><FriendlyTime value={this.props.build.createdAt} /></span>
         </div>
       </Panel.RowLink>
     );
@@ -31,6 +34,7 @@ export default Relay.createContainer(Build, {
         id
         url
         number
+        createdAt
       }
     `
   }

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -85,7 +85,7 @@ class Show extends React.Component {
 
               {this.renderEnv()}
 
-              <div><strong>Creator</strong></div>
+              <div><strong>Created By</strong></div>
               <div className="mb2 dark-gray">{this.props.pipelineSchedule.createdBy.name}</div>
             </Panel.Section>
           </Panel>
@@ -93,7 +93,7 @@ class Show extends React.Component {
           <Panel>
             <Panel.Header>Recent Builds</Panel.Header>
             <Panel.Row>
-              <div className="dark-gray py2">
+              <div className="dark-gray py1">
                 <Emojify text={`Next build scheduled for ${getRelativeDateString(this.props.pipelineSchedule.nextBuildAt)}`} />
               </div>
             </Panel.Row>

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -94,8 +94,8 @@ class Show extends React.Component {
           <Panel>
             <Panel.Header>Recent Builds</Panel.Header>
             <Panel.Row>
-              <div className="dark-gray py2 center">
-                <Emojify text={`:timer_clock: Next build scheduled for ${getRelativeDateString(this.props.pipelineSchedule.nextBuildAt)}…`} />
+              <div className="dark-gray py2">
+                <Emojify text={`Next build scheduled for ${getRelativeDateString(this.props.pipelineSchedule.nextBuildAt)}`} />
               </div>
             </Panel.Row>
             {this.props.pipelineSchedule.builds.edges.map((edge) => <Build key={edge.node.id} build={edge.node} />)}

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -67,8 +67,8 @@ class Show extends React.Component {
       <DocumentTitle title={this.props.pipelineSchedule.cronline}>
         <div>
           <PageHeader>
-            <PageHeader.Title>{this.props.pipelineSchedule.cronline}</PageHeader.Title>
-            <PageHeader.Description><Emojify text={this.props.pipelineSchedule.label || "No label"} /></PageHeader.Description>
+            <PageHeader.Title><Emojify text={this.props.pipelineSchedule.label || "No description"} /></PageHeader.Title>
+            <PageHeader.Description>{this.props.pipelineSchedule.cronline}</PageHeader.Description>
             <PageHeader.Menu>{this.renderMenu()}</PageHeader.Menu>
           </PageHeader>
 

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -78,13 +78,12 @@ class Show extends React.Component {
               <div className="mb2 dark-gray"><code>{this.props.pipelineSchedule.commit}</code></div>
 
               <div><strong>Branch</strong></div>
-              <div className="mb2 dark-gray"><code>{this.props.pipelineSchedule.branch}</code></div>
+              <div className="mb2 dark-gray">{this.props.pipelineSchedule.branch}</div>
 
               <div><strong>Message</strong></div>
-              <div className="mb2 dark-gray">{this.props.pipelineSchedule.message || "n/a"}</div>
+              <div className="mb2 dark-gray">{this.props.pipelineSchedule.message || "Scheduled build"}</div>
 
-              <div><strong>Environment Variables</strong></div>
-              <div className="mb2 dark-gray"><pre><code>{this.props.pipelineSchedule.env.join("\n")}</code></pre></div>
+              {this.renderEnv()}
 
               <div><strong>Creator</strong></div>
               <div className="mb2 dark-gray">{this.props.pipelineSchedule.createdBy.name}</div>
@@ -103,6 +102,19 @@ class Show extends React.Component {
         </div>
       </DocumentTitle>
     );
+  }
+
+  renderEnv() {
+    if (this.props.pipelineSchedule.env.length !== 0) {
+      return (
+        <div>
+          <div><strong>Environment Variables</strong></div>
+          <div className="mb2 dark-gray"><pre><code>{this.props.pipelineSchedule.env.join("\n")}</code></pre></div>
+        </div>
+      );
+    } else {
+      return null;
+    }
   }
 
   renderMenu() {

--- a/app/components/shared/FormInputLabel.js
+++ b/app/components/shared/FormInputLabel.js
@@ -6,7 +6,8 @@ class FormInputLabel extends React.PureComponent {
   static propTypes = {
     label: PropTypes.node.isRequired,
     children: PropTypes.node,
-    errors: PropTypes.bool
+    errors: PropTypes.bool,
+    required: PropTypes.bool
   };
 
   render() {
@@ -14,6 +15,7 @@ class FormInputLabel extends React.PureComponent {
       <label>
         <div className={classNames("bold mb1", { "red": this.props.errors })}>
           {this.props.label}
+          {this.props.required && <span className="dark-gray h6"> — Required</span>}
         </div>
         {this.props.children}
       </label>

--- a/app/components/shared/FormTextField.js
+++ b/app/components/shared/FormTextField.js
@@ -43,7 +43,11 @@ class FormTextField extends React.Component {
     } else {
       return (
         <div className="mb2">
-          <FormInputLabel label={this.props.label} errors={this._hasErrors()}>
+          <FormInputLabel
+            label={this.props.label}
+            errors={this._hasErrors()}
+            required={this.props.required}
+          >
             {this._renderInput()}
           </FormInputLabel>
           {this._renderErrors()}

--- a/app/components/team/Form.js
+++ b/app/components/team/Form.js
@@ -26,7 +26,7 @@ class TeamForm extends React.Component {
       <div>
         <FormTextField
           label="Name"
-          help="Pick a name for your team (you can even use :emoji:)"
+          help="The name for the team (supports :emoji:)"
           errors={errors.findForField("name")}
           value={this.props.name}
           onChange={this.handleTeamNameChange}
@@ -35,7 +35,7 @@ class TeamForm extends React.Component {
 
         <FormTextField
           label="Description"
-          help="Describe what this team is all about"
+          help="The description for the team (supports :emoji:)"
           errors={errors.findForField("description")}
           value={this.props.description}
           onChange={this.handleDescriptionChange}


### PR DESCRIPTION
Some cleanups before we announce scheduled builds are live:

* Clarifies which fields are required
* Puts the description at the top before all the Hard Stuff
* Added more information about the the cron interval syntax, along with `@` extensions we support
* Made sure teams forms were consistent

There's some things that still need improving which people might ask:

* Such as "How do I change/update the "Creator" of the builds?"
* What happens if the "Creator" is removed from the org?

Before:

<img width="877" alt="before-1" src="https://cloud.githubusercontent.com/assets/153/26183243/f51396e4-3bc0-11e7-8c92-e0c8a48b689c.png">

After:

<img width="874" alt="after-1" src="https://cloud.githubusercontent.com/assets/153/26183248/f9ae3308-3bc0-11e7-9a72-98c4f21dabfc.png">

Before:

<img width="883" alt="before-2" src="https://cloud.githubusercontent.com/assets/153/26183260/08a3e290-3bc1-11e7-82c4-983d47514b6b.png">

After:

<img width="891" alt="after-2" src="https://cloud.githubusercontent.com/assets/153/26183262/0b1cb18c-3bc1-11e7-94dd-e8ca8431fd97.png">

Before:

<img width="916" alt="before-3" src="https://cloud.githubusercontent.com/assets/153/26183264/0fc1dd3e-3bc1-11e7-9afc-8b12d0185f64.png">

After:

<img width="933" alt="after-3" src="https://cloud.githubusercontent.com/assets/153/26183266/1385d308-3bc1-11e7-9834-56610fdba4b8.png">