### PR TITLE
Hide invite teams without teams

### DIFF
--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -27,6 +27,7 @@ class MemberNew extends React.PureComponent {
       name: PropTypes.string.isRequired,
       slug: PropTypes.string.isRequired,
       teams: PropTypes.shape({
+        count: PropTypes.number.isRequired,
         edges: PropTypes.arrayOf(
           PropTypes.shape({
             node: PropTypes.shape({
@@ -174,6 +175,11 @@ class MemberNew extends React.PureComponent {
       return null;
     }
 
+    // If there aren't any teams then we don't have the feature
+    if (this.props.organization.teams.count === 0) {
+      return null;
+    }
+
     const teamEdges = this.props.organization.teams.edges
       .filter(({ node }) =>
         node.name !== 'Everyone' && node.description !== 'All users in your organization'
@@ -225,6 +231,7 @@ export default Relay.createContainer(MemberNew, {
         name
         slug
         teams(first: 50) @include(if: $isMounted) {
+          count
           edges {
             node {
               id


### PR DESCRIPTION
While investigating a flakey spec I noticed the invite page shows a _Teams_ section even if the organization doesn't have teams enabled:

![image](https://cloud.githubusercontent.com/assets/14028/26186562/d653d3d0-3bd5-11e7-9173-31da77f132c3.png)

This just checks the teams count and hides teams if there aren't any at all, which should be a reasonable check because there should at least be an _Everyone_ team at the moment, and at least one team otherwise:

![image](https://cloud.githubusercontent.com/assets/14028/26186576/e231c28e-3bd5-11e7-923f-08bc1f01ad4a.png)

Which reminds me, we should probably make sure there is always at least one team in an organization.