### PR TITLE
Don't pluralize "members" for a single member

### DIFF
--- a/app/components/member/Index.js
+++ b/app/components/member/Index.js
@@ -149,7 +149,7 @@ class MemberIndex extends React.PureComponent {
       return (
         <div className="bg-silver semi-bold py2 px3">
           <small className="dark-gray">
-            {formatNumber(members.count)} matching members
+            {formatNumber(members.count)} matching member{members.count !== 1 && 's'}
           </small>
         </div>
       );

--- a/app/components/team/Members/index.js
+++ b/app/components/team/Members/index.js
@@ -116,7 +116,7 @@ class Members extends React.Component {
       return (
         <div className="bg-silver semi-bold py2 px3">
           <small className="dark-gray">
-            {formatNumber(members.count)} matching members
+            {formatNumber(members.count)} matching member{members.count !== 1 && 's'}
           </small>
         </div>
       );


### PR DESCRIPTION
Currently when you filter down users to a single user, it incorrectly pluralises the phrase "1 member" as "1 members":

<img width="169" alt="members" src="https://user-images.githubusercontent.com/153/27163589-c6a6436c-51cb-11e7-8f6f-5e9e23ba8567.png">

With this change, it now shows "1 member":

<img width="159" alt="singular" src="https://user-images.githubusercontent.com/153/27163616-f507c65e-51cb-11e7-9c5a-5291924f39b5.png">