### PR TITLE
Tweak maintainer copy in the team member role window

### DIFF
--- a/app/components/shared/Chooser/select-option.js
+++ b/app/components/shared/Chooser/select-option.js
@@ -26,7 +26,7 @@ SelectOption.displayName = "Chooser.SelectOption";
 SelectOption.propTypes = {
   value: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+  description: PropTypes.node.isRequired,
   saving: PropTypes.bool,
   selected: PropTypes.bool
 };

--- a/app/components/shared/Icon/permission-small-cross.svg
+++ b/app/components/shared/Icon/permission-small-cross.svg
@@ -1,0 +1,4 @@
+<g stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="square" transform="translate(10.000000, 10.000000) rotate(45.000000) translate(-10.000000, -10.000000) translate(5.000000, 5.000000)">
+  <path d="M0,5 L10,5"></path>
+  <path d="M5,10 L5,1.77635684e-15"></path>
+</g>

--- a/app/components/shared/Icon/permission-small-tick.svg
+++ b/app/components/shared/Icon/permission-small-tick.svg
@@ -1,0 +1,1 @@
+<polyline stroke-width="2" stroke="currentColor" fill="none" points="5.74865723 10.3518066 9.29565517 13.9886531 15.2611084 5.61889648"></polyline>

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -7,6 +7,27 @@ import Icon from '../../shared/Icon';
 
 import TeamMemberRoleConstants from '../../../constants/TeamMemberRoleConstants';
 
