### PR TITLE
Ask GraphQL for agent priority, too

### DIFF
--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -316,6 +316,7 @@ export default Relay.createContainer(AgentShow, {
         operatingSystem {
           name
         }
+        priority
         permissions {
           agentStop {
             allowed


### PR DESCRIPTION
We seem to have missed a field in the graphql query required for showing the agent priority on the new agent show page, so here's a tiny change to include it!

I wonder if we should be showing priority in the agent index as well?

### Before

![image](https://cloud.githubusercontent.com/assets/14028/26619265/0143b286-4621-11e7-9c8f-1f72c1317ec9.png)

### After

![image](https://cloud.githubusercontent.com/assets/14028/26619237/e6edfc98-4620-11e7-83fc-4772687fc4f3.png)