### PR TITLE
Upgrade to styled-components v2

### DIFF
--- a/app/components/layout/Navigation/MyBuilds/build.js
+++ b/app/components/layout/Navigation/MyBuilds/build.js
@@ -13,15 +13,13 @@ import { buildStatus } from '../../../../lib/builds';
 import { shortMessage } from '../../../../lib/commits';
 import { getDateString } from '../../../../lib/date';
 
-const BuildLink = styled.a`
+const BuildLink = styled.a.attrs({
+  className: 'flex text-decoration-none dark-gray hover-lime mb2'
+})`
   &:hover .build-link-message {
     color: inherit;
   }
 `;
-
-BuildLink.defaultProps = {
-  className: "flex text-decoration-none dark-gray hover-lime mb2"
-};
 
 class BuildsDropdownBuild extends React.PureComponent {
   static propTypes = {

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -15,17 +15,15 @@ import Builds from './builds';
 import permissions from '../../../lib/permissions';
 import { repositoryProviderIcon } from '../../../lib/repositories';
 
-const HeaderVitals = styled.div`
+const HeaderVitals = styled.div.attrs({
+  className: 'flex flex-auto items-center my2'
+})`
   flex-basis: 100%;
 
   @media (min-width: 768px) {
     flex-basis: 320px;
   }
 `;
-
-HeaderVitals.defaultProps = {
-  className: 'flex flex-auto items-center my2'
-};
 
 const HeaderBuilds = styled(Builds)`
   flex: 1 1 auto;

--- a/app/components/shared/Dialog.js
+++ b/app/components/shared/Dialog.js
@@ -7,7 +7,9 @@ import Icon from './Icon';
 
 const BUTTON_SIZE = 30;
 
-const CloseButton = styled.button`
+const CloseButton = styled.button.attrs({
+  className: 'absolute circle shadow-subtle bg-white bold flex items-center cursor-pointer border border-white p0 hover-lime focus-lime'
+})`
   top: ${-BUTTON_SIZE / 2}px;
   right: ${-BUTTON_SIZE / 2}px;
   width: ${BUTTON_SIZE}px;
@@ -18,11 +20,9 @@ const CloseButton = styled.button`
   }
 `;
 
-CloseButton.defaultProps = {
-  className: 'absolute circle shadow-subtle bg-white bold flex items-center cursor-pointer border border-white p0 hover-lime focus-lime'
-};
-
-const DialogBackdrop = styled.div`
+const DialogBackdrop = styled.div.attrs({
+  className: 'absolute bg-white'
+})`
   top: 0;
   left: 0;
   bottom: 0;
@@ -30,11 +30,9 @@ const DialogBackdrop = styled.div`
   opacity: 0.9;
 `;
 
-DialogBackdrop.defaultProps = {
-  className: 'absolute bg-white'
-};
-
-const DialogContainer = styled.div`
+const DialogContainer = styled.div.attrs({
+  className: 'flex flex-column'
+})`
   width: 100vw;
   maxWidth: 100%;
   height: 100%;
@@ -53,31 +51,23 @@ const DialogContainer = styled.div`
 // which would otherwise be applied, but is ignored by both
 // Firefox and Safari!
 
-DialogContainer.defaultProps = {
-  className: 'flex flex-column'
-};
-
-const DialogBox = styled.div`
+const DialogBox = styled.div.attrs({
+  className: 'background bg-white rounded-3 shadow-subtle relative'
+})`
   width: 100%;
   maxWidth: ${(props) => props.width}px;
   margin: auto;
 `;
 
-DialogBox.defaultProps = {
-  className: 'background bg-white rounded-3 shadow-subtle relative'
-};
-
-const DialogWrapper = styled.div`
+const DialogWrapper = styled.div.attrs({
+  className: 'fixed'
+})`
   top: 0;
   left: 0;
   bottom: 0;
   right: 0;
   z-index: 1000;
 `;
