### PR TITLE
Default teams

### DIFF
--- a/app/components/member/Edit.js
+++ b/app/components/member/Edit.js
@@ -115,7 +115,7 @@ class MemberEdit extends React.PureComponent {
     return (
       <Panel className="mb4">
         <Panel.Header>Roles</Panel.Header>
-        <Panel.Row>
+        <Panel.Section>
           <FormCheckbox
             label="Administrator"
             help="Allow this person to edit organization details, manage billing information, invite new members, change notification services and see the agent registration token."
@@ -123,7 +123,7 @@ class MemberEdit extends React.PureComponent {
             onChange={this.handleAdminChange}
             checked={this.state.isAdmin}
           />
-        </Panel.Row>
+        </Panel.Section>
         <Panel.Row>
           {saveRowContent}
         </Panel.Row>

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -32,7 +32,8 @@ class MemberNew extends React.PureComponent {
           PropTypes.shape({
             node: PropTypes.shape({
               id: PropTypes.string.isRequired,
-              slug: PropTypes.string.isRequired
+              slug: PropTypes.string.isRequired,
+              isDefaultTeam: PropTypes.bool.isRequired
             }).isRequired
           })
         ).isRequired
@@ -47,13 +48,28 @@ class MemberNew extends React.PureComponent {
 
   state = {
     emails: '',
-    teams: [],
+    teams: null, // when mounted we set this to the default teams
     role: OrganizationMemberRoleConstants.MEMBER,
     errors: null
   };
 
   componentDidMount() {
-    this.props.relay.forceFetch({ isMounted: true });
+    this.props.relay.forceFetch(
+      { isMounted: true },
+      (readyState) => {
+        if (readyState.done) {
+        }
+      }
+    );
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // Initialize state teams to default teams when mounted and we get props
+    if (this.state.teams === null && nextProps.organization.teams) {
+      this.state.teams = nextProps.organization.teams.edges
+        .filter(({ node }) => node.isDefaultTeam)
+        .map(({ node }) => node.id);
+    }
   }
 
   render() {
@@ -235,6 +251,7 @@ export default Relay.createContainer(MemberNew, {
             node {
               id
               slug
+              isDefaultTeam
               ${TeamRow.getFragment('team')}
             }
           }

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -31,7 +31,8 @@ class MemberNew extends React.PureComponent {
         edges: PropTypes.arrayOf(
           PropTypes.shape({
             node: PropTypes.shape({
-              id: PropTypes.string.isRequired
+              id: PropTypes.string.isRequired,
+              slug: PropTypes.string.isRequired
             }).isRequired
           })
         ).isRequired
@@ -181,9 +182,7 @@ class MemberNew extends React.PureComponent {
     }
 
     const teamEdges = this.props.organization.teams.edges
-      .filter(({ node }) =>
-        node.name !== 'Everyone' && node.description !== 'All users in your organization'
-      );
+      .filter(({ node }) => node.slug != 'everyone');
 
     return (
       <div>
@@ -235,8 +234,7 @@ export default Relay.createContainer(MemberNew, {
           edges {
             node {
               id
-              name
-              description
+              slug
               ${TeamRow.getFragment('team')}
             }
           }

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -60,9 +60,11 @@ class MemberNew extends React.PureComponent {
   componentWillReceiveProps(nextProps) {
     // Initialize state teams to default teams when mounted and we get props
     if (this.state.teams === null && nextProps.organization.teams) {
-      this.state.teams = nextProps.organization.teams.edges
-        .filter(({ node }) => node.isDefaultTeam)
-        .map(({ node }) => node.id);
+      this.setState({
+        teams: nextProps.organization.teams.edges
+          .filter(({ node }) => node.isDefaultTeam)
+          .map(({ node }) => node.id);
+      });
     }
   }
 

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -60,11 +60,11 @@ class MemberNew extends React.PureComponent {
   componentWillReceiveProps(nextProps) {
     // Initialize state teams to default teams when mounted and we get props
     if (this.state.teams === null && nextProps.organization.teams) {
-      this.setState({
-        teams: nextProps.organization.teams.edges
-          .filter(({ node }) => node.isDefaultTeam)
-          .map(({ node }) => node.id);
-      });
+      let defaultTeams = nextProps.organization.teams.edges
+        .filter(({ node }) => node.isDefaultTeam)
+        .map(({ node }) => node.id);
+
+      this.setState({ teams: defaultTeams });
     }
   }
 

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -54,13 +54,7 @@ class MemberNew extends React.PureComponent {
   };
 
   componentDidMount() {
-    this.props.relay.forceFetch(
-      { isMounted: true },
-      (readyState) => {
-        if (readyState.done) {
-        }
-      }
-    );
+    this.props.relay.forceFetch({ isMounted: true });
   }
 
   componentWillReceiveProps(nextProps) {

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -194,7 +194,7 @@ class MemberNew extends React.PureComponent {
     }
 
     const teamEdges = this.props.organization.teams.edges
-      .filter(({ node }) => node.slug != 'everyone');
+      .filter(({ node }) => node.slug !== 'everyone');
 
     return (
       <div>

--- a/app/components/shared/FormCheckbox.js
+++ b/app/components/shared/FormCheckbox.js
@@ -18,7 +18,7 @@ export default class FormCheckbox extends React.PureComponent {
   render() {
     return (
       <div className="mb2">
-        <label className="block cursor-pointer" style={{ paddingLeft: '1.7em' }}>
+        <label className="inline-block pl4 cursor-pointer">
           <input
             name={this.props.name}
             type="checkbox"
@@ -26,8 +26,8 @@ export default class FormCheckbox extends React.PureComponent {
             onChange={this.props.onChange}
             className="absolute"
             style={{
-              marginLeft: '-1.7em',
-              cursor: this.props.disabled ? 'not-allowed' : 'inherit'
+              marginLeft: "-20px",
+              cursor: this.props.disabled ? "not-allowed" : "inherit"
             }}
             disabled={this.props.disabled}
             ref={(_checkbox) => this._checkbox = _checkbox}

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -19,6 +19,8 @@ class TeamEdit extends React.Component {
       slug: PropTypes.string.isRequired,
       description: PropTypes.string,
       privacy: PropTypes.string.isRequired,
+      isDefaultTeam: PropTypes.bool.isRequired,
+      defaultMemberRole: PropTypes.string.isRequired,
       organization: PropTypes.shape({
         name: PropTypes.string.isRequired,
         slug: PropTypes.string.isRequired
@@ -34,6 +36,8 @@ class TeamEdit extends React.Component {
     name: this.props.team.name,
     description: this.props.team.description,
     privacy: this.props.team.privacy,
+    isDefaultTeam: this.props.team.isDefaultTeam,
+    defaultMemberRole: this.props.team.defaultMemberRole,
     saving: false,
     errors: null
   };
@@ -54,6 +58,7 @@ class TeamEdit extends React.Component {
                 name={this.state.name}
                 description={this.state.description}
                 privacy={this.state.privacy}
+                isDefaultTeam={this.state.isDefaultTeam}
               />
             </Panel.Section>
 
@@ -82,7 +87,9 @@ class TeamEdit extends React.Component {
       team: this.props.team,
       name: this.state.name,
       description: this.state.description,
-      privacy: this.state.privacy
+      privacy: this.state.privacy,
+      isDefaultTeam: this.state.isDefaultTeam,
+      defaultMemberRole: this.state.defaultMemberRole
     });
 
     Relay.Store.commitUpdate(mutation, {
@@ -118,6 +125,8 @@ export default Relay.createContainer(TeamEdit, {
         slug
         description
         privacy
+        isDefaultTeam
+        defaultMemberRole
         organization {
           name
           slug

--- a/app/components/team/Form.js
+++ b/app/components/team/Form.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import FormTextField from '../shared/FormTextField';
+import FormCheckbox from '../shared/FormCheckbox';
+import FormInputLabel from '../shared/FormInputLabel';
 import FormRadioGroup from '../shared/FormRadioGroup';
+import FormTextField from '../shared/FormTextField';
 import ValidationErrors from '../../lib/ValidationErrors';
 import TeamPrivacyConstants from '../../constants/TeamPrivacyConstants';
 
@@ -11,6 +13,7 @@ class TeamForm extends React.Component {
     name: PropTypes.string,
     description: PropTypes.string,
     privacy: PropTypes.oneOf(Object.keys(TeamPrivacyConstants)),
+    isDefaultTeam: PropTypes.bool,
     errors: PropTypes.array,
     onChange: PropTypes.func
   };
@@ -54,6 +57,16 @@ class TeamForm extends React.Component {
           ]}
         />
 
+        <FormInputLabel label="Default" />
+
+        <FormCheckbox
+          name="team-is-default-team"
+          label="Automatically add new users to this team"
+          help="Users will automatically be added to this team when they sign in with SSO"
+          checked={this.props.isDefaultTeam}
+          onChange={this.handleIsDefaultTeamChange}
+        />
+
       </div>
     );
   }
@@ -68,6 +81,10 @@ class TeamForm extends React.Component {
 
   handlePrivacyChange = (evt) => {
     this.props.onChange('privacy', evt.target.value);
+  };
+
+  handleIsDefaultTeamChange = (evt) => {
+    this.props.onChange('isDefaultTeam', evt.target.checked);
   };
 }
 

--- a/app/components/team/New.js
+++ b/app/components/team/New.js
@@ -10,6 +10,7 @@ import TeamForm from './Form';
 
 import TeamCreateMutation from '../../mutations/TeamCreate';
 import GraphQLErrors from '../../constants/GraphQLErrors';
+import TeamMemberRoleConstants from '../../constants/TeamMemberRoleConstants';
 import TeamPrivacyConstants from '../../constants/TeamPrivacyConstants';
 
 class TeamNew extends React.Component {
@@ -28,6 +29,8 @@ class TeamNew extends React.Component {
     name: '',
     description: '',
     privacy: TeamPrivacyConstants.VISIBLE,
+    isDefaultTeam: false,
+    defaultMemberRole: TeamMemberRoleConstants.MEMBER,
     saving: false,
     errors: null
   };
@@ -48,6 +51,7 @@ class TeamNew extends React.Component {
                 name={this.state.name}
                 description={this.state.description}
                 privacy={this.state.privacy}
+                isDefaultTeam={this.state.isDefaultTeam}
               />
             </Panel.Section>
 
@@ -76,7 +80,9 @@ class TeamNew extends React.Component {
       organization: this.props.organization,
       name: this.state.name,
       description: this.state.description,
-      privacy: this.state.privacy
+      privacy: this.state.privacy,
+      isDefaultTeam: this.state.isDefaultTeam,
+      defaultMemberRole: this.state.defaultMemberRole
     });
 
     Relay.Store.commitUpdate(mutation, {

--- a/app/components/team/Row.js
+++ b/app/components/team/Row.js
@@ -19,6 +19,7 @@ class TeamRow extends React.PureComponent {
       description: PropTypes.string,
       slug: PropTypes.string.isRequired,
       privacy: PropTypes.string.isRequired,
+      isDefaultTeam: PropTypes.bool.isRequired,
       organization: PropTypes.shape({
         slug: PropTypes.string.isRequired
       }).isRequired,
@@ -41,7 +42,7 @@ class TeamRow extends React.PureComponent {
       <Panel.RowLink key={this.props.team.id} to={`/organizations/${this.props.team.organization.slug}/teams/${this.props.team.slug}`}>
         <div className="flex flex-stretch items-center line-height-1" style={{ minHeight: '3em' }}>
           <div className="flex-auto">
-            <div className="m0 flex items-center"><Emojify text={this.props.team.name} className="semi-bold" />{this._renderPrivacyLabel()}</div>
+            <div className="m0 flex items-center"><Emojify text={this.props.team.name} className="semi-bold" />{this._renderPrivacyLabel()}{this._renderDefaultLabel()}</div>
             {this._renderDescription()}
           </div>
           <div className="flex flex-none flex-stretch items-center my1">
@@ -57,6 +58,14 @@ class TeamRow extends React.PureComponent {
     if (this.props.team.privacy === TeamPrivacyConstants.SECRET) {
       return (
         <div className="ml1 regular small border border-gray rounded dark-gray p1">Secret</div>
+      );
+    }
+  }
+
+  _renderDefaultLabel() {
+    if (this.props.team.isDefaultTeam) {
+      return (
+        <div className="ml1 regular small border border-gray rounded dark-gray p1">Default</div>
       );
     }
   }
@@ -130,6 +139,7 @@ export default Relay.createContainer(TeamRow, {
         description
         slug
         privacy
+        isDefaultTeam
         organization {
           slug
         }

--- a/app/mutations/TeamCreate.js
+++ b/app/mutations/TeamCreate.js
@@ -60,7 +60,14 @@ class TeamCreate extends Relay.Mutation {
   }
 
   getVariables() {
-    return { organizationID: this.props.organization.id, name: this.props.name, description: this.props.description, privacy: this.props.privacy };
+    return {
+      organizationID: this.props.organization.id,
+      name: this.props.name,
+      description: this.props.description,
+      privacy: this.props.privacy,
+      isDefaultTeam: this.props.isDefaultTeam,
+      defaultMemberRole: this.props.defaultMemberRole
+    };
   }
 }
 

--- a/app/mutations/TeamUpdate.js
+++ b/app/mutations/TeamUpdate.js
@@ -25,6 +25,8 @@ class TeamUpdate extends Relay.Mutation {
           slug
           description
           privacy
+          isDefaultTeam
+          defaultMemberRole
         }
       }
     `;
@@ -40,7 +42,14 @@ class TeamUpdate extends Relay.Mutation {
   }
 
   getVariables() {
-    return { id: this.props.team.id, name: this.props.name, description: this.props.description, privacy: this.props.privacy };
+    return {
+      id: this.props.team.id,
+      name: this.props.name,
+      description: this.props.description,
+      privacy: this.props.privacy,
+      isDefaultTeam: this.props.isDefaultTeam,
+      defaultMemberRole: this.props.defaultMemberRole
+    };
   }
 }
 


### PR DESCRIPTION
Adds a checkbox to team create and edit forms to toggle whether a team is a "default" team:

![image](https://cloud.githubusercontent.com/assets/14028/26233845/9e5b2c84-3ca3-11e7-9798-54ce14f13200.png)

Also marks which teams are default in the teams list:

![image](https://cloud.githubusercontent.com/assets/14028/26233839/95113376-3ca3-11e7-9a25-50a33fc7f35a.png)

And pre-selects default teams on the invite page:

![image](https://cloud.githubusercontent.com/assets/14028/26233860/c0b10c04-3ca3-11e7-8fe8-96b03378c651.png)

I think my backend changes broke the team create and edit forms by making the default fields required as part of the mutation input so maybe should get these changes in asap.