### PR TITLE
Purify components

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -71,8 +71,10 @@ rules:
   linebreak-style: error
   no-const-assign: error
   no-duplicate-imports: error
+  no-else-return: warn
   no-eval: error
   no-implied-eval: error
+  no-multi-spaces: error
   no-new-require: error
   no-trailing-spaces: error
   no-unsafe-negation: error
@@ -127,6 +129,10 @@ rules:
     - error
     - never
 
+  react/jsx-first-prop-new-line:
+    - error
+    - multiline
+
   react/jsx-handler-names: error
 
   react/jsx-indent:
@@ -138,14 +144,18 @@ rules:
     - 2
 
   react/jsx-key: error
-  react/jsx-max-props-per-line: off
+  react/jsx-max-props-per-line:
+    - error
+    - when: multiline
 
   react/jsx-no-bind:
     - warn
     - ignoreRefs: true
 
+  react/jsx-no-comment-textnodes: error
   react/jsx-no-duplicate-props: error
   react/jsx-no-literals: off
+  react/jsx-no-target-blank: error
   react/jsx-no-undef: error
   react/jsx-pascal-case: error
   react/jsx-sort-prop-types: off
@@ -153,7 +163,9 @@ rules:
   react/jsx-uses-react: error
   react/jsx-uses-vars: error
   react/jsx-wrap-multilines: error
+  react/no-array-index-key: warn
   react/no-danger: off
+  react/no-danger-with-children: error
   react/no-deprecated: error
   react/no-did-mount-set-state: error
   react/no-did-update-set-state: error
@@ -166,17 +178,17 @@ rules:
 
   react/no-set-state: off
   react/no-string-refs: error
+  react/no-unescaped-entities: error
   react/no-unknown-property: error
-
-  react/no-unused-prop-types:
-    - error
-    - skipShapeProps: true
-
+  react/no-unused-prop-types: error
   react/prefer-es6-class: error
   react/prefer-stateless-function: off
   react/prop-types: error
   react/react-in-jsx-scope: error
   react/require-optimization: error
+  react/require-render-return: error
   react/self-closing-comp: warn
   react/sort-comp: off
   react/style-prop-object: warn
+  react/jsx-tag-spacing: error
+  react/void-dom-elements-no-children: error

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -176,7 +176,7 @@ rules:
   react/prefer-stateless-function: off
   react/prop-types: error
   react/react-in-jsx-scope: error
-  react/require-optimization: warn
+  react/require-optimization: error
   react/self-closing-comp: warn
   react/sort-comp: off
   react/style-prop-object: warn

--- a/app/app.js
+++ b/app/app.js
@@ -91,9 +91,9 @@ window["Webpack"] = {
 
     if (exported) {
       return exported;
-    } else {
-      throw "No webpack module exported `" + module + "`";
     }
+
+    throw "No webpack module exported `" + module + "`";
   }
 };
 

--- a/app/components/Main.js
+++ b/app/components/Main.js
@@ -7,7 +7,7 @@ import Navigation from './layout/Navigation';
 import Footer from './layout/Footer';
 import Flashes from './layout/Flashes';
 
