### PR TITLE
Update AgentStateIcon to use isRunningJob

### DIFF
--- a/app/components/agent/Index/row.js
+++ b/app/components/agent/Index/row.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { Link } from 'react-router';
 
-import StateIcon from '../state-icon';
+import AgentStateIcon from '../state-icon';
 import Panel from '../../shared/Panel';
 import JobLink from '../../shared/JobLink';
 
@@ -11,7 +11,6 @@ class AgentRow extends React.PureComponent {
   static propTypes = {
     agent: PropTypes.shape({
       id: PropTypes.string.isRequired,
-      connectionState: PropTypes.string.isRequired,
       hostname: PropTypes.string.isRequired,
       job: PropTypes.shape({
         state: PropTypes.string
@@ -29,7 +28,11 @@ class AgentRow extends React.PureComponent {
   renderJob() {
     const { agent } = this.props;
 
-    if (agent.job) {
+    if (agent.isRunningJob) {
+      const job = agent.job
+        ? <JobLink job={agent.job} />
+        : 'a job owned by another team';
+
       return (
         <small
           className="block mt1 pt1 border border-gray"
@@ -39,7 +42,7 @@ class AgentRow extends React.PureComponent {
             borderBottom: 'none'
           }}
         >
-          Running <JobLink job={agent.job} />
+          Running {job}
         </small>
       );
     }
@@ -56,7 +59,7 @@ class AgentRow extends React.PureComponent {
     return (
       <Panel.Row>
         <div className="flex">
-          <StateIcon agent={agent} className="pr3 pt1" />
+          <AgentStateIcon agent={agent} className="pr3 pt1" />
           <div className="flex flex-auto flex-column">
             <div className="flex flex-auto">
               <div className="flex-auto">
@@ -87,14 +90,15 @@ export default Relay.createContainer(AgentRow, {
   fragments: {
     agent: () => Relay.QL`
       fragment on Agent {
+        ${AgentStateIcon.getFragment('agent')}
         id
-        connectionState
         hostname
         metaData
         name
         organization {
           slug
         }
+        isRunningJob
         job {
           ...on JobTypeCommand {
             state

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -4,7 +4,7 @@ import Relay from 'react-relay/classic';
 import DocumentTitle from 'react-document-title';
 import { seconds } from 'metrick/duration';
 
-import StateIcon from './state-icon';
+import AgentStateIcon from './state-icon';
 import Button from '../shared/Button';
 import FlashesStore from '../../stores/FlashesStore';
 import FriendlyTime from '../shared/FriendlyTime';
@@ -87,7 +87,7 @@ class AgentShow extends React.Component {
 
     extras.push(this.renderExtraItem('State', (
       <span>
-        <StateIcon agent={agent} className="pr2" />
+        <AgentStateIcon agent={agent} className="pr2" />
         {getLabelForConnectionState(agent.connectionState)}
       </span>
     )));
@@ -120,8 +120,14 @@ class AgentShow extends React.Component {
       extras.push(this.renderExtraItem('Priority', agent.priority));
     }
 
-    if (agent.job) {
-      extras.push(this.renderExtraItem('Running', <JobLink job={agent.job} />));
+    if (agent.isRunningJob) {
+      extras.push(this.renderExtraItem(
+        'Running',
+        // if we have access to the job, show a link
+        agent.job
+          ? <JobLink job={agent.job} />
+          : 'A job owned by another team'
+      ));
     }
 
     if (agent.connectedAt) {
@@ -295,6 +301,7 @@ export default Relay.createContainer(AgentShow, {
   fragments: {
     agent: () => Relay.QL`
       fragment on Agent {
+        ${AgentStateIcon.getFragment('agent')}
         ${AgentStopMutation.getFragment('agent')}
         id
         name
@@ -311,6 +318,7 @@ export default Relay.createContainer(AgentShow, {
         job {
           ${JobLink.getFragment('job')}
         }
+        isRunningJob
         lostAt
         metaData
         operatingSystem {

--- a/app/components/agent/state-icon.js
+++ b/app/components/agent/state-icon.js
@@ -8,7 +8,7 @@ import { getColourForConnectionState, getLabelForConnectionState } from './share
 
 import BuildStates from '../../constants/BuildStates';
 
-class AgentStateIcon extends React.Component {
+class AgentStateIcon extends React.PureComponent {
   static propTypes = {
     agent: PropTypes.shape({
       connectionState: PropTypes.string.isRequired,

--- a/app/components/agent/state-icon.js
+++ b/app/components/agent/state-icon.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Relay from 'react-relay/classic';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -7,38 +8,57 @@ import { getColourForConnectionState, getLabelForConnectionState } from './share
 
 import BuildStates from '../../constants/BuildStates';
 
-export default function StateIcon(props) {
-  const title = getLabelForConnectionState(props.agent.connectionState);
-  const color = getColourForConnectionState(props.agent.connectionState, 'bg-');
-  let icon;
+class AgentStateIcon extends React.Component {
+  static propTypes = {
+    agent: PropTypes.shape({
+      connectionState: PropTypes.string.isRequired,
+      isRunningJob: PropTypes.bool.isRequired
+    }),
+    className: PropTypes.string
+  };
 
-  // If we've got a job, we'll steal the "running" icon from the build state
-  // to show that the agent is doing something.
-  if (props.agent.job) {
-    icon = (
-      <BuildState.XSmall state={BuildStates.RUNNING} style={{ display: 'inline-block' }} />
-    );
-  } else {
-    icon = (
-      <div
-        className={classNames('inline-block circle', color)}
-        style={{ width: 13, height: 13 }}
-        title={getLabelForConnectionState(props.agent.connectionState)}
-      />
+  render() {
+    const { agent, className } = this.props;
+
+    const title = getLabelForConnectionState(agent.connectionState);
+    const color = getColourForConnectionState(agent.connectionState, 'bg-');
+
+    let icon;
+
+    // If the agent is running a job, we'll steal the "running" icon
+    // from the build state to show that the agent is doing something.
+    if (agent.isRunningJob) {
+      icon = (
+        <BuildState.XSmall
+          state={BuildStates.RUNNING}
+          style={{ display: 'inline-block' }}
+        />
+      );
+    } else {
+      icon = (
+        <div
+          className={classNames('inline-block circle', color)}
+          style={{ width: 13, height: 13 }}
+          title={getLabelForConnectionState(agent.connectionState)}
+        />
+      );
+    }
+
+    return (
+      <div title={title} className={classNames("inline align-middle", className)}>
+        {icon}
+      </div>
     );
   }
-
-  return (
-    <div title={title} className={classNames("inline align-middle", props.className)}>
-      {icon}
-    </div>
-  );
 }
 
-StateIcon.propTypes = {
-  className: PropTypes.string,
-  agent: PropTypes.shape({
-    connectionState: PropTypes.string.isRequired,
-    job: PropTypes.object
-  })
-};
+export default Relay.createContainer(AgentStateIcon, {
+  fragments: {
+    agent: () => Relay.QL`
+      fragment on Agent {
+        connectionState
+        isRunningJob
+      }
+    `
+  }
+});


### PR DESCRIPTION
This means that users who don’t have permission to view a job do not see agents running them as idle; instead they’re told they’re busy with something they can’t see!

<img width="296" alt="screen shot 2017-06-13 at 1 11 06 pm" src="https://user-images.githubusercontent.com/282113/27102404-ff16c3d6-5039-11e7-940f-e9200b5dd0c9.png">

<img width="583" alt="screen shot 2017-06-13 at 1 11 19 pm" src="https://user-images.githubusercontent.com/282113/27102405-ff337378-5039-11e7-951b-9a2ac67e7334.png">

This also updates the `AgentStateIcon` to be a Relay component defining its data requirements explicitly.