### PR TITLE
Handle private GitHub emails in email prompt

### DIFF
--- a/app/components/build/AvatarWithUnknownEmailPrompt.js
+++ b/app/components/build/AvatarWithUnknownEmailPrompt.js
@@ -149,7 +149,7 @@ class AvatarWithUnknownEmailPrompt extends React.PureComponent {
           <div>
             <h1 className="h4 m0 mb1 bold">Unknown GitHub account</h1>
             <p className="m0">
-              The GitHub account <strong className="semi-bold">@{authorEmail.split('@').shift()}</strong> could not be matched to any users in your organization. If this GitHub account belongs to you, connect it to your Buildkite account.
+              The GitHub account <strong className="semi-bold">{authorEmail.split('@').shift()}</strong> could not be matched to any users in your organization. If this GitHub account belongs to you, connect it to your Buildkite account.
             </p>
           </div>
         );

--- a/app/components/build/AvatarWithUnknownEmailPrompt.js
+++ b/app/components/build/AvatarWithUnknownEmailPrompt.js
@@ -159,9 +159,9 @@ class AvatarWithUnknownEmailPrompt extends React.PureComponent {
             theme="primary"
             className="center flex-auto m1"
             href="/user/connected-apps"
-            loading={loading && "Manage Connected Apps"}
+            loading={loading && "Connect GitHub Account"}
           >
-            Manage Connected Apps
+            Connect GitHub Account
           </Button>,
           <button
             key="dismiss-github"


### PR DESCRIPTION
This has been a little improvement that feels like it should’ve been here forever, but here we go!

This updates the email prompt component to better deal with GitHub’s private email addresses. Given they’re predictable, instead of prompting the user to add the email address to their account…

<img width="460" alt="screen shot 2017-06-08 at 4 15 27 pm" src="https://user-images.githubusercontent.com/282113/26954647-07c21d3c-4c66-11e7-9884-4d98f55aca28.png">

…let’s instead prompt them to link their GitHub account, which will _actually_ connect the builds and not require a weird email verification dance!

<img width="459" alt="screen shot 2017-06-08 at 4 16 30 pm" src="https://user-images.githubusercontent.com/282113/26954662-24e6a662-4c66-11e7-9790-2623441fb80c.png">

“Manage Connected Apps” takes the user to `/user/connected-apps` where they can add their GitHub account. We _could_ hypothetically make this link directly do the GitHub auth flow, but this component doesn’t (read: currently can’t!) actually check if an account is connected, and it feels like it’d be weird to do that straight from a build page.

It also _doesn’t_ address the case of a user having an account connected already - either because this is actually another user’s GitHub account, or because they’ve changed account names and our cache hasn’t caught up.