-class Main extends React.Component {
+class Main extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
     viewer: PropTypes.object.isRequired,
@@ -16,7 +16,7 @@ class Main extends React.Component {
 
   render() {
     return (
-      <DocumentTitle title={`Buildkite`}>
+      <DocumentTitle title="Buildkite">
         <div>
           <Navigation organization={this.props.organization} viewer={this.props.viewer} />
           <Flashes />

--- a/app/components/agent/Index/AgentTokenItem.js
+++ b/app/components/agent/Index/AgentTokenItem.js
@@ -5,7 +5,7 @@ import { createFragmentContainer, graphql } from 'react-relay/compat';
 import Panel from '../../shared/Panel';
 import RevealButton from '../../shared/RevealButton';
 
-class AgentTokenItem extends React.Component {
+class AgentTokenItem extends React.PureComponent {
   static propTypes = {
     agentToken: PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/app/components/agent/Index/AgentTokenList.js
+++ b/app/components/agent/Index/AgentTokenList.js
@@ -56,20 +56,20 @@ class AgentTokenList extends React.Component {
             <AgentTokenItem key={edge.node.id} agentToken={edge.node} showDescription={this.props.organization.agentTokens.edges.length > 1} />
           );
         });
-      } else {
-        return (
-          <Panel.Section>
-            <p className="dark-gray">You don’t have permission to see your organization’s Agent tokens.</p>
-          </Panel.Section>
-        );
       }
-    } else {
+
       return (
-        <Panel.Section className="center">
-          <Spinner />
+        <Panel.Section>
+          <p className="dark-gray">You don’t have permission to see your organization’s Agent tokens.</p>
         </Panel.Section>
       );
     }
+
+    return (
+      <Panel.Section className="center">
+        <Spinner />
+      </Panel.Section>
+    );
   }
 }
 

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -263,9 +263,9 @@ class Agents extends React.PureComponent {
   handleSearch = (query) => {
     if (this.useLocalSearch) {
       return this.handleLocalSearch(query);
-    } else {
-      return this.handleRemoteSearch(query);
     }
+
+    return this.handleRemoteSearch(query);
   };
 
   handleLocalSearch = (query) => {

--- a/app/components/agent/Index/index.js
+++ b/app/components/agent/Index/index.js
@@ -10,7 +10,7 @@ import AgentTokenList from './AgentTokenList';
 import AgentInstallation from './installation';
 import QuickStart from './quick-start';
 
-class AgentIndex extends React.Component {
+class AgentIndex extends React.PureComponent {
   static propTypes = {
     location: PropTypes.shape({
       query: PropTypes.object

--- a/app/components/agent/Index/row.js
+++ b/app/components/agent/Index/row.js
@@ -7,7 +7,7 @@ import StateIcon from '../state-icon';
 import Panel from '../../shared/Panel';
 import JobLink from '../../shared/JobLink';
 
-class AgentRow extends React.Component {
+class AgentRow extends React.PureComponent {
   static propTypes = {
     agent: PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/app/components/api_access_token_code/APIAccessTokenCodeAuthorize.js
+++ b/app/components/api_access_token_code/APIAccessTokenCodeAuthorize.js
@@ -70,11 +70,11 @@ class APIAccessTokenCodeAuthorize extends React.Component {
       return (
         <Spinner />
       );
-    } else {
-      return (
-        <Button onClick={this.handleAuthorizeButtonClick}>Authorize</Button>
-      );
     }
+
+    return (
+      <Button onClick={this.handleAuthorizeButtonClick}>Authorize</Button>
+    );
   }
 
   handleAuthorizeButtonClick = () => {

--- a/app/components/build/CommentsList.js
+++ b/app/components/build/CommentsList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Relay from 'react-relay/classic';
 
-class CommentsList extends React.Component {
+class CommentsList extends React.PureComponent {
   render() {
     return (
       <span>Comments</span>

--- a/app/components/icons/BuildState.js
+++ b/app/components/icons/BuildState.js
@@ -78,7 +78,7 @@ class BuildState extends React.PureComponent {
             strokeWidth={strokeWidth * 2}
           />
           <clipPath id={strokeClipPathId}>
-            <use xlinkHref={`#${outerCircleId}`}/>
+            <use xlinkHref={`#${outerCircleId}`} />
           </clipPath>
           {defs}
         </defs>

--- a/app/components/icons/Pipeline.js
+++ b/app/components/icons/Pipeline.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-class Pipeline extends React.Component {
+export default class Pipeline extends React.PureComponent {
   render() {
     return (
       <svg width="80px" height="80px" viewBox="0 0 90 90">
@@ -33,5 +33,3 @@ class Pipeline extends React.Component {
     );
   }
 }
-
-export default Pipeline;

--- a/app/components/job/Index/jobs.js
+++ b/app/components/job/Index/jobs.js
@@ -110,28 +110,28 @@ class Jobs extends React.PureComponent {
           <Spinner />
         </Panel.Section>
       );
-    } else {
-      if (jobs.edges.length === 0) {
-        return (
-          <Panel.Section className="center">
-            <div>
+    }
+
+    if (jobs.edges.length === 0) {
+      return (
+        <Panel.Section className="center">
+          <div>
               No jobs could be found
             </div>
-          </Panel.Section>
-        );
-      } else {
-        return jobs.edges.map((edge) => {
-          return (
-            <Row
-              key={edge.node.id}
-              job={edge.node}
-              onConcurrencyGroupClick={this.handleConcurrencyGroupClick}
-              onAgentQueryRuleClick={this.handleAgentQueryRuleClick}
-            />
-          );
-        });
-      }
+        </Panel.Section>
+      );
     }
+
+    return jobs.edges.map((edge) => {
+      return (
+        <Row
+          key={edge.node.id}
+          job={edge.node}
+          onConcurrencyGroupClick={this.handleConcurrencyGroupClick}
+          onAgentQueryRuleClick={this.handleAgentQueryRuleClick}
+        />
+      );
+    });
   }
 
   renderFooter() {

--- a/app/components/layout/Flashes/index.js
+++ b/app/components/layout/Flashes/index.js
@@ -110,9 +110,9 @@ class Flashes extends React.PureComponent {
           ))}
         </div>
       );
-    } else {
-      return null;
     }
+
+    return null;
   }
 
   handleFlashRemove = (flash) => {

--- a/app/components/layout/Footer/index.js
+++ b/app/components/layout/Footer/index.js
@@ -5,7 +5,7 @@ import Relay from 'react-relay/classic';
 import Link from './link';
 import Icon from '../../shared/Icon';
 
-class Footer extends React.Component {
+class Footer extends React.PureComponent {
   static propTypes = {
     viewer: PropTypes.shape({
       unreadChangelogs: PropTypes.shape({

--- a/app/components/layout/Footer/link.js
+++ b/app/components/layout/Footer/link.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class Link extends React.Component {
+export default class Link extends React.PureComponent {
   static displayName = "Footer.Link";
 
   static propTypes = {
@@ -15,5 +15,3 @@ class Link extends React.Component {
     );
   }
 }
-
-export default Link;

--- a/app/components/layout/Navigation/MyBuilds/index.js
+++ b/app/components/layout/Navigation/MyBuilds/index.js
@@ -118,9 +118,9 @@ class MyBuilds extends React.Component {
     // setup instructions.
     if (this.props.viewer.user.builds.edges.length > 0) {
       return this.renderBuilds();
-    } else {
-      return this.renderSetupInstructions();
     }
+
+    return this.renderSetupInstructions();
   }
 
   renderBuilds() {

--- a/app/components/layout/Navigation/dropdown-button.js
+++ b/app/components/layout/Navigation/dropdown-button.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-class DropdownButton extends React.Component {
+export default class DropdownButton extends React.PureComponent {
   static displayName = "Navigation.DropdownButton";
 
   static propTypes = {
@@ -22,5 +22,3 @@ class DropdownButton extends React.Component {
     );
   }
 }
-
-export default DropdownButton;

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -271,7 +271,8 @@ class Navigation extends React.PureComponent {
             <NavigationButton className="py0 xs-hide sm-hide" onClick={this.handleSupportClick}>Support</NavigationButton>
 
             <Dropdown width={170} className="flex" ref={(userDropdown) => this.userDropdown = userDropdown} onToggle={this.handleUserDropdownToggle}>
-              <DropdownButton className={classNames("py0", { "lime": this.state.showingUserDropdown })}
+              <DropdownButton
+                className={classNames("py0", { "lime": this.state.showingUserDropdown })}
                 style={{ paddingRight: 0 }}
               >
                 <UserAvatar user={this.props.viewer.user} className="flex-none flex items-center" style={{ width: 26, height: 26 }} />

--- a/app/components/layout/Navigation/navigation-button.js
+++ b/app/components/layout/Navigation/navigation-button.js
@@ -41,10 +41,10 @@ export default class NavigationButton extends React.PureComponent {
       return (
         <Link to={this.props.href} {...props}>{this.props.children}</Link>
       );
-    } else {
-      return (
-        <a href={this.props.href} {...props}>{this.props.children}</a>
-      );
     }
+
+    return (
+      <a href={this.props.href} {...props}>{this.props.children}</a>
+    );
   }
 }

--- a/app/components/layout/Navigation/navigation-button.js
+++ b/app/components/layout/Navigation/navigation-button.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Link } from 'react-router';
 
-class NavigationButton extends React.Component {
+export default class NavigationButton extends React.PureComponent {
   static displayName = "Navigation.NavigationButton";
 
   static propTypes = {
@@ -19,6 +19,9 @@ class NavigationButton extends React.Component {
     linkIf: false
   };
 
+  // NOTE: This uses PureComponent despite using `this.context`
+  // as it is *not* possible for a single component instance to
+  // move to or from a Router-controlled context in one lifetime
   static contextTypes = {
     router: PropTypes.object
   };
@@ -45,5 +48,3 @@ class NavigationButton extends React.Component {
     }
   }
 }
-
-export default NavigationButton;

--- a/app/components/member/Edit/team-memberships/chooser.js
+++ b/app/components/member/Edit/team-memberships/chooser.js
@@ -92,13 +92,13 @@ class Chooser extends React.Component {
           Could not find a team with name <em>{teamAddSearch}</em>
         </AutocompleteDialog.ErrorMessage>
       ];
-    } else {
-      return [
-        <AutocompleteDialog.ErrorMessage key="error">
-          {`Could not find any more teams ${this.props.isSelf ? 'to join' : 'to add'}`}
-        </AutocompleteDialog.ErrorMessage>
-      ];
     }
+
+    return [
+      <AutocompleteDialog.ErrorMessage key="error">
+        {`Could not find any more teams ${this.props.isSelf ? 'to join' : 'to add'}`}
+      </AutocompleteDialog.ErrorMessage>
+    ];
   }
 
   handleDialogOpen = () => {

--- a/app/components/member/Index.js
+++ b/app/components/member/Index.js
@@ -19,7 +19,7 @@ import Row from './Row';
 
 import OrganizationMemberRoleConstants from '../../constants/OrganizationMemberRoleConstants';
 
-const ORGANIZATION_ROLES =  [
+const ORGANIZATION_ROLES = [
   { name: 'Everyone', id: null },
   { name: 'Administrators', id: OrganizationMemberRoleConstants.ADMIN },
   { name: 'Users', id: OrganizationMemberRoleConstants.MEMBER }
@@ -165,17 +165,17 @@ class MemberIndex extends React.PureComponent {
           <Spinner />
         </Panel.Section>
       );
-    } else {
-      return members.edges.map((edge) => {
-        return (
-          <Row
-            key={edge.node.id}
-            organization={this.props.organization}
-            organizationMember={edge.node}
-          />
-        );
-      });
     }
+
+    return members.edges.map((edge) => {
+      return (
+        <Row
+          key={edge.node.id}
+          organization={this.props.organization}
+          organizationMember={edge.node}
+        />
+      );
+    });
   }
 
   renderMemberFooter() {
@@ -276,9 +276,10 @@ class MemberIndex extends React.PureComponent {
           <Spinner />
         </Panel.Section>
       );
-    } else {
-      if (invitations.edges.length > 0) {
-        return (
+    }
+
+    if (invitations.edges.length > 0) {
+      return (
           invitations.edges.map((edge) => {
             return (
               <InvitationRow
@@ -288,15 +289,14 @@ class MemberIndex extends React.PureComponent {
               />
             );
           })
-        );
-      } else {
-        return (
-          <Panel.Section>
-            <div className="dark-gray">There are no pending invitations</div>
-          </Panel.Section>
-        );
-      }
+      );
     }
+
+    return (
+      <Panel.Section>
+        <div className="dark-gray">There are no pending invitations</div>
+      </Panel.Section>
+    );
   }
 
   renderInvitationFooter() {

--- a/app/components/organization/Pipeline/Metrics/metric.js
+++ b/app/components/organization/Pipeline/Metrics/metric.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import classNames from 'classnames';
 
-class Metric extends React.Component {
+class Metric extends React.PureComponent {
   static propTypes = {
     pipelineMetric: PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/app/components/organization/Pipeline/Metrics/metric.js
+++ b/app/components/organization/Pipeline/Metrics/metric.js
@@ -36,11 +36,11 @@ class Metric extends React.PureComponent {
       return (
         <span className={classNames(valueClasses, "truncate")}>{this.props.pipelineMetric.value}</span>
       );
-    } else {
-      return (
-        <span className={classNames(valueClasses, "gray")}>-</span>
-      );
     }
+
+    return (
+      <span className={classNames(valueClasses, "gray")}>-</span>
+    );
   }
 }
 

--- a/app/components/organization/Pipeline/bar.js
+++ b/app/components/organization/Pipeline/bar.js
@@ -70,7 +70,8 @@ class Bar extends React.PureComponent {
           style={{ height: '100%', left: this.props.left, bottom: 0 }}
           width={300}
         >
-          <a href={this.props.href}
+          <a
+            href={this.props.href}
             className="border-box inline-block color-inherit"
             style={{ height: '100%', width: BAR_WIDTH_WITH_SEPERATOR }}
             onMouseOver={this.handleMouseOver}
@@ -96,20 +97,20 @@ class Bar extends React.PureComponent {
           />
         </AnchoredPopover>
       );
-    } else {
-      return (
-        <div
-          className="border-box inline-block absolute"
-          style={{
-            height: BAR_HEIGHT_MINIMUM,
-            left: this.props.left,
-            width: BAR_WIDTH,
-            bottom: 0,
-            border: `1px solid ${backgroundColor}`
-          }}
-        />
-      );
     }
+
+    return (
+      <div
+        className="border-box inline-block absolute"
+        style={{
+          height: BAR_HEIGHT_MINIMUM,
+          left: this.props.left,
+          width: BAR_WIDTH,
+          bottom: 0,
+          border: `1px solid ${backgroundColor}`
+        }}
+      />
+    );
   }
 }
 

--- a/app/components/organization/Pipeline/graph.js
+++ b/app/components/organization/Pipeline/graph.js
@@ -164,9 +164,9 @@ class Graph extends React.Component {
       return SKIPPED_COLOR;
     } else if (build.state === BuildStates.NOT_RUN) {
       return NOT_RUN_COLOR;
-    } else {
-      return FAILED_COLOR;
     }
+
+    return FAILED_COLOR;
   }
 
   hoverColorForBuild(build) {
@@ -180,9 +180,9 @@ class Graph extends React.Component {
       return SKIPPED_COLOR_HOVER;
     } else if (build.state === BuildStates.NOT_RUN) {
       return NOT_RUN_COLOR_HOVER;
-    } else {
-      return FAILED_COLOR_HOVER;
     }
+
+    return FAILED_COLOR_HOVER;
   }
 
   toggleRenderInterval(buildEdges) {

--- a/app/components/organization/Pipeline/status.js
+++ b/app/components/organization/Pipeline/status.js
@@ -36,7 +36,8 @@ class Status extends React.Component {
 
       return (
         <AnchoredPopover>
-          <a href={build.url}
+          <a
+            href={build.url}
             className="color-inherit relative"
             onMouseOver={this.handleMouseOver}
             onMouseOut={this.handleMouseOut}

--- a/app/components/organization/Pipeline/status.js
+++ b/app/components/organization/Pipeline/status.js
@@ -48,11 +48,11 @@ class Status extends React.Component {
           <BuildTooltip build={build} visible={this.state.hover} left={-8} top={44} />
         </AnchoredPopover>
       );
-    } else {
-      return (
-        <BuildState.Regular state={null} />
-      );
     }
+
+    return (
+      <BuildState.Regular state={null} />
+    );
   }
 
   handleMouseOver = () => {

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -157,11 +157,11 @@ class OrganizationPipelines extends React.Component {
           {`No pipelines matching “${this.props.filter}”`}
         </p>
       );
-    } else {
-      return (
-        <Welcome organizationSlug={this.props.organization.slug} />
-      );
     }
+
+    return (
+      <Welcome organizationSlug={this.props.organization.slug} />
+    );
   }
 
   renderPipelines() {

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -159,7 +159,7 @@ class OrganizationPipelines extends React.Component {
       );
     } else {
       return (
-        <Welcome organization={this.props.organization.slug} />
+        <Welcome organizationSlug={this.props.organization.slug} />
       );
     }
   }

--- a/app/components/organization/SettingsSection.js
+++ b/app/components/organization/SettingsSection.js
@@ -5,7 +5,7 @@ import Relay from 'react-relay/classic';
 import PageWithMenu from '../shared/PageWithMenu';
 import SettingsMenu from './SettingsMenu';
 
-class SettingsSection extends React.Component {
+class SettingsSection extends React.PureComponent {
   static propTypes = {
     organization: PropTypes.object.isRequired,
     children: PropTypes.node.isRequired

--- a/app/components/organization/Show.js
+++ b/app/components/organization/Show.js
@@ -80,7 +80,7 @@ class OrganizationShow extends React.Component {
                 href={`/organizations/${this.props.organization.slug}/pipelines/new`}
                 title="New Pipeline"
               >
-                <Icon icon="plus" title="New Pipeline"/>
+                <Icon icon="plus" title="New Pipeline" />
               </Button>
             </div>
 

--- a/app/components/organization/Welcome.js
+++ b/app/components/organization/Welcome.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 
 import PipelineIcon from '../icons/Pipeline';
 
-class Welcome extends React.Component {
+export default class Welcome extends React.PureComponent {
   static propTypes = {
-    organization: PropTypes.string.isRequired
+    organizationSlug: PropTypes.string.isRequired
   }
 
   render() {
@@ -24,7 +24,7 @@ class Welcome extends React.Component {
         <p>
           <a
             className="mt4 btn btn-primary bg-lime hover-white white rounded"
-            href={`/organizations/${this.props.organization}/pipelines/new`}
+            href={`/organizations/${this.props.organizationSlug}/pipelines/new`}
           >
             New Pipeline
           </a>
@@ -33,5 +33,3 @@ class Welcome extends React.Component {
     );
   }
 }
-
-export default Welcome;

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -185,9 +185,9 @@ class Header extends React.Component {
   renderDescription() {
     if (this.props.pipeline.description) {
       return <Emojify text={this.props.pipeline.description} />;
-    } else {
-      return this.props.pipeline.repository.url;
     }
+
+    return this.props.pipeline.repository.url;
   }
 
   handleActionsDropdownToggle = (visible) => {

--- a/app/components/pipeline/SettingsMenu.js
+++ b/app/components/pipeline/SettingsMenu.js
@@ -90,7 +90,8 @@ class SettingsMenu extends React.Component {
         render: (idx) => (
           <Menu.Button
             key={idx}
-            icon="teams" link={`${url}/teams`}
+            icon="teams"
+            link={`${url}/teams`}
             badge={this.props.pipeline.teams.count}
             label="Teams"
           />
@@ -101,7 +102,9 @@ class SettingsMenu extends React.Component {
         render: (idx) => (
           <Menu.Button
             key={idx}
-            icon="schedules" link={`${url}/schedules`} badge={this.props.pipeline.schedules.count}
+            icon="schedules"
+            link={`${url}/schedules`}
+            badge={this.props.pipeline.schedules.count}
             label="Schedules"
           />
         )
@@ -111,7 +114,8 @@ class SettingsMenu extends React.Component {
         render: (idx) => (
           <Menu.Button
             key={idx}
-            icon="badges" href={`${url}/badges`}
+            icon="badges"
+            href={`${url}/badges`}
             label="Build Badges"
           />
         )

--- a/app/components/pipeline/SettingsMenu.js
+++ b/app/components/pipeline/SettingsMenu.js
@@ -126,9 +126,9 @@ class SettingsMenu extends React.Component {
   providerLabel() {
     if (this.provider.__typename === "RepositoryProviderUnknown") {
       return "Repository";
-    } else {
-      return this.provider.name;
     }
+
+    return this.provider.name;
   }
 
   isPipelineButtonActive(url) {

--- a/app/components/pipeline/SettingsMenu.js
+++ b/app/components/pipeline/SettingsMenu.js
@@ -46,7 +46,7 @@ class SettingsMenu extends React.Component {
             key={idx}
             icon="pipeline"
             href={`${url}`}
-            active={this.isPipelineButtonActive(url)}
+            forceActive={this.isPipelineButtonActive(url)}
             label="Pipeline"
           />
         )

--- a/app/components/pipeline/SettingsSection.js
+++ b/app/components/pipeline/SettingsSection.js
@@ -5,7 +5,7 @@ import Relay from 'react-relay/classic';
 import Header from './Header';
 import SettingsMenu from './SettingsMenu';
 
-class SettingsSection extends React.Component {
+class SettingsSection extends React.PureComponent {
   static propTypes = {
     pipeline: PropTypes.object.isRequired,
     children: PropTypes.node.isRequired

--- a/app/components/pipeline/schedules/Index/index.js
+++ b/app/components/pipeline/schedules/Index/index.js
@@ -66,9 +66,9 @@ class Index extends React.Component {
           <Row key={edge.node.id} pipelineSchedule={edge.node} />
         );
       });
-    } else {
-      return null;
     }
+
+    return null;
   }
 }
 

--- a/app/components/pipeline/schedules/Index/row.js
+++ b/app/components/pipeline/schedules/Index/row.js
@@ -5,7 +5,7 @@ import Relay from 'react-relay/classic';
 import Panel from '../../../shared/Panel';
 import Emojify from '../../../shared/Emojify';
 
-class Row extends React.Component {
+class Row extends React.PureComponent {
   static propTypes = {
     pipelineSchedule: PropTypes.shape({
       uuid: PropTypes.string.isRequired,

--- a/app/components/pipeline/schedules/Show/build.js
+++ b/app/components/pipeline/schedules/Show/build.js
@@ -5,7 +5,7 @@ import Relay from 'react-relay/classic';
 import FriendlyTime from '../../../shared/FriendlyTime';
 import Panel from '../../../shared/Panel';
 
-class Build extends React.Component {
+class Build extends React.PureComponent {
   static propTypes = {
     build: PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -112,9 +112,9 @@ class Show extends React.Component {
           <div className="mb2 dark-gray"><pre><code>{this.props.pipelineSchedule.env.join("\n")}</code></pre></div>
         </div>
       );
-    } else {
-      return null;
     }
+
+    return null;
   }
 
   renderMenu() {

--- a/app/components/pipeline/teams/Index/index.js
+++ b/app/components/pipeline/teams/Index/index.js
@@ -71,13 +71,15 @@ class Index extends React.Component {
           <Row key={edge.node.id} teamPipeline={edge.node} organization={this.props.pipeline.organization} />
         );
       });
-    } else {
-      return (
-        <Panel.Row>
-          <div className="dark-gray py2 center"><Emojify text="This Pipeline has not been added to any teams yet" /></div>
-        </Panel.Row>
-      );
     }
+
+    return (
+      <Panel.Row>
+        <div className="dark-gray py2 center">
+          <Emojify text="This Pipeline has not been added to any teams yet" />
+        </div>
+      </Panel.Row>
+    );
   }
 
   renderAutoCompleteSuggestions(search) {
@@ -107,9 +109,9 @@ class Index extends React.Component {
           Could not find a team with name <em>{search}</em>
         </AutocompleteField.ErrorMessage>
       ];
-    } else {
-      return [];
     }
+
+    return [];
   }
 
   handleTeamSearch = (text) => {

--- a/app/components/pipeline/teams/Index/row.js
+++ b/app/components/pipeline/teams/Index/row.js
@@ -91,49 +91,49 @@ class Row extends React.Component {
       return (
         <div className="flex flex-auto" />
       );
-    } else {
-      const pipelines = this.props.teamPipeline.team.pipelines.count;
-      const members = this.props.teamPipeline.team.members.count;
-
-      return (
-        <div className="flex flex-auto items-center">
-          <div className="regular dark-gray">
-            {`${pipelines} Pipeline${pipelines === 1 ? '' : 's'}, ${members} Member${members === 1 ? '' : 's'}`}
-          </div>
-        </div>
-      );
     }
+
+    const pipelines = this.props.teamPipeline.team.pipelines.count;
+    const members = this.props.teamPipeline.team.members.count;
+
+    return (
+      <div className="flex flex-auto items-center">
+        <div className="regular dark-gray">
+          {`${pipelines} Pipeline${pipelines === 1 ? '' : 's'}, ${members} Member${members === 1 ? '' : 's'}`}
+        </div>
+      </div>
+    );
   }
 
   renderActions() {
     // Don't render any actions until the record has been created
     if (this.isCreating()) {
       return (
-        <Spinner size={18} color={false}/>
-      );
-    } else {
-      return permissions(this.props.teamPipeline.permissions).collect(
-        {
-          allowed: "teamPipelineUpdate",
-          render: (idx) => (
-            <AccessLevel key={idx} teamPipeline={this.props.teamPipeline} onAccessLevelChange={this.handleAccessLevelChange} saving={this.state.savingNewAccessLevel} />
-          )
-        },
-        {
-          allowed: "teamPipelineDelete",
-          render: (idx) => (
-            <Button
-              key={idx}
-              loading={this.state.removing ? "Removing…" : false}
-              theme={"default"}
-              outline={true}
-              className="ml3"
-              onClick={this.handleRemove}
-            >Remove</Button>
-          )
-        }
+        <Spinner size={18} color={false} />
       );
     }
+    return permissions(this.props.teamPipeline.permissions).collect(
+      {
+        allowed: "teamPipelineUpdate",
+        render: (idx) => (
+          <AccessLevel key={idx} teamPipeline={this.props.teamPipeline} onAccessLevelChange={this.handleAccessLevelChange} saving={this.state.savingNewAccessLevel} />
+          )
+      },
+      {
+        allowed: "teamPipelineDelete",
+        render: (idx) => (
+          <Button
+            key={idx}
+            loading={this.state.removing ? "Removing…" : false}
+            theme={"default"}
+            outline={true}
+            className="ml3"
+            onClick={this.handleRemove}
+          >Remove</Button>
+          )
+      }
+      );
+
   }
 
   // Returns true/false depending on whether or not this team pipeline record

--- a/app/components/shared/Autocomplete/Field/index.js
+++ b/app/components/shared/Autocomplete/Field/index.js
@@ -104,24 +104,24 @@ class AutocompleteField extends React.PureComponent {
             {item}
           </div>
         );
-      } else {
-        const isSelected = item[1] && this.state.selected && (item[1].id === this.state.selected.id);
-
-        // `selected` needs to always return a boolean as it's a requirement of
-        // the Suggestion component
-        return (
-          <Suggestion
-            key={index}
-            className="rounded"
-            selected={!!isSelected}
-            suggestion={item[1]}
-            onMouseOver={this.handleSuggestionMouseOver}
-            onMouseDown={this.handleSuggestionMouseDown}
-          >
-            {item[0]}
-          </Suggestion>
-        );
       }
+
+      const isSelected = item[1] && this.state.selected && (item[1].id === this.state.selected.id);
+
+      // `selected` needs to always return a boolean as it's a requirement of
+      // the Suggestion component
+      return (
+        <Suggestion
+          key={index}
+          className="rounded"
+          selected={!!isSelected}
+          suggestion={item[1]}
+          onMouseOver={this.handleSuggestionMouseOver}
+          onMouseDown={this.handleSuggestionMouseDown}
+        >
+          {item[0]}
+        </Suggestion>
+      );
     });
 
     return (

--- a/app/components/shared/Badge.js
+++ b/app/components/shared/Badge.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-class Badge extends React.Component {
+export default class Badge extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string
@@ -21,5 +21,3 @@ class Badge extends React.Component {
     );
   }
 }
-
-export default Badge;

--- a/app/components/shared/Button.js
+++ b/app/components/shared/Button.js
@@ -19,7 +19,7 @@ const OUTLINE_THEMES = {
   error: "btn-outline border-red red"
 };
 
-class Button extends React.Component {
+export default class Button extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -97,5 +97,3 @@ class Button extends React.Component {
     }
   }
 }
-
-export default Button;

--- a/app/components/shared/Button.js
+++ b/app/components/shared/Button.js
@@ -86,14 +86,14 @@ export default class Button extends React.PureComponent {
       return (
         <Link to={this.props.link} {...props}>{children}</Link>
       );
-    } else {
-      props.href = this.props.link || this.props.href;
-
-      if (props.href) {
-        return React.DOM.a(props, children);
-      } else {
-        return React.DOM.button(props, children);
-      }
     }
+
+    props.href = this.props.link || this.props.href;
+
+    if (props.href) {
+      return React.DOM.a(props, children);
+    }
+
+    return React.DOM.button(props, children);
   }
 }

--- a/app/components/shared/Chooser/index.js
+++ b/app/components/shared/Chooser/index.js
@@ -34,9 +34,9 @@ class Chooser extends React.Component {
   isSelected(value) {
     if (this.props.multiple) {
       return this.props.selected.indexOf(value) >= 0;
-    } else {
-      return this.props.selected === value;
     }
+
+    return this.props.selected === value;
   }
 
   handleChoiceClick = (value, data) => {

--- a/app/components/shared/Chooser/select-option.js
+++ b/app/components/shared/Chooser/select-option.js
@@ -40,13 +40,13 @@ function Icon(props) {
         <Spinner className="fit absolute" size={16} style={{ marginTop: 3 }} color={false} />
       </div>
     );
-  } else {
-    const tickColor = props.selected ? "green" : "gray";
-
-    return (
-      <div className={tickColor} style={{ fontSize: 16, width: width }}>✔</div>
-    );
   }
+
+  const tickColor = props.selected ? "green" : "gray";
+
+  return (
+    <div className={tickColor} style={{ fontSize: 16, width: width }}>✔</div>
+  );
 }
 
 Icon.propTypes = {

--- a/app/components/shared/CollapsableFormField.js
+++ b/app/components/shared/CollapsableFormField.js
@@ -7,7 +7,7 @@ let _collapsableFormFieldCounter = 0;
 // Legacy bootstap collapsable field
 //
 // This should be replaced with something more akin to CollapsableArea
-class CollapsableFormField extends React.Component {
+export default class CollapsableFormField extends React.PureComponent {
   static propTypes = {
     label: PropTypes.string.isRequired,
     collapsed: PropTypes.bool.isRequired,
@@ -45,5 +45,3 @@ class CollapsableFormField extends React.Component {
     );
   }
 }
-
-export default CollapsableFormField;

--- a/app/components/shared/FormInputErrors.js
+++ b/app/components/shared/FormInputErrors.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class FormInputErrors extends React.Component {
+export default class FormInputErrors extends React.PureComponent {
   static propTypes = {
     errors: PropTypes.array.isRequired
   };
@@ -12,5 +12,3 @@ class FormInputErrors extends React.Component {
     );
   }
 }
-
-export default FormInputErrors;

--- a/app/components/shared/FormInputHelp.js
+++ b/app/components/shared/FormInputHelp.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class FormInputHelp extends React.Component {
+export default class FormInputHelp extends React.PureComponent {
   static propTypes = {
     html: PropTypes.string.isRequired
   };
@@ -12,5 +12,3 @@ class FormInputHelp extends React.Component {
     );
   }
 }
-
-export default FormInputHelp;

--- a/app/components/shared/FormMarkdownEditorField.js
+++ b/app/components/shared/FormMarkdownEditorField.js
@@ -44,7 +44,7 @@ class FormMarkdownEdtiorField extends React.Component {
             <i className="fa fa-warning mr2" />{this.state.error}
           </div>
           <div className="col-right">
-            <button className="btn m0 p0" onClick={this.handleErrorDismissClick}><i className="fa fa-close"/></button>
+            <button className="btn m0 p0" onClick={this.handleErrorDismissClick}><i className="fa fa-close" /></button>
           </div>
         </div>
       );

--- a/app/components/shared/FormRadioGroup.js
+++ b/app/components/shared/FormRadioGroup.js
@@ -56,7 +56,7 @@ class FormRadioGroup extends React.Component {
   _renderErrors() {
     if (this._hasErrors()) {
       return (
-        <FormInputErrors errors={this.props.errors}/>
+        <FormInputErrors errors={this.props.errors} />
       );
     }
   }

--- a/app/components/shared/FormTextField.js
+++ b/app/components/shared/FormTextField.js
@@ -40,21 +40,21 @@ class FormTextField extends React.Component {
           {this._renderHelp()}
         </CollapsableFormField>
       );
-    } else {
-      return (
-        <div className="mb2">
-          <FormInputLabel
-            label={this.props.label}
-            errors={this._hasErrors()}
-            required={this.props.required}
-          >
-            {this._renderInput()}
-          </FormInputLabel>
-          {this._renderErrors()}
-          {this._renderHelp()}
-        </div>
-      );
     }
+
+    return (
+      <div className="mb2">
+        <FormInputLabel
+          label={this.props.label}
+          errors={this._hasErrors()}
+          required={this.props.required}
+        >
+          {this._renderInput()}
+        </FormInputLabel>
+        {this._renderErrors()}
+        {this._renderHelp()}
+      </div>
+    );
   }
 
   getValue() {

--- a/app/components/shared/FormTextField.js
+++ b/app/components/shared/FormTextField.js
@@ -76,7 +76,7 @@ class FormTextField extends React.Component {
   _renderErrors() {
     if (this._hasErrors()) {
       return (
-        <FormInputErrors errors={this.props.errors}/>
+        <FormInputErrors errors={this.props.errors} />
       );
     }
   }
@@ -84,7 +84,7 @@ class FormTextField extends React.Component {
   _renderHelp() {
     if (this.props.help) {
       return (
-        <FormInputHelp html={this.props.help}/>
+        <FormInputHelp html={this.props.help} />
       );
     }
   }

--- a/app/components/shared/FormTextarea.js
+++ b/app/components/shared/FormTextarea.js
@@ -94,7 +94,7 @@ class FormTextarea extends React.Component {
   _renderErrors() {
     if (this._hasErrors()) {
       return (
-        <FormInputErrors errors={this.props.errors}/>
+        <FormInputErrors errors={this.props.errors} />
       );
     }
   }
@@ -102,7 +102,7 @@ class FormTextarea extends React.Component {
   _renderHelp() {
     if (this.props.help) {
       return (
-        <FormInputHelp html={this.props.help}/>
+        <FormInputHelp html={this.props.help} />
       );
     }
   }

--- a/app/components/shared/FormTextarea.js
+++ b/app/components/shared/FormTextarea.js
@@ -57,17 +57,17 @@ class FormTextarea extends React.Component {
           {this._renderHelp()}
         </CollapsableFormField>
       );
-    } else {
-      return (
-        <div className="mb2">
-          <FormInputLabel label={this.props.label} errors={this._hasErrors()}>
-            {this._renderTextArea()}
-          </FormInputLabel>
-          {this._renderErrors()}
-          {this._renderHelp()}
-        </div>
-      );
     }
+
+    return (
+      <div className="mb2">
+        <FormInputLabel label={this.props.label} errors={this._hasErrors()}>
+          {this._renderTextArea()}
+        </FormInputLabel>
+        {this._renderErrors()}
+        {this._renderHelp()}
+      </div>
+    );
   }
 
   // In some cases the initial height can be incorrect and you need to explicit tell

--- a/app/components/shared/FriendlyTime.js
+++ b/app/components/shared/FriendlyTime.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { minute } from 'metrick/duration';
 import { getDateString, getRelativeDateString } from '../../lib/date';
 
-class FriendlyTime extends React.PureComponent {
+export default class FriendlyTime extends React.PureComponent {
   static propTypes = {
     value: PropTypes.string.isRequired,
     updateFrequency: PropTypes.number.isRequired,
@@ -71,5 +71,3 @@ class FriendlyTime extends React.PureComponent {
     );
   }
 }
-
-export default FriendlyTime;

--- a/app/components/shared/JobLink.js
+++ b/app/components/shared/JobLink.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import Emojify from './Emojify';
 
-class JobLink extends React.Component {
+class JobLink extends React.PureComponent {
   static propTypes = {
     job: PropTypes.shape({
       label: PropTypes.string,

--- a/app/components/shared/Menu/button.js
+++ b/app/components/shared/Menu/button.js
@@ -97,7 +97,7 @@ class Button extends React.Component {
   _renderIcon() {
     if (this.props.icon) {
       return (
-        <Icon className="flex-none icon-mr" icon={this.props.icon}/>
+        <Icon className="flex-none icon-mr" icon={this.props.icon} />
       );
     }
   }

--- a/app/components/shared/Menu/header.js
+++ b/app/components/shared/Menu/header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class Header extends React.Component {
+export default class Header extends React.PureComponent {
   static displayName = "Menu.Header";
 
   static propTypes = {
@@ -16,5 +16,3 @@ class Header extends React.Component {
     );
   }
 }
-
-export default Header;

--- a/app/components/shared/Menu/index.js
+++ b/app/components/shared/Menu/index.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import Header from './header';
 import Button from './button';
 
-class Menu extends React.Component {
+class Menu extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired
   };

--- a/app/components/shared/PageHeader/button.js
+++ b/app/components/shared/PageHeader/button.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import BaseButton from '../Button';
 
-class Button extends React.Component {
+export default class Button extends React.PureComponent {
   static displayName = "PageHeader.Button";
 
   static propTypes = {
@@ -16,5 +16,3 @@ class Button extends React.Component {
     );
   }
 }
-
-export default Button;

--- a/app/components/shared/PageWithContainer.js
+++ b/app/components/shared/PageWithContainer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class PageWithContainer extends React.Component {
+export default class PageWithContainer extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired
   };
@@ -12,5 +12,3 @@ class PageWithContainer extends React.Component {
     );
   }
 }
-
-export default PageWithContainer;

--- a/app/components/shared/PageWithMenu.js
+++ b/app/components/shared/PageWithMenu.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class PageWithMenu extends React.Component {
+export default class PageWithMenu extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired
   };
@@ -23,5 +23,3 @@ class PageWithMenu extends React.Component {
     );
   }
 }
-
-export default PageWithMenu;

--- a/app/components/shared/Panel/index.js
+++ b/app/components/shared/Panel/index.js
@@ -8,7 +8,7 @@ import RowActions from './row-actions';
 import RowLink from './row-link';
 import Header from './header';
 
-class Panel extends React.Component {
+class Panel extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
     className: PropTypes.string

--- a/app/components/shared/Panel/intro-with-button.js
+++ b/app/components/shared/Panel/intro-with-button.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class IntroWithButton extends React.Component {
+export default class IntroWithButton extends React.PureComponent {
   static displayName = "Panel.IntroWithButton";
 
   static propTypes = {
@@ -36,5 +36,3 @@ class IntroWithButton extends React.Component {
     );
   }
 }
-
-export default IntroWithButton;

--- a/app/components/shared/Panel/row-actions.js
+++ b/app/components/shared/Panel/row-actions.js
@@ -1,19 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import shallowCompare from 'react-addons-shallow-compare';
 
-export default class RowActions extends React.Component {
+export default class RowActions extends React.PureComponent {
   static displayName = "Panel.RowActions";
 
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     const children = React.Children.toArray(this.props.children);

--- a/app/components/shared/Panel/row-actions.js
+++ b/app/components/shared/Panel/row-actions.js
@@ -23,8 +23,8 @@ export default class RowActions extends React.PureComponent {
           {this.props.children}
         </div>
       );
-    } else {
-      return <noscript />;
     }
+
+    return <noscript />;
   }
 }

--- a/app/components/shared/Panel/row-link.js
+++ b/app/components/shared/Panel/row-link.js
@@ -23,15 +23,15 @@ export default class RowLink extends React.PureComponent {
           <Icon icon="chevron-right" className="flex-none dark-gray" style={{ height: 15, width: 15 }} />
         </Link>
       );
-    } else {
-      return (
-        <a href={this.props.href} className="btn py2 px3 flex items-center hover-bg-silver hover-black focus-black">
-          <div className="flex-auto">
-            {this.props.children}
-          </div>
-          <Icon icon="chevron-right" className="flex-none dark-gray" style={{ height: 15, width: 15 }} />
-        </a>
-      );
     }
+
+    return (
+      <a href={this.props.href} className="btn py2 px3 flex items-center hover-bg-silver hover-black focus-black">
+        <div className="flex-auto">
+          {this.props.children}
+        </div>
+        <Icon icon="chevron-right" className="flex-none dark-gray" style={{ height: 15, width: 15 }} />
+      </a>
+    );
   }
 }

--- a/app/components/shared/SearchField.js
+++ b/app/components/shared/SearchField.js
@@ -110,20 +110,20 @@ export default class SearchField extends React.PureComponent {
           style={style}
         />
       );
-    } else {
-      return (
-        <Icon
-          icon="search"
-          className={className}
-          style={{
-            color: 'currentColor',
-            width: iconSize,
-            height: iconSize,
-            ...style
-          }}
-        />
-      );
     }
+
+    return (
+      <Icon
+        icon="search"
+        className={className}
+        style={{
+          color: 'currentColor',
+          width: iconSize,
+          height: iconSize,
+          ...style
+        }}
+      />
+    );
   }
 
   handleInputChange = (evt) => {

--- a/app/components/shared/SectionLoader.js
+++ b/app/components/shared/SectionLoader.js
@@ -2,14 +2,12 @@ import React from 'react';
 
 import Spinner from './Spinner';
 
-class SectionLoader extends React.Component {
+export default class SectionLoader extends React.PureComponent {
   render() {
     return (
       <div className="center my4">
-        <Spinner/>
+        <Spinner />
       </div>
     );
   }
 }
-
-export default SectionLoader;

--- a/app/components/shared/Spinner.js
+++ b/app/components/shared/Spinner.js
@@ -32,19 +32,19 @@ export default class Spinner extends React.PureComponent {
       <div className={classNames("inline-block relative", this.props.className, { "animation-fade-in": this.props.fadeIn })} style={style}>
         <div className="absolute top-0 left-0">
           <svg viewBox="0 0 20 20" width="20px" height="20px" className="absolute top-0 left-0" style={{ width: this.props.size, height: this.props.size }}>
-            <circle className="stroke-gray" fill="transparent" strokeMiterlimit="10" strokeWidth="3" cx="10" cy="10" r="7"/>
+            <circle className="stroke-gray" fill="transparent" strokeMiterlimit="10" strokeWidth="3" cx="10" cy="10" r="7" />
           </svg>
           <svg viewBox="0 0 20 20" width="20px" height="20px" className="absolute top-0 left-0 animation-spin" style={{ width: this.props.size, height: this.props.size }}>
             <defs>
               <clipPath id="spinner-clip-path">
-                <rect fill="none" x="10" y="-10" width="20" height="20"/>
+                <rect fill="none" x="10" y="-10" width="20" height="20" />
               </clipPath>
             </defs>
             <g transform="translate(10, 10)">
               <g className="animation-spin">
                 <g transform="translate(-10, -10)">
                   <g clipPath="url(#spinner-clip-path)">
-                    <circle fill="transparent" className={this.props.color ? "stroke-lime" : "stroke-dark-gray"} strokeMiterlimit="10" strokeWidth="3" cx="10" cy="10" r="7"/>
+                    <circle fill="transparent" className={this.props.color ? "stroke-lime" : "stroke-dark-gray"} strokeMiterlimit="10" strokeWidth="3" cx="10" cy="10" r="7" />
                   </g>
                 </g>
               </g>

--- a/app/components/shared/Spinner.js
+++ b/app/components/shared/Spinner.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import update from 'react-addons-update';
 import classNames from 'classnames';
 
-class Spinner extends React.Component {
+export default class Spinner extends React.PureComponent {
   static propTypes = {
     size: PropTypes.number,
     className: PropTypes.string,
@@ -55,5 +55,3 @@ class Spinner extends React.Component {
     );
   }
 }
-
-export default Spinner;

--- a/app/components/shared/UserAvatar.js
+++ b/app/components/shared/UserAvatar.js
@@ -16,7 +16,8 @@ export default class UserAvatar extends React.PureComponent {
 
   render() {
     return (
-      <img src={this.props.user.avatar.url}
+      <img
+        src={this.props.user.avatar.url}
         className={classNames("circle border border-gray bg-white", this.props.className)}
         alt={this.props.user.name}
         title={this.props.user.name}

--- a/app/components/shared/UserAvatar.js
+++ b/app/components/shared/UserAvatar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export default class UserAvatar extends React.Component {
+export default class UserAvatar extends React.PureComponent {
   static propTypes = {
     user: PropTypes.shape({
       name: PropTypes.string.isRequired,

--- a/app/components/sso/Index.js
+++ b/app/components/sso/Index.js
@@ -96,47 +96,47 @@ class SSOIndex extends React.PureComponent {
           <Panel.Section className="max-width-3">
             <p className="h4 bold">Single Sign On is enabled for this organization.</p>
             <p>To login, users can enter their their email address on the Buildkite login page and they will redirected to {this.props.organization.sso.provider.name} for authentication and sign-in.</p>
-            <p>If you have multiple organizations configured with SSO, users can login using this organization-specific login URL:<br/>{this.renderLoginLink()}</p>
+            <p>If you have multiple organizations configured with SSO, users can login using this organization-specific login URL:<br />{this.renderLoginLink()}</p>
           </Panel.Section>
         </Panel>
       );
-    } else {
-      return (
-        <div>
-          <Panel>
-            <Panel.Section className="max-width-3">
-              <p>Single Sign On (SSO) allows you to use your own authentication server for signing into Buildkite.</p>
-              <p>During the sign in process, new users will be automatically added to your organization.</p>
-              <p>Supported SSO systems:</p>
-              <ul>
-                <li>Bitium (<a className="semi-bold lime text-decoration-none hover-lime hover-underline" href="https://support.bitium.com/administration/saml-buildkite/">Instructions</a>)</li>
-                <li>Okta (<a className="semi-bold lime text-decoration-none hover-lime hover-underline" href="http://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Buildkite.html">Instructions</a>)</li>
-                <li>Google Apps (G Suite)</li>
-                <li>SAML</li>
-                <li>ADFS (SAML)</li>
-              </ul>
-              <p>To enable SSO for this organization, contact support with your authentication server details.</p>
-              <Button href={this.renderEmailURI()}>
-                Contact Support
-              </Button>
-            </Panel.Section>
-          </Panel>
-          <Panel className="mt4">
-            <Panel.Header>
-              Frequently Asked SSO Questions
-            </Panel.Header>
-            <Panel.Section className="max-width-2">
-              <h3 className="mt3 h4 bold">How does user billing work with SSO?</h3>
-              <p>When a user signs in with SSO, the additional user is added to your account and will be charged immediately, just as if you had invited them to the account.</p>
-              <h3 className="mt3 h4 bold">Can I use multiple email domains?</h3>
-              <p>We currently only support a single email domain (e.g. example.com) for an organization.</p>
-              <h3 className="mt3 h4 bold">Can I set up SSO for additional organizations?</h3>
-              <p>We support setting up SSO for additional organizations, but one of the organizations will be the default. To login to the secondary organizations, you can add ?asd to your organization’s login URL.</p>
-            </Panel.Section>
-          </Panel>
-        </div>
-      );
     }
+
+    return (
+      <div>
+        <Panel>
+          <Panel.Section className="max-width-3">
+            <p>Single Sign On (SSO) allows you to use your own authentication server for signing into Buildkite.</p>
+            <p>During the sign in process, new users will be automatically added to your organization.</p>
+            <p>Supported SSO systems:</p>
+            <ul>
+              <li>Bitium (<a className="semi-bold lime text-decoration-none hover-lime hover-underline" href="https://support.bitium.com/administration/saml-buildkite/">Instructions</a>)</li>
+              <li>Okta (<a className="semi-bold lime text-decoration-none hover-lime hover-underline" href="http://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Buildkite.html">Instructions</a>)</li>
+              <li>Google Apps (G Suite)</li>
+              <li>SAML</li>
+              <li>ADFS (SAML)</li>
+            </ul>
+            <p>To enable SSO for this organization, contact support with your authentication server details.</p>
+            <Button href={this.renderEmailURI()}>
+              Contact Support
+            </Button>
+          </Panel.Section>
+        </Panel>
+        <Panel className="mt4">
+          <Panel.Header>
+            Frequently Asked SSO Questions
+          </Panel.Header>
+          <Panel.Section className="max-width-2">
+            <h3 className="mt3 h4 bold">How does user billing work with SSO?</h3>
+            <p>When a user signs in with SSO, the additional user is added to your account and will be charged immediately, just as if you had invited them to the account.</p>
+            <h3 className="mt3 h4 bold">Can I use multiple email domains?</h3>
+            <p>We currently only support a single email domain (e.g. example.com) for an organization.</p>
+            <h3 className="mt3 h4 bold">Can I set up SSO for additional organizations?</h3>
+            <p>We support setting up SSO for additional organizations, but one of the organizations will be the default. To login to the secondary organizations, you can add ?asd to your organization’s login URL.</p>
+          </Panel.Section>
+        </Panel>
+      </div>
+    );
   }
 }
 

--- a/app/components/team/Index.js
+++ b/app/components/team/Index.js
@@ -124,13 +124,13 @@ class TeamIndex extends React.PureComponent {
           <Row key={edge.node.id} team={edge.node} />
         );
       });
-    } else {
-      return (
-        <Panel.Section className="center">
-          <Spinner />
-        </Panel.Section>
-      );
     }
+
+    return (
+      <Panel.Section className="center">
+        <Spinner />
+      </Panel.Section>
+    );
   }
 
   renderTeamSearchInfo() {

--- a/app/components/team/Index.js
+++ b/app/components/team/Index.js
@@ -19,7 +19,7 @@ import Row from './Row';
 
 import TeamPrivacyConstants from '../../constants/TeamPrivacyConstants';
 
-const TEAM_PRIVACIES =  [
+const TEAM_PRIVACIES = [
   { name: 'All Teams', id: null },
   { name: 'Visible', id: TeamPrivacyConstants.VISIBLE },
   { name: 'Secret', id: TeamPrivacyConstants.SECRET }

--- a/app/components/team/Members/chooser.js
+++ b/app/components/team/Members/chooser.js
@@ -92,13 +92,13 @@ class Chooser extends React.Component {
           Could not find a user with name <em>{memberAddSearch}</em>
         </AutocompleteDialog.ErrorMessage>
       ];
-    } else {
-      return [
-        <AutocompleteDialog.ErrorMessage key="error">
-          Could not find any more users to add
-        </AutocompleteDialog.ErrorMessage>
-      ];
     }
+
+    return [
+      <AutocompleteDialog.ErrorMessage key="error">
+        Could not find any more users to add
+      </AutocompleteDialog.ErrorMessage>
+    ];
   }
 
   handleDialogOpen = () => {

--- a/app/components/team/Members/index.js
+++ b/app/components/team/Members/index.js
@@ -78,12 +78,17 @@ class Members extends React.Component {
           <Row key={edge.node.id} teamMember={edge.node} onRemoveClick={this.handleTeamMemberRemove} onRoleChange={this.handleRoleChange} relay={this.props.relay} />
         );
       });
-    } else {
-      if (this.props.relay.variables.memberSearch) {
-        return null;
-      }
-      return <Panel.Section className="dark-gray">There are no users assigned to this team</Panel.Section>;
     }
+
+    if (this.props.relay.variables.memberSearch) {
+      return null;
+    }
+
+    return (
+      <Panel.Section className="dark-gray">
+        There are no users assigned to this team
+      </Panel.Section>
+    );
   }
 
   renderMemberSearch() {
@@ -99,9 +104,9 @@ class Members extends React.Component {
           />
         </div>
       );
-    } else {
-      return null;
     }
+
+    return null;
   }
 
   renderMemberSearchInfo() {

--- a/app/components/team/Members/row.js
+++ b/app/components/team/Members/row.js
@@ -52,7 +52,7 @@ export default class Row extends React.PureComponent {
 
     if (transaction) {
       return (
-        <Spinner size={18} color={false}/>
+        <Spinner size={18} color={false} />
       );
     } else {
       return permissions(this.props.teamMember.permissions).collect(

--- a/app/components/team/Members/row.js
+++ b/app/components/team/Members/row.js
@@ -54,24 +54,31 @@ export default class Row extends React.PureComponent {
       return (
         <Spinner size={18} color={false} />
       );
-    } else {
-      return permissions(this.props.teamMember.permissions).collect(
-        {
-          allowed: "teamMemberUpdate",
-          render: (idx) => (
-            <Role key={idx} teamMember={this.props.teamMember} onRoleChange={this.handleRoleChange} savingNewRole={this.state.savingNewRole} />
-          )
-        },
-        {
-          allowed: "teamMemberDelete",
-          render: (idx) => (
-            <Button key={idx} loading={this.state.removing ? "Removing…" : false} theme={"default"} outline={true} className="ml3"
-              onClick={this.handleMemberRemove}
-            >Remove</Button>
-          )
-        }
-      );
     }
+
+    return permissions(this.props.teamMember.permissions).collect(
+      {
+        allowed: "teamMemberUpdate",
+        render: (idx) => (
+          <Role key={idx} teamMember={this.props.teamMember} onRoleChange={this.handleRoleChange} savingNewRole={this.state.savingNewRole} />
+        )
+      },
+      {
+        allowed: "teamMemberDelete",
+        render: (idx) => (
+          <Button
+            key={idx}
+            loading={this.state.removing ? "Removing…" : false}
+            theme={"default"}
+            outline={true}
+            className="ml3"
+            onClick={this.handleMemberRemove}
+          >
+            Remove
+          </Button>
+        )
+      }
+    );
   }
 
   handleRoleChange = (role) => {

--- a/app/components/team/Pipelines/chooser.js
+++ b/app/components/team/Pipelines/chooser.js
@@ -90,13 +90,12 @@ class Chooser extends React.Component {
           Could not find a pipeline with name <em>{pipelineAddSearch}</em>
         </AutocompleteDialog.ErrorMessage>
       ];
-    } else {
-      return [
-        <AutocompleteDialog.ErrorMessage key={"error"}>
-          Could not find any more pipelines to add
-        </AutocompleteDialog.ErrorMessage>
-      ];
     }
+    return [
+      <AutocompleteDialog.ErrorMessage key={"error"}>
+        Could not find any more pipelines to add
+      </AutocompleteDialog.ErrorMessage>
+    ];
   }
 
   handleDialogOpen = () => {

--- a/app/components/team/Pipelines/index.js
+++ b/app/components/team/Pipelines/index.js
@@ -80,12 +80,16 @@ class Pipelines extends React.Component {
           <Row key={edge.node.id} teamPipeline={edge.node} onRemoveClick={this.handleTeamPipelineRemove} onAccessLevelChange={this.handleAccessLevelChange} relay={this.props.relay} />
         );
       });
-    } else {
-      if (this.props.relay.variables.pipelineSearch) {
-        return null;
-      }
-      return <Panel.Section className="dark-gray">There are no pipelines assigned to this team</Panel.Section>;
     }
+    if (this.props.relay.variables.pipelineSearch) {
+      return null;
+    }
+
+    return (
+      <Panel.Section className="dark-gray">
+        There are no pipelines assigned to this team
+      </Panel.Section>
+    );
   }
 
   renderPipelineSearch() {
@@ -101,9 +105,9 @@ class Pipelines extends React.Component {
           />
         </div>
       );
-    } else {
-      return null;
     }
+
+    return null;
   }
 
   renderPipelineSearchInfo() {

--- a/app/components/team/Pipelines/row.js
+++ b/app/components/team/Pipelines/row.js
@@ -51,26 +51,33 @@ export default class Row extends React.PureComponent {
 
     if (transaction) {
       return (
-        <Spinner size={18} color={false}/>
-      );
-    } else {
-      return permissions(this.props.teamPipeline.permissions).collect(
-        {
-          allowed: "teamPipelineUpdate",
-          render: (idx) => (
-            <AccessLevel key={idx} teamPipeline={this.props.teamPipeline} onAccessLevelChange={this.handleAccessLevelChange} saving={this.state.savingNewAccessLevel} />
-          )
-        },
-        {
-          allowed: "teamPipelineDelete",
-          render: (idx) => (
-            <Button key={idx} loading={this.state.removing ? "Removing…" : false} theme={"default"} outline={true} className="ml3"
-              onClick={this.handlePipelineRemove}
-            >Remove</Button>
-          )
-        }
+        <Spinner size={18} color={false} />
       );
     }
+
+    return permissions(this.props.teamPipeline.permissions).collect(
+      {
+        allowed: "teamPipelineUpdate",
+        render: (idx) => (
+          <AccessLevel key={idx} teamPipeline={this.props.teamPipeline} onAccessLevelChange={this.handleAccessLevelChange} saving={this.state.savingNewAccessLevel} />
+        )
+      },
+      {
+        allowed: "teamPipelineDelete",
+        render: (idx) => (
+          <Button
+            key={idx}
+            loading={this.state.removing ? "Removing…" : false}
+            theme={"default"}
+            outline={true}
+            className="ml3"
+            onClick={this.handlePipelineRemove}
+          >
+            Remove
+          </Button>
+        )
+      }
+    );
   }
 
   handleAccessLevelChange = (accessLevel) => {

--- a/app/components/team/Row.js
+++ b/app/components/team/Row.js
@@ -107,7 +107,8 @@ class TeamRow extends React.PureComponent {
 
     if (extrasCount > 0) {
       return (
-        <div className="inline-block bg-gray bold center border border-white semi-bold px1"
+        <div
+          className="inline-block bg-gray bold center border border-white semi-bold px1"
           style={{ borderRadius: avatarSize / 2, minWidth: avatarSize, height: avatarSize, lineHeight: `${avatarSize - 4}px`, fontSize: 11, borderWidth: 2 }}
           title={`and another ${formatNumber(extrasCount)} member${extrasCount === 1 ? '' : 's'}`}
         >

--- a/app/components/user/BuildCountsBreakdown.js
+++ b/app/components/user/BuildCountsBreakdown.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import PusherStore from '../../stores/PusherStore';
 import StateSwitcher from '../build/StateSwitcher';
 
-class BuildCountsBreakdown extends React.Component {
+export default class BuildCountsBreakdown extends React.PureComponent {
   static propTypes = {
     viewer: PropTypes.shape({
       builds: PropTypes.shape({
@@ -27,11 +27,11 @@ class BuildCountsBreakdown extends React.Component {
   };
 
   componentDidMount() {
-    PusherStore.on("user_stats:change", this._onStoreChange.bind(this));
+    PusherStore.on("user_stats:change", this.handleStoreChange);
   }
 
   componentWillUnmount() {
-    PusherStore.off("user_stats:change", this._onStoreChange.bind(this));
+    PusherStore.off("user_stats:change", this.handleStoreChange);
   }
 
   render() {
@@ -46,7 +46,7 @@ class BuildCountsBreakdown extends React.Component {
     );
   }
 
-  _onStoreChange(payload) {
+  handleStoreChange = (payload) => {
     this.setState({
       buildsCount: payload.buildsCount,
       scheduledBuildsCount: payload.scheduledBuildsCount,
@@ -54,5 +54,3 @@ class BuildCountsBreakdown extends React.Component {
     });
   }
 }
-
-export default BuildCountsBreakdown;

--- a/app/lib/MarkdownEditor.js
+++ b/app/lib/MarkdownEditor.js
@@ -56,9 +56,9 @@ class MarkdownEditor {
       // instead of just wrapping with a `
       if (selectedText.split(/\r\n|\r|\n/).length > 1) {
         return "```\n{s}{t}{s}\n```";
-      } else {
-        return "`{s}{t}{s}`";
       }
+
+      return "`{s}{t}{s}`";
     });
   }
 
@@ -70,9 +70,9 @@ class MarkdownEditor {
         return "[{s}text{s}]({t})";
       } else if (selectedText.length > 0) {
         return "[{t}]({s}url{s})";
-      } else {
-        return "[{s}text{s}](url)";
       }
+
+      return "[{s}text{s}](url)";
     });
   }
 

--- a/app/lib/ValidationErrors.js
+++ b/app/lib/ValidationErrors.js
@@ -14,9 +14,9 @@ class ValidationErrors {
       });
 
       return messages;
-    } else {
-      return null;
     }
+
+    return null;
   }
 }
 

--- a/app/lib/commits.js
+++ b/app/lib/commits.js
@@ -6,7 +6,7 @@ export function shortCommit(commitish) {
   // Does this look like a git sha?
   if (commitish && commitish.length === 40 && !commitish.match(/[^a-f0-9]/i)) {
     return commitish.substring(0, 7);
-  } else {
-    return commitish;
   }
+
+  return commitish;
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -58,11 +58,11 @@ const getMainQueries = ({ params }) => {
       viewer: ViewerQuery.query,
       organization: OrganizationQuery.query
     };
-  } else {
-    return {
-      viewer: ViewerQuery.query
-    };
   }
+
+  return {
+    viewer: ViewerQuery.query
+  };
 };
 
 // Since you can't pass `undefined` as a property to a Relay.Container, and

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -32,7 +32,7 @@ const IS_PRODUCTION = (process.env.NODE_ENV === "production");
 // folder with every hashed version of files we've changed (webpack doesn't
 // clean up after itself)
 const filenameFormat = IS_PRODUCTION ? "[name]-[chunkhash].js" : "[name].js";
-const chunkFilename  = IS_PRODUCTION ? "[id]-[chunkhash].js"   : "[id].js";
+const chunkFilename = IS_PRODUCTION ? "[id]-[chunkhash].js" : "[id].js";
 
 // Toggle between the devtool if on prod/dev since cheap-module-eval-source-map
 // is way faster for development.


### PR DESCRIPTION
This purifies a bunch of components, upgrades the requirement of optimised components to an error, and then reviews some more of the ESLint rules!

ESLint rules changed are:
- 🆕 `no-else-return`: require functions which have multiple possible returns to do them linearly
- 🆕 `no-multi-spaces`: disallow multiple spaces between operators
- 🆕 `react/jsx-first-pro-new-line[multiline]`: require multiline jsx component instances to have the first prop on a new line
- 🔁 `react/jsx-max-props-per-line[multiline]`: require all props on separate lines in multiline jsx component instances
- 🆕 `react/jsx-no-comment-textnodes`: throw an error on text node literals that look like JavaScript comment syntax
- 🆕 `react/jsx-no-target-blank`: disallow target=_blank without extra security
- 🆕 `react/no-array-index-key`: warn on use of array index as key (we should be using object identifiers!)
- 🆕 `react/no-danger-with-children`: error if something which uses dangerouslySetInnerHTML has children already
- 🆕 `react/no-unescaped-entities`: error if something that looks like react syntax ends up in a text node
- 🔁 `react/no-unused-prop-types`: go back to checking shaped props!
- 🆕 `react/require-render-return`: require all render methods to return something
- 🆕 `react/jsx-tag-spacing`: enforce sensible JSX tag spacing
- 🆕 `react/void-dom-elements-no-children`: for void DOM elements, require that we don't attempt to give them children