### PR TITLE
Use tidier monospace font stack

### DIFF
--- a/app/components/agent/Index/quick-start.js
+++ b/app/components/agent/Index/quick-start.js
@@ -145,7 +145,7 @@ class QuickStart extends React.PureComponent {
           }}
           elementProps={{
             'code': {
-              style: { fontFamily: 'Monaco, Consolas, monospace', fontSize: '.9em' }
+              style: { fontFamily: '"SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", Courier, monospace', fontSize: '.9em' }
             },
             'a': {
               className: 'blue hover-navy text-decoration-none hover-underline'

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -70,7 +70,7 @@
   --darken-4: rgba(0, 0, 0, .5);
 
   --font-family-system: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Helvetica, sans-serif;
-  --font-family-mono: Monaco, Consolas, monospace;
+  --font-family-mono: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", Courier, monospace;
 
   --bold-font-weight: 600;
 


### PR DESCRIPTION
This updates our monospace font stack to include SFMono, as well as Liberation Mono for better Linux support.

This brings out mono stack more in line with that of GitHub!