-
-DialogWrapper.defaultProps = {
-  className: 'fixed'
-};
 
 class Dialog extends React.Component {
   static propTypes = {

--- a/app/components/shared/Popover/index.js
+++ b/app/components/shared/Popover/index.js
@@ -10,16 +10,14 @@ const ScrollZone = styled.div`
   -webkit-overflow-scrolling: touch;
 `;
 
-const Nib = styled.img`
+const Nib = styled.img.attrs({
+  className: 'absolute pointer-events-none'
+})`
   top: -20px;
   width: ${NIB_WIDTH}px;
   height: 20px;
   z-index: 3;
 `;
-
-Nib.defaultProps = {
-  className: 'absolute pointer-events-none'
-};
 
 export default class Popover extends React.PureComponent {
   static propTypes = {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react-type-snob": "^0.0.3",
     "search-query-parser": "^1.3.0",
     "shuffle-array": "^1.0.0",
-    "styled-components": "^1.4.4",
+    "styled-components": "^2.0.0",
     "throttleit": "^1.0.0",
     "uuid": "^3.0.1",
     "webpack-bundle-analyzer": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,7 +1329,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.0.2:
+buffer@^5.0.3:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.6.tgz#2ea669f7eec0b6eda05b08f8b5ff661b28573588"
   dependencies:
@@ -1574,10 +1574,6 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@0.5.x:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
-
 colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
@@ -1795,15 +1791,9 @@ css-color-function@^1.2.0:
     debug "~0.7.4"
     rgb "~0.1.0"
 
-css-color-list@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/css-color-list/-/css-color-list-0.0.1.tgz#8718e8695ae7a2cc8787be8715f1c008a7f28b15"
-  dependencies:
-    css-color-names "0.0.1"
-
-css-color-names@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.1.tgz#5d0548fa256456ede4a9a0c2ac7ab19d3eb1ad81"
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
 
 css-color-names@0.0.4:
   version "0.0.4"
@@ -1842,13 +1832,13 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-to-react-native@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-1.0.6.tgz#728c7e774e56536558a0ecaa990d9507c43a4ac4"
+css-to-react-native@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.0.4.tgz#cf4cc407558b3474d4ba8be1a2cd3b6ce713101b"
   dependencies:
-    css-color-list "0.0.1"
+    css-color-keywords "^1.0.0"
     fbjs "^0.8.5"
-    nearley "^2.7.7"
+    postcss-value-parser "^3.3.0"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -2114,10 +2104,6 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
-
-discontinuous-range@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
 doc-chomp@1.1.0, doc-chomp@^1.1.0:
   version "1.1.0"
@@ -2768,7 +2754,7 @@ fbjs@^0.6.1:
     ua-parser-js "^0.7.9"
     whatwg-fetch "^0.9.0"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.7, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -4840,14 +4826,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-nearley@^2.7.7:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.8.0.tgz#7f88b503e3b373503f5c7e5b3b52bf134c86145b"
-  dependencies:
-    nomnom "~1.6.2"
-    railroad-diagrams "^1.0.0"
-    randexp "^0.4.2"
-
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
@@ -4917,13 +4895,6 @@ node-pre-gyp@^0.6.29:
 node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
-
-nomnom@~1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
-  dependencies:
-    colors "0.5.x"
-    underscore "~1.4.4"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -5958,17 +5929,6 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
-railroad-diagrams@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
-
-randexp@^0.4.2:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.5.tgz#ffe3a80c3f666cd71e6b008e477e584c1a32ff3e"
-  dependencies:
-    discontinuous-range "1.0.0"
-    ret "~0.1.10"
-
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
@@ -6413,10 +6373,6 @@ restore-cursor@^1.0.1:
   dependencies:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
-
-ret@~0.1.10:
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.14.tgz#58c636837b12e161f8a380cf081c6a230fd1664e"
 
 rgb-hex@^1.0.0:
   version "1.0.0"
@@ -6867,18 +6823,24 @@ style-loader@^0.14.1:
   dependencies:
     loader-utils "^1.0.2"
 
-styled-components@^1.4.4:
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-1.4.6.tgz#58f32e8a6ab510fb1481e901e838e0477f148b06"
+styled-components@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.0.0.tgz#0906652b77647e7400ca7e5a6d8d45eba6fa77ec"
   dependencies:
-    buffer "^5.0.2"
-    css-to-react-native "^1.0.6"
-    fbjs "^0.8.7"
+    buffer "^5.0.3"
+    css-to-react-native "^2.0.3"
+    fbjs "^0.8.9"
+    hoist-non-react-statics "^1.2.0"
     inline-style-prefixer "^2.0.5"
     is-function "^1.0.1"
     is-plain-object "^2.0.1"
     prop-types "^15.5.4"
-    supports-color "^3.1.2"
+    stylis "^2.0.0"
+    supports-color "^3.2.3"
+
+stylis@^2.0.0:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-2.0.12.tgz#547253055d170f2a7ac2f6d09365d70635f2bec6"
 
 sum-up@^1.0.1:
   version "1.0.3"
@@ -7134,10 +7096,6 @@ uglify-to-browserify@~1.0.0:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
-
-underscore@~1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
[styled-components v2](https://medium.com/styled-components/announcing-v2-f01ef3766ac2) just landed!

We can finally dust off the old test branch which used `attrs` rather than `defaultProps`! Hooray!