+const PermissionBlock = ({ children }) => (
+  <div className="pointer-events-none" style={{ marginTop: 8, marginLeft: -4 }}>
+    {children}
+  </div>
+);
+
+const Permission = ({ icon, children }) => (
+  <div className="flex mt1" style={{ lineHeight: 1.4 }}>
+    <Icon icon={icon} className="dark-gray flex-none mr1" style={{ marginTop: -3 }} />
+    {children}
+  </div>
+);
+
+const Can = ({ permission }) => (
+  <Permission icon="permission-small-tick" title="Tick">Can {permission}.</Permission>
+);
+
+const CanNot = ({ permission }) => (
+  <Permission icon="permission-small-cross" title="Cross">Can not {permission}.</Permission>
+);
+
 export default class MemberRole extends React.PureComponent {
   static displayName = "Team.Pipelines.Role";
 
@@ -20,27 +41,6 @@ export default class MemberRole extends React.PureComponent {
 
   render() {
     const saving = this.props.savingNewRole;
-
-    const PermissionBlock = ({ children }) => (
-      <div className="pointer-events-none" style={{ marginTop: 8, marginLeft: -4 }}>
-        {children}
-      </div>
-    );
-
-    const Permission = ({ icon, children }) => (
-      <div className="flex mt1" style={{ lineHeight: 1.4 }}>
-        <Icon icon={icon} className="dark-gray flex-none mr1" style={{ marginTop: -3 }} />
-        {children}
-      </div>
-    );
-
-    const Can = ({ permission }) => (
-      <Permission icon="permission-small-tick" title="Tick">Can {permission}.</Permission>
-    );
-
-    const CanNot = ({ permission }) => (
-      <Permission icon="permission-small-cross" title="Cross">Can not {permission}.</Permission>
-    );
 
     return (
       <Dropdown width={270}>

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import Chooser from '../../shared/Chooser';
 import Dropdown from '../../shared/Dropdown';
+import Icon from '../../shared/Icon';
 
 import TeamMemberRoleConstants from '../../../constants/TeamMemberRoleConstants';
 
@@ -20,6 +21,27 @@ export default class MemberRole extends React.PureComponent {
   render() {
     const saving = this.props.savingNewRole;
 
+    const PermissionBlock = ({ children }) => (
+      <div className="pointer-events-none" style={{ marginTop: 8, marginLeft: -4 }}>
+        {children}
+      </div>
+    );
+
+    const Permission = ({ icon, children }) => (
+      <div className="flex mt1" style={{ lineHeight: 1.4 }}>
+        <Icon icon={icon} className="dark-gray flex-none mr1" style={{ marginTop: -3 }} />
+        {children}
+      </div>
+    )
+
+    const Can = ({ permission }) => (
+      <Permission icon="permission-small-tick" title="Tick">Can {permission}.</Permission>
+    );
+
+    const CanNot = ({ permission }) => (
+      <Permission icon="permission-small-cross" title="Cross">Can not {permission}.</Permission>
+    );
+
     return (
       <Dropdown width={270}>
         <div className="underline-dotted cursor-pointer inline-block regular">{this.label(this.props.teamMember.role)}</div>
@@ -30,14 +52,24 @@ export default class MemberRole extends React.PureComponent {
             saving={saving === TeamMemberRoleConstants.MAINTAINER}
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MAINTAINER}
             label={this.label(TeamMemberRoleConstants.MAINTAINER)}
-            description={<span>Can create and access pipelines.<br />Can add and remove users.</span>}
+            description={
+              <PermissionBlock>
+                <Can permission="add and remove pipelines" />
+                <Can permission="add and remove users" />
+              </PermissionBlock>
+            }
           />
           <Chooser.SelectOption
             value={TeamMemberRoleConstants.MEMBER}
             saving={saving === TeamMemberRoleConstants.MEMBER}
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MEMBER}
             label={this.label(TeamMemberRoleConstants.MEMBER)}
-            description="Can create and access pipelines."
+            description={
+              <PermissionBlock>
+                <Can permission="and and remove pipelines" />
+                <CanNot permission="add or remove users" />
+              </PermissionBlock>
+            }
           />
         </Chooser>
       </Dropdown>
@@ -47,9 +79,9 @@ export default class MemberRole extends React.PureComponent {
   label(value) {
     switch (value) {
       case TeamMemberRoleConstants.MAINTAINER:
-        return "Maintainer";
+        return "Team Maintainer";
       case TeamMemberRoleConstants.MEMBER:
-        return "Member";
+        return "Team Member";
     }
   }
 }

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -30,14 +30,14 @@ export default class MemberRole extends React.PureComponent {
             saving={saving === TeamMemberRoleConstants.MAINTAINER}
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MAINTAINER}
             label={this.label(TeamMemberRoleConstants.MAINTAINER)}
-            description="Create and access pipelines in this team, along with adding and removing users."
+            description={<span>Create and access pipelines.<br />Add and remove users.</span>}
           />
           <Chooser.SelectOption
             value={TeamMemberRoleConstants.MEMBER}
             saving={saving === TeamMemberRoleConstants.MEMBER}
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MEMBER}
             label={this.label(TeamMemberRoleConstants.MEMBER)}
-            description="Create and access pipelines in this team."
+            description="Create and access pipelines."
           />
         </Chooser>
       </Dropdown>

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -30,14 +30,14 @@ export default class MemberRole extends React.PureComponent {
             saving={saving === TeamMemberRoleConstants.MAINTAINER}
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MAINTAINER}
             label={this.label(TeamMemberRoleConstants.MAINTAINER)}
-            description={<span>Create and access pipelines.<br />Add and remove users.</span>}
+            description={<span>Can create and access pipelines.<br />Can add and remove users.</span>}
           />
           <Chooser.SelectOption
             value={TeamMemberRoleConstants.MEMBER}
             saving={saving === TeamMemberRoleConstants.MEMBER}
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MEMBER}
             label={this.label(TeamMemberRoleConstants.MEMBER)}
-            description="Create and access pipelines."
+            description="Can create and access pipelines."
           />
         </Chooser>
       </Dropdown>

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -12,6 +12,7 @@ const PermissionBlock = ({ children }) => (
     {children}
   </div>
 );
+PermissionBlock.propTypes = { children: PropTypes.node };
 
 const Permission = ({ icon, children }) => (
   <div className="flex mt1" style={{ lineHeight: 1.4 }}>
@@ -19,14 +20,17 @@ const Permission = ({ icon, children }) => (
     {children}
   </div>
 );
+Permission.propTypes = { icon: PropTypes.string.isRequired, children: PropTypes.node };
 
 const Can = ({ permission }) => (
   <Permission icon="permission-small-tick" title="Tick">Can {permission}.</Permission>
 );
+Can.propTypes = { permission: PropTypes.node.isRequired };
 
 const CanNot = ({ permission }) => (
   <Permission icon="permission-small-cross" title="Cross">Can not {permission}.</Permission>
 );
+CanNot.propTypes = { permission: PropTypes.node.isRequired };
 
 export default class MemberRole extends React.PureComponent {
   static displayName = "Team.Pipelines.Role";

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -32,7 +32,7 @@ export default class MemberRole extends React.PureComponent {
         <Icon icon={icon} className="dark-gray flex-none mr1" style={{ marginTop: -3 }} />
         {children}
       </div>
-    )
+    );
 
     const Can = ({ permission }) => (
       <Permission icon="permission-small-tick" title="Tick">Can {permission}.</Permission>

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -30,14 +30,14 @@ export default class MemberRole extends React.PureComponent {
             saving={saving === TeamMemberRoleConstants.MAINTAINER}
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MAINTAINER}
             label={this.label(TeamMemberRoleConstants.MAINTAINER)}
-            description="Manage members and pipelines with unrestricted access"
+            description="Create and access pipelines in this team, along with adding and removing users."
           />
           <Chooser.SelectOption
             value={TeamMemberRoleConstants.MEMBER}
             saving={saving === TeamMemberRoleConstants.MEMBER}
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MEMBER}
             label={this.label(TeamMemberRoleConstants.MEMBER)}
-            description="Create and access pipelines based on each pipeline’s permissions"
+            description="Create and access pipelines in this team."
           />
         </Chooser>
       </Dropdown>


### PR DESCRIPTION
I tried this:

![screen shot 2017-07-10 at 2 16 27 pm](https://user-images.githubusercontent.com/25882/28002648-7cefe99a-657a-11e7-9220-80f2abe1f83c.png)

And a slightly more verbose copy which looked a little better in the window:

![screen shot 2017-07-10 at 2 15 39 pm](https://user-images.githubusercontent.com/25882/28002661-8a4f8e38-657a-11e7-84f3-d46bb2490fd3.png)

What do you prefer @toolmantim? I went with the longer one in this PR.