### PR TITLE
Pipeline paginator

### DIFF
--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -5,7 +5,6 @@ import { second, seconds } from 'metrick/duration';
 import throttle from 'throttleit';
 
 import Panel from '../../shared/Panel';
-import Button from '../../shared/Button';
 import SearchField from '../../shared/SearchField';
 import ShowMoreFooter from '../../shared/ShowMoreFooter';
 import Spinner from '../../shared/Spinner';

--- a/app/components/member/Edit/team-memberships/index.js
+++ b/app/components/member/Edit/team-memberships/index.js
@@ -4,6 +4,7 @@ import Relay from 'react-relay/classic';
 
 import Button from '../../../shared/Button';
 import Panel from '../../../shared/Panel';
+import ShowMoreFooter from '../../../shared/ShowMoreFooter';
 import Spinner from '../../../shared/Spinner';
 
 import Row from './row';
@@ -20,9 +21,6 @@ class TeamMemberships extends React.PureComponent {
       uuid: PropTypes.string.isRequired,
       teams: PropTypes.shape({
         count: PropTypes.number.isRequired,
-        pageInfo: PropTypes.shape({
-          hasNextPage: PropTypes.bool.isRequired
-        }).isRequired,
         edges: PropTypes.arrayOf(
           PropTypes.shape({
             node: PropTypes.object.isRequired
@@ -51,7 +49,12 @@ class TeamMemberships extends React.PureComponent {
         </div>
         <Panel>
           {this.renderTeams()}
-          {this.renderTeamsFooter()}
+          <ShowMoreFooter
+            connection={this.props.organizationMember.teams}
+            label="teams"
+            loading={this.state.loading}
+            onShowMore={this.handleShowMoreTeams}
+          />
         </Panel>
       </div>
     );
@@ -81,36 +84,7 @@ class TeamMemberships extends React.PureComponent {
     ));
   }
 
-  renderTeamsFooter() {
-    // don't show any footer if we haven't ever loaded
-    // any teams, or if there's no next page
-    if (!this.props.organizationMember.teams || !this.props.organizationMember.teams.pageInfo.hasNextPage) {
-      return;
-    }
-
-    let footerContent = (
-      <Button
-        outline={true}
-        theme="default"
-        onClick={this.handleLoadMoreTeamsClick}
-      >
-        Show more memberships…
-      </Button>
-    );
-
-    // show a spinner if we're loading more teams
-    if (this.state.loading) {
-      footerContent = <Spinner style={{ margin: 9.5 }} />;
-    }
-
-    return (
-      <Panel.Footer className="center">
-        {footerContent}
-      </Panel.Footer>
-    );
-  }
-
-  handleLoadMoreTeamsClick = () => {
+  handleShowMoreTeams = () => {
     this.setState({ loading: true });
 
     let { teamsPageSize } = this.props.relay.variables;
@@ -141,10 +115,8 @@ export default Relay.createContainer(TeamMemberships, {
           id
         }
         teams(first: $teamsPageSize, order: NAME) {
+          ${ShowMoreFooter.getFragment('connection')}
           count
-          pageInfo {
-            hasNextPage
-          }
           edges {
             node {
               id

--- a/app/components/member/Edit/team-memberships/index.js
+++ b/app/components/member/Edit/team-memberships/index.js
@@ -2,10 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 
-import Button from '../../../shared/Button';
 import Panel from '../../../shared/Panel';
 import ShowMoreFooter from '../../../shared/ShowMoreFooter';
-import Spinner from '../../../shared/Spinner';
 
 import Row from './row';
 import Chooser from './chooser';

--- a/app/components/member/Index.js
+++ b/app/components/member/Index.js
@@ -43,9 +43,6 @@ class MemberIndex extends React.PureComponent {
         ).isRequired
       }),
       invitations: PropTypes.shape({
-        pageInfo: PropTypes.shape({
-          hasNextPage: PropTypes.bool.isRequired
-        }).isRequired,
         edges: PropTypes.arrayOf(
           PropTypes.shape({
             node: PropTypes.object.isRequired
@@ -109,11 +106,11 @@ class MemberIndex extends React.PureComponent {
             {this.renderMemberSearchInfo()}
             {this.renderMembers()}
             <ShowMoreFooter
-              label="Users"
+              connection={this.props.organization.members}
+              label="users"
               loading={this.state.loadingMembers}
               searching={this.state.searchingMembers}
               onShowMore={this.handleShowMoreMembers}
-              connection={this.props.organization.members}
             />
           </Panel>
 
@@ -237,10 +234,10 @@ class MemberIndex extends React.PureComponent {
           <Panel.Header>Invitations</Panel.Header>
           {this.renderInvitations()}
             <ShowMoreFooter
-              label="Invitations"
-              loading={this.state.loadingInvitations}
-              onShowMore={this.handleLoadMoreInvitationsClick}
               connection={this.props.organization.invitations}
+              label="invitations"
+              loading={this.state.loadingInvitations}
+              onShowMore={this.handleShowMoreInvitations}
             />
         </Panel>
       );
@@ -279,36 +276,7 @@ class MemberIndex extends React.PureComponent {
     );
   }
 
-  renderInvitationFooter() {
-    // don't show any footer if we haven't ever loaded
-    // any invitations, or if there's no next page
-    if (!this.props.organization.invitations || !this.props.organization.invitations.pageInfo.hasNextPage) {
-      return;
-    }
-
-    let footerContent = (
-      <Button
-        outline={true}
-        theme="default"
-        onClick={this.handleLoadMoreInvitationsClick}
-      >
-        Show more invitations…
-      </Button>
-    );
-
-    // show a spinner if we're loading more invitations
-    if (this.state.loadingInvitations) {
-      footerContent = <Spinner style={{ margin: 9.5 }} />;
-    }
-
-    return (
-      <Panel.Footer className="center">
-        {footerContent}
-      </Panel.Footer>
-    );
-  }
-
-  handleLoadMoreInvitationsClick = () => {
+  handleShowMoreInvitations = () => {
     this.setState({ loadingInvitations: true });
 
     let { invitationPageSize } = this.props.relay.variables;
@@ -357,14 +325,12 @@ export default Relay.createContainer(MemberIndex, {
           }
         }
         invitations(first: $invitationPageSize, state: PENDING) @include(if: $isMounted) {
+          ${ShowMoreFooter.getFragment('connection')}
           edges {
             node {
               id
               ${InvitationRow.getFragment('organizationInvitation')}
             }
-          }
-          pageInfo {
-            hasNextPage
           }
         }
       }

--- a/app/components/member/Index.js
+++ b/app/components/member/Index.js
@@ -7,7 +7,7 @@ import DocumentTitle from 'react-document-title';
 import Button from '../shared/Button';
 import Dropdown from '../shared/Dropdown';
 import Icon from '../shared/Icon';
-import LoadMoreFooter from '../shared/LoadMoreFooter';
+import ShowMoreFooter from '../shared/ShowMoreFooter';
 import PageHeader from '../shared/PageHeader';
 import Panel from '../shared/Panel';
 import SearchField from '../shared/SearchField';
@@ -36,9 +36,6 @@ class MemberIndex extends React.PureComponent {
       permissions: PropTypes.object.isRequired,
       members: PropTypes.shape({
         count: PropTypes.number.isRequired,
-        pageInfo: PropTypes.shape({
-          hasNextPage: PropTypes.bool.isRequired
-        }).isRequired,
         edges: PropTypes.arrayOf(
           PropTypes.shape({
             node: PropTypes.object.isRequired
@@ -111,15 +108,13 @@ class MemberIndex extends React.PureComponent {
             </div>
             {this.renderMemberSearchInfo()}
             {this.renderMembers()}
-            {this.props.relay.variables.isMounted && (
-              <LoadMoreFooter
-                label="Users"
-                loading={this.state.loadingMembers}
-                searching={this.state.searchingMembers}
-                onLoadMore={this.handleLoadMoreMembers}
-                connection={this.props.organization.members}
-              />
-            )}
+            <ShowMoreFooter
+              label="Users"
+              loading={this.state.loadingMembers}
+              searching={this.state.searchingMembers}
+              onShowMore={this.handleShowMoreMembers}
+              connection={this.props.organization.members}
+            />
           </Panel>
 
           {this.renderInvitationsPanel()}
@@ -218,7 +213,7 @@ class MemberIndex extends React.PureComponent {
     );
   };
 
-  handleLoadMoreMembers = () => {
+  handleShowMoreMembers = () => {
     this.setState({ loadingMembers: true });
 
     let { memberPageSize } = this.props.relay.variables;
@@ -241,7 +236,12 @@ class MemberIndex extends React.PureComponent {
         <Panel>
           <Panel.Header>Invitations</Panel.Header>
           {this.renderInvitations()}
-          {this.renderInvitationFooter()}
+            <ShowMoreFooter
+              label="Invitations"
+              loading={this.state.loadingInvitations}
+              onShowMore={this.handleLoadMoreInvitationsClick}
+              connection={this.props.organization.invitations}
+            />
         </Panel>
       );
     }
@@ -347,7 +347,7 @@ export default Relay.createContainer(MemberIndex, {
           }
         }
         members(first: $memberPageSize, search: $memberSearch, role: $memberRole, order: NAME) @include(if: $isMounted) {
-          ${LoadMoreFooter.getFragment('connection')}
+          ${ShowMoreFooter.getFragment('connection')}
           count
           edges {
             node {

--- a/app/components/member/Index.js
+++ b/app/components/member/Index.js
@@ -4,7 +4,6 @@ import Relay from 'react-relay/classic';
 import { second } from 'metrick/duration';
 import DocumentTitle from 'react-document-title';
 
-import Button from '../shared/Button';
 import Dropdown from '../shared/Dropdown';
 import Icon from '../shared/Icon';
 import ShowMoreFooter from '../shared/ShowMoreFooter';
@@ -233,12 +232,12 @@ class MemberIndex extends React.PureComponent {
         <Panel>
           <Panel.Header>Invitations</Panel.Header>
           {this.renderInvitations()}
-            <ShowMoreFooter
-              connection={this.props.organization.invitations}
-              label="invitations"
-              loading={this.state.loadingInvitations}
-              onShowMore={this.handleShowMoreInvitations}
-            />
+          <ShowMoreFooter
+            connection={this.props.organization.invitations}
+            label="invitations"
+            loading={this.state.loadingInvitations}
+            onShowMore={this.handleShowMoreInvitations}
+          />
         </Panel>
       );
     }

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -2,9 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 
-import Button from '../shared/Button';
 import SectionLoader from '../shared/SectionLoader';
-import Spinner from '../shared/Spinner';
+import ShowMoreFooter from '../shared/ShowMoreFooter';
 
 import FlashesStore from '../../stores/FlashesStore';
 import UserSessionStore from '../../stores/UserSessionStore';
@@ -27,10 +26,7 @@ class OrganizationPipelines extends React.Component {
               id: PropTypes.string.isRequired
             }).isRequired
           }).isRequired
-        ),
-        pageInfo: PropTypes.shape({
-          hasNextPage: PropTypes.bool.isRequired
-        }).isRequired
+        )
       })
     }),
     relay: PropTypes.object.isRequired,
@@ -148,7 +144,13 @@ class OrganizationPipelines extends React.Component {
       return (
         <div>
           {this.renderPipelines()}
-          {this.renderPipelineFooter()}
+          <ShowMoreFooter
+            connection={this.props.organization.pipelines}
+            label="pipelines"
+            loading={this.state.loadingMore}
+            onShowMore={this.handleShowMorePipelines}
+            wrappingElement="div"
+          />
         </div>
       );
     } else if (this.props.filter) {
@@ -193,39 +195,7 @@ class OrganizationPipelines extends React.Component {
     return [];
   }
 
-  renderPipelineFooter() {
-    const { organization } = this.props;
-    const { loadingMore } = this.state;
-
-    // don't show any footer if we haven't ever loaded
-    // any pipelines, or if there's no next page
-    if (!organization.pipelines || !organization.pipelines.pageInfo.hasNextPage) {
-      return;
-    }
-
-    let footerContent = (
-      <Button
-        outline={true}
-        theme="default"
-        onClick={this.handleLoadMorePipelinesClick}
-      >
-        Load more pipelines…
-      </Button>
-    );
-
-    // show a spinner if we're loading more pipelines
-    if (loadingMore) {
-      footerContent = <Spinner style={{ margin: 9.5 }} />;
-    }
-
-    return (
-      <div className="center">
-        {footerContent}
-      </div>
-    );
-  }
-
-  handleLoadMorePipelinesClick = () => {
+  handleShowMorePipelines = () => {
     this.setState({ loadingMore: true });
 
     this.props.relay.setVariables(
@@ -256,15 +226,13 @@ export default Relay.createContainer(OrganizationPipelines, {
         id
         slug
         pipelines(search: $pipelineFilter, first: $pageSize, team: $teamSearch, order: NAME_WITH_FAVORITES_FIRST) @include(if: $isMounted) {
+          ${ShowMoreFooter.getFragment('connection')}
           edges {
             node {
               id
               favorite
               ${Pipeline.getFragment('pipeline', { includeGraphData: variables.includeGraphData })}
             }
-          }
-          pageInfo {
-            hasNextPage
           }
         }
       }

--- a/app/components/shared/LoadMoreFooter.js
+++ b/app/components/shared/LoadMoreFooter.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Relay from 'react-relay/classic';
+
+import Button from './Button';
+import Panel from './Panel';
+import Spinner from './Spinner';
+
+class LoadMoreFooter extends React.PureComponent {
+  static propTypes = {
+    connection: PropTypes.shape({
+      pageInfo: PropTypes.shape({
+        hasNextPage: PropTypes.bool.isRequired
+      }).isRequiredk
+    }),
+    onShowMore: PropTypes.func.isRequired,
+    label: PropTypes.string,
+    loading: PropTypes.bool,
+    searching: PropTypes.bool
+  };
+
+  static defaultProps = {
+    loading: false,
+    searching: false
+  };
+
+  render() {
+    const { connection, loading, searching } = this.props;
+
+    // don't show any footer if we're searching
+    if (searching) {
+      return;
+    }
+
+    // don't show any footer if we haven't ever loaded
+    // any agents, or if there's no next page
+    if (!connection || !connection.pageInfo.hasNextPage) {
+      return;
+    }
+
+    let footerContent = (
+      <Button
+        outline={true}
+        theme="default"
+        onClick={this.props.onShowMore}
+      >
+        Show more{this.props.label ? ` ${this.props.label}` : ''}…
+      </Button>
+    );
+
+    // show a spinner if we're loading more
+    if (loading) {
+      footerContent = <Spinner style={{ margin: 9.5 }} />;
+    }
+
+    return (
+      <Panel.Footer className="center">
+        {footerContent}
+      </Panel.Footer>
+    );
+  }
+}
+
+export default Relay.createContainer(LoadMoreFooter, {
+  fragments: {
+    connection: () => Relay.QL`
+      fragment on Connection {
+        pageInfo {
+          hasNextPage
+        }
+      }
+    `
+  }
+});

--- a/app/components/shared/Panel/index.js
+++ b/app/components/shared/Panel/index.js
@@ -1,12 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import styled from 'styled-components';
 
 import IntroWithButton from './intro-with-button';
 import Row from './row';
 import RowActions from './row-actions';
 import RowLink from './row-link';
 import Header from './header';
+
+const Separator = styled.hr.attrs({
+  className: 'p0 m0 bg-gray'
+})`
+  border: none;
+  height: 1px;
+
+  &:last-child {
+    display: none;
+  }
+`;
 
 class Panel extends React.PureComponent {
   static propTypes = {
@@ -22,7 +34,7 @@ class Panel extends React.PureComponent {
     let key = 0;
     for (let index = 0, length = children.length; index < length; index++) {
       if (index > 0) {
-        nodes.push(<hr key={key += 1} className="p0 m0 bg-gray" style={{ border: "none", height: 1 }} />);
+        nodes.push(<Separator key={key += 1} />);
       }
 
       nodes.push(children[index]);

--- a/app/components/shared/ShowMoreFooter.js
+++ b/app/components/shared/ShowMoreFooter.js
@@ -16,12 +16,17 @@ class ShowMoreFooter extends React.PureComponent {
     onShowMore: PropTypes.func.isRequired,
     label: PropTypes.string,
     loading: PropTypes.bool,
-    searching: PropTypes.bool
+    searching: PropTypes.bool,
+    wrappingElement: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string
+    ]).isRequired
   };
 
   static defaultProps = {
     loading: false,
-    searching: false
+    searching: false,
+    wrappingElement: Panel.Footer
   };
 
   render() {
@@ -53,10 +58,12 @@ class ShowMoreFooter extends React.PureComponent {
       footerContent = <Spinner style={{ margin: 9.5 }} />;
     }
 
+    const Wrapper = this.props.wrappingElement;
+
     return (
-      <Panel.Footer className="center">
+      <Wrapper className="center">
         {footerContent}
-      </Panel.Footer>
+      </Wrapper>
     );
   }
 }

--- a/app/components/shared/ShowMoreFooter.js
+++ b/app/components/shared/ShowMoreFooter.js
@@ -6,12 +6,12 @@ import Button from './Button';
 import Panel from './Panel';
 import Spinner from './Spinner';
 
-class LoadMoreFooter extends React.PureComponent {
+class ShowMoreFooter extends React.PureComponent {
   static propTypes = {
     connection: PropTypes.shape({
       pageInfo: PropTypes.shape({
         hasNextPage: PropTypes.bool.isRequired
-      }).isRequiredk
+      }).isRequired
     }),
     onShowMore: PropTypes.func.isRequired,
     label: PropTypes.string,
@@ -29,13 +29,13 @@ class LoadMoreFooter extends React.PureComponent {
 
     // don't show any footer if we're searching
     if (searching) {
-      return;
+      return null;
     }
 
     // don't show any footer if we haven't ever loaded
-    // any agents, or if there's no next page
+    // any items, or if there's no next page
     if (!connection || !connection.pageInfo.hasNextPage) {
-      return;
+      return null;
     }
 
     let footerContent = (
@@ -61,7 +61,7 @@ class LoadMoreFooter extends React.PureComponent {
   }
 }
 
-export default Relay.createContainer(LoadMoreFooter, {
+export default Relay.createContainer(ShowMoreFooter, {
   fragments: {
     connection: () => Relay.QL`
       fragment on Connection {

--- a/app/components/team/Index.js
+++ b/app/components/team/Index.js
@@ -4,7 +4,6 @@ import Relay from 'react-relay/classic';
 import { second } from 'metrick/duration';
 import DocumentTitle from 'react-document-title';
 
-import Button from '../shared/Button';
 import Dropdown from '../shared/Dropdown';
 import Icon from '../shared/Icon';
 import PageHeader from '../shared/PageHeader';

--- a/app/components/team/Members/index.js
+++ b/app/components/team/Members/index.js
@@ -4,11 +4,9 @@ import Relay from 'react-relay/classic';
 import { second } from 'metrick/duration';
 
 import Badge from '../../shared/Badge';
-import Button from '../../shared/Button';
 import Panel from '../../shared/Panel';
 import SearchField from '../../shared/SearchField';
 import ShowMoreFooter from '../../shared/ShowMoreFooter';
-import Spinner from '../../shared/Spinner';
 
 import { formatNumber } from '../../../lib/number';
 

--- a/app/components/team/Members/index.js
+++ b/app/components/team/Members/index.js
@@ -37,6 +37,7 @@ class Members extends React.Component {
 
   state = {
     loading: false,
+    searchingMembers: false,
     searchingMembersIsSlow: false
   };
 

--- a/app/components/team/Members/index.js
+++ b/app/components/team/Members/index.js
@@ -7,6 +7,7 @@ import Badge from '../../shared/Badge';
 import Button from '../../shared/Button';
 import Panel from '../../shared/Panel';
 import SearchField from '../../shared/SearchField';
+import ShowMoreFooter from '../../shared/ShowMoreFooter';
 import Spinner from '../../shared/Spinner';
 
 import { formatNumber } from '../../../lib/number';
@@ -29,9 +30,6 @@ class Members extends React.Component {
       }).isRequired,
       members: PropTypes.shape({
         count: PropTypes.number.isRequired,
-        pageInfo: PropTypes.shape({
-          hasNextPage: PropTypes.bool.isRequired
-        }).isRequired,
         edges: PropTypes.array.isRequired
       }).isRequired
     }).isRequired,
@@ -55,7 +53,13 @@ class Members extends React.Component {
           {this.renderMemberSearch()}
           {this.renderMemberSearchInfo()}
           {this.renderMembers()}
-          {this.renderMemberFooter()}
+          <ShowMoreFooter
+            connection={this.props.team.members}
+            label="members"
+            loading={this.state.loading}
+            searching={this.state.searchingMembers}
+            onShowMore={this.handleShowMoreMembers}
+          />
         </Panel>
       </div>
     );
@@ -123,35 +127,6 @@ class Members extends React.Component {
     }
   }
 
-  renderMemberFooter() {
-    // don't show any footer if we haven't ever loaded
-    // any members, or if there's no next page
-    if (!this.props.team.members || !this.props.team.members.pageInfo.hasNextPage) {
-      return;
-    }
-
-    let footerContent = (
-      <Button
-        outline={true}
-        theme="default"
-        onClick={this.handleLoadMoreMembersClick}
-      >
-        Show more members…
-      </Button>
-    );
-
-    // show a spinner if we're loading more members
-    if (this.state.loading) {
-      footerContent = <Spinner style={{ margin: 9.5 }} />;
-    }
-
-    return (
-      <Panel.Footer className="center">
-        {footerContent}
-      </Panel.Footer>
-    );
-  }
-
   handleMemberSearch = (memberSearch) => {
     this.setState({ searchingMembers: true });
 
@@ -179,7 +154,7 @@ class Members extends React.Component {
     );
   };
 
-  handleLoadMoreMembersClick = () => {
+  handleShowMoreMembers = () => {
     this.setState({ loading: true });
 
     let { pageSize } = this.props.relay.variables;
@@ -237,6 +212,7 @@ export default Relay.createContainer(Members, {
         }
 
         members(first: $pageSize, search: $memberSearch, order: NAME) {
+          ${ShowMoreFooter.getFragment('connection')}
           count
           edges {
             node {
@@ -261,9 +237,6 @@ export default Relay.createContainer(Members, {
               ${TeamMemberDeleteMutation.getFragment('teamMember')}
               ${TeamMemberUpdateMutation.getFragment('teamMember')}
             }
-          }
-          pageInfo {
-            hasNextPage
           }
         }
       }

--- a/app/graph/schema.json
+++ b/app/graph/schema.json
@@ -2114,8 +2114,81 @@
           ],
           "inputFields": null,
           "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PageInfo",
+          "description": "Metadata about a connection",
+          "fields": [
+            {
+              "name": "hasNextPage",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasPreviousPage",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
 
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "Represents `true` or `false` values.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2768,16 +2841,6 @@
               "deprecationReason": null
             }
           ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Int",
-          "description": "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -3679,7 +3742,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -4350,16 +4417,6 @@
         },
         {
           "kind": "SCALAR",
-          "name": "Boolean",
-          "description": "Represents `true` or `false` values.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
           "name": "DateTime",
           "description": "An ISO-8601 encoded UTC date string",
           "fields": null,
@@ -4426,7 +4483,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -5792,7 +5853,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -6000,12 +6065,12 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "PageInfo",
-          "description": "Metadata about a connection",
+          "kind": "INTERFACE",
+          "name": "Connection",
+          "description": null,
           "fields": [
             {
-              "name": "hasNextPage",
+              "name": "count",
               "description": null,
               "args": [
 
@@ -6015,7 +6080,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -6023,30 +6088,130 @@
               "deprecationReason": null
             },
             {
-              "name": "hasPreviousPage",
+              "name": "pageInfo",
               "description": null,
               "args": [
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             }
           ],
           "inputFields": null,
-          "interfaces": [
-
-          ],
+          "interfaces": null,
           "enumValues": null,
-          "possibleTypes": null
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "APIAccessTokenConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AgentConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AgentTokenConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AnnotationConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ArtifactConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "BuildConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "BuildMetaDataConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ChangelogConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "CommentConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "EmailConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "JobConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "OrganizationConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "OrganizationInvitationConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "OrganizationInvitationTeamAssignmentConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "OrganizationMemberConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "PipelineConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "PipelineMetricConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "PipelineScheduleConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "TeamConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "TeamMemberConnection",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "TeamPipelineConnection",
+              "ofType": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",
@@ -6466,7 +6631,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -7204,7 +7373,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -7637,7 +7810,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -7826,7 +8003,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -8401,7 +8582,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -8538,7 +8723,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -8856,7 +9045,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -9013,7 +9206,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -9630,7 +9827,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -10047,7 +10248,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -10484,7 +10689,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -10695,7 +10904,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -11020,7 +11233,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -11177,7 +11394,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -11392,7 +11613,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -11610,7 +11835,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -11894,7 +12123,11 @@
           ],
           "inputFields": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "Connection",
+              "ofType": null
+            }
           ],
           "enumValues": null,
           "possibleTypes": null


### PR DESCRIPTION
This is an extension of #291 which adds the “Show More” component to the Pipeline index.

I didn’t include it in #291 because it feels a bit _iffy_. Passing a component reference at render time feels really awkward and weird.

It also feels like, with the knowledge that we’re pondering design refreshes for these components, but those refreshes don’t appear to apply to the Pipelines page, this might need to be held back until we know what we want.

Or maybe I’m overthinking the whole thing 🤔