### PR TITLE
Work around webpack-dev-server hostname checking requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ ADD package.json yarn.lock /frontend/
 RUN yarn install
 
 ADD . /frontend/
+
 CMD ["npm", "start"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,9 +1,9 @@
-version: '2'
+version: '2.1'
 
 services:
   frontend:
     volumes:
-      - ".:/frontend:cached,ro"
+      - ".:/frontend:cached"
       - "./bundle-analysis:/frontend/bundle-analysis"
       - "./dist:/frontend/dist"
       - "./coverage:/frontend/coverage"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 services:
   frontend:
@@ -8,9 +8,11 @@ services:
       - "./bundle-analysis:/frontend/bundle-analysis"
       - "./dist:/frontend/dist"
       - "./coverage:/frontend/coverage"
+    extra_hosts:
+     - "buildkite.dev:0.0.0.0" # fix for hostname checking in webpack-dev-server
     environment:
-      - EMOJI_HOST
-      - FRONTEND_HOST
+      - EMOJI_HOST=${EMOJI_HOST:-http://buildkite.dev:4890/_frontend/dist/}
+      - FRONTEND_HOST=${FRONTEND_HOST:-http://buildkite.dev:4890/_frontend/vendor/emojis/}
       - BUILDKITE
       - BUILDKITE_COMMIT
       - BUILDKITE_ORGANIZATION_SLUG

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "env": "env",
-    "start": "NODE_ENV=development webpack-dev-server --config webpack/config.js --progress --colors --cache --inline --hot --port 4890",
+    "start": "NODE_ENV=development webpack-dev-server --config webpack/config.js --progress --colors --cache --inline --hot --host buildkite.dev --port 4890",
     "test": "jest",
     "test-with-coverage": "jest --coverage",
     "lint": "eslint .",


### PR DESCRIPTION
To fix security things, webpack-dev-server added a check for hostname in https://github.com/webpack/webpack-dev-server/issues/887. 

Unfortunately, they also used that host check as the address to bind to, with only 127.0.0.1 and localhost as exceptions. This breaks docker containers or proxies. 

The workaround is to set up a host entry in the container for `buildkite.dev` to point to `0.0.0.0`. This then still has the hostname check, but it binds to the correct interface in the container.
