### PR TITLE
Teams form tweaks

### DIFF
--- a/app/components/shared/FormRadioGroup.js
+++ b/app/components/shared/FormRadioGroup.js
@@ -66,17 +66,20 @@ class FormRadioGroup extends React.Component {
       (option, index) => (
         <div key={index} className="mt1">
           <label className="mt1 inline-block pl4">
-            <input
-              className={classNames('absolute', { "is-error": this._hasErrors() }, option.className)}
-              style={{ marginLeft: '-20px' }}
-              name={this.props.name}
-              type="radio"
-              defaultChecked={this.props.value === option.value}
-              value={option.value}
-              onChange={this.props.onChange}
-              ref={(input) => this.inputs[index] = input}
-            />
-            <span className="bold block" style={{ marginBottom: -5 }}> {option.label}</span>
+            <div className="flex">
+              <input
+                className={classNames('absolute', { "is-error": this._hasErrors() }, option.className)}
+                style={{ marginLeft: '-20px' }}
+                name={this.props.name}
+                type="radio"
+                defaultChecked={this.props.value === option.value}
+                value={option.value}
+                onChange={this.props.onChange}
+                ref={(input) => this.inputs[index] = input}
+              />
+              <span className="bold block" style={{ marginBottom: -5 }}> {option.label}</span>
+              {option.badge && <div className="ml1 regular small border border-gray rounded dark-gray px1">{option.badge}</div>}
+            </div>
             {option.help && <FormInputHelp html={option.help} />}
           </label>
         </div>

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 
+import Panel from '../shared/Panel';
+
 import TeamForm from './Form';
 import TeamDelete from './TeamDelete';
 
@@ -45,7 +47,6 @@ class TeamEdit extends React.Component {
       <div>
         <form onSubmit={this.handleFormSubmit}>
           <TeamForm
-            uuid={this.props.team.uuid}
             onChange={this.handleFormChange}
             errors={this.state.errors}
             name={this.state.name}
@@ -56,6 +57,15 @@ class TeamEdit extends React.Component {
             button={this.state.saving ? "Saving team…" : "Save Team"}
           />
         </form>
+
+        <Panel className="mt3">
+          <Panel.Header>REST API Integration</Panel.Header>
+          <Panel.Section>
+            <p>You can use this UUID to reference this team when using the <a href="/docs/rest-api/pipelines#create-a-pipeline" className="blue hover-navy">Create a Pipeline</a> REST API.</p>
+            <code className="block bg-silver p2 rounded">{this.props.team.uuid}</code>
+          </Panel.Section>
+        </Panel>
+
         <TeamDelete team={this.props.team} />
       </div>
     );

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -102,6 +102,9 @@ class TeamEdit extends React.Component {
     this.setState({ saving: false });
 
     FlashesStore.flash(FlashesStore.SUCCESS, "Settings for this team have been saved successfully")
+
+    // Update the URL with the latest version of the slug
+    this.context.router.push(`/organizations/${this.props.team.organization.slug}/teams/${response.teamUpdate.team.slug}/settings`);
   };
 }
 

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -43,22 +43,17 @@ class TeamEdit extends React.Component {
   render() {
     return (
       <form onSubmit={this.handleFormSubmit}>
-        <Panel>
-          <Panel.Section>
-            <TeamForm
-              onChange={this.handleFormChange}
-              errors={this.state.errors}
-              name={this.state.name}
-              description={this.state.description}
-              privacy={this.state.privacy}
-              isDefaultTeam={this.state.isDefaultTeam}
-            />
-          </Panel.Section>
-
-          <Panel.Footer>
-            <Button loading={this.state.saving ? "Saving team…" : false} theme="success">Save Team</Button>
-          </Panel.Footer>
-        </Panel>
+        <TeamForm
+          uuid={this.props.team.uuid}
+          onChange={this.handleFormChange}
+          errors={this.state.errors}
+          name={this.state.name}
+          description={this.state.description}
+          privacy={this.state.privacy}
+          isDefaultTeam={this.state.isDefaultTeam}
+          saving={this.state.saving}
+          button={this.state.saving ? "Saving team…" : "Save Team"}
+        />
       </form>
     );
   }
@@ -113,6 +108,7 @@ export default Relay.createContainer(TeamEdit, {
     team: () => Relay.QL`
       fragment on Team {
         ${TeamUpdateMutation.getFragment('team')}
+        uuid
         name
         slug
         description

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -116,6 +116,7 @@ export default Relay.createContainer(TeamEdit, {
     team: () => Relay.QL`
       fragment on Team {
         ${TeamUpdateMutation.getFragment('team')}
+        ${TeamDelete.getFragment('team')}
         uuid
         name
         slug

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 
-import Panel from '../shared/Panel';
-import Button from '../shared/Button';
 import TeamForm from './Form';
 
 import TeamUpdateMutation from '../../mutations/TeamUpdate';
@@ -15,6 +13,7 @@ class TeamEdit extends React.Component {
     team: PropTypes.shape({
       name: PropTypes.string.isRequired,
       slug: PropTypes.string.isRequired,
+      uuid: PropTypes.string.isRequired,
       description: PropTypes.string,
       privacy: PropTypes.string.isRequired,
       isDefaultTeam: PropTypes.bool.isRequired,
@@ -101,7 +100,7 @@ class TeamEdit extends React.Component {
   handleMutationSuccess = (response) => {
     this.setState({ saving: false });
 
-    FlashesStore.flash(FlashesStore.SUCCESS, "Settings for this team have been saved successfully")
+    FlashesStore.flash(FlashesStore.SUCCESS, "Settings for this team have been saved successfully");
 
     // Update the URL with the latest version of the slug
     this.context.router.push(`/organizations/${this.props.team.organization.slug}/teams/${response.teamUpdate.team.slug}/settings`);

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -99,7 +99,9 @@ class TeamEdit extends React.Component {
   };
 
   handleMutationSuccess = (response) => {
-    this.context.router.push(`/organizations/${this.props.team.organization.slug}/teams/${response.teamUpdate.team.slug}`);
+    this.setState({ saving: false });
+
+    FlashesStore.flash(FlashesStore.SUCCESS, "Settings for this team have been saved successfully")
   };
 }
 

--- a/app/components/team/Edit.js
+++ b/app/components/team/Edit.js
@@ -61,7 +61,7 @@ class TeamEdit extends React.Component {
         <Panel className="mt3">
           <Panel.Header>REST API Integration</Panel.Header>
           <Panel.Section>
-            <p>You can use this UUID to reference this team when using the <a href="/docs/rest-api/pipelines#create-a-pipeline" className="blue hover-navy">Create a Pipeline</a> REST API.</p>
+            <p>You can use this UUID to reference this team when using the <a href="/docs/rest-api/pipelines#create-a-pipeline" className="blue hover-navy">Create Pipeline REST API</a>.</p>
             <code className="block bg-silver p2 rounded">{this.props.team.uuid}</code>
           </Panel.Section>
         </Panel>

--- a/app/components/team/Form.js
+++ b/app/components/team/Form.js
@@ -5,6 +5,9 @@ import FormCheckbox from '../shared/FormCheckbox';
 import FormInputLabel from '../shared/FormInputLabel';
 import FormRadioGroup from '../shared/FormRadioGroup';
 import FormTextField from '../shared/FormTextField';
+import Panel from '../shared/Panel';
+import Button from '../shared/Button';
+
 import ValidationErrors from '../../lib/ValidationErrors';
 import TeamPrivacyConstants from '../../constants/TeamPrivacyConstants';
 
@@ -15,60 +18,91 @@ class TeamForm extends React.Component {
     privacy: PropTypes.oneOf(Object.keys(TeamPrivacyConstants)),
     isDefaultTeam: PropTypes.bool,
     errors: PropTypes.array,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    saving: PropTypes.bool,
+    button: PropTypes.string.isRequired,
+    uuid: PropTypes.string,
+    autofocus: PropTypes.bool
   };
 
   componentDidMount() {
-    this.nameTextField.focus();
+    if(this.props.autofocus) {
+      this.nameTextField.focus();
+    }
   }
 
   render() {
     const errors = new ValidationErrors(this.props.errors);
 
     return (
-      <div>
-        <FormTextField
-          label="Name"
-          help="The name for the team (supports :emoji:)"
-          errors={errors.findForField("name")}
-          value={this.props.name}
-          onChange={this.handleTeamNameChange}
-          ref={(nameTextField) => this.nameTextField = nameTextField}
-        />
+      <Panel>
+        <Panel.Section>
+          <FormTextField
+            label="Name"
+            help="The name for the team (supports :emoji:)"
+            errors={errors.findForField("name")}
+            value={this.props.name}
+            onChange={this.handleTeamNameChange}
+            required={true}
+            ref={(nameTextField) => this.nameTextField = nameTextField}
+          />
 
-        <FormTextField
-          label="Description"
-          help="The description for the team (supports :emoji:)"
-          errors={errors.findForField("description")}
-          value={this.props.description}
-          onChange={this.handleDescriptionChange}
-        />
+          <FormTextField
+            label="Description"
+            help="The description for the team (supports :emoji:)"
+            errors={errors.findForField("description")}
+            value={this.props.description}
+            onChange={this.handleDescriptionChange}
+          />
+        </Panel.Section>
 
-        <FormRadioGroup
-          name="team-privacy"
-          label="Visibility"
-          help="Something"
-          value={this.props.privacy}
-          errors={errors.findForField("privacy")}
-          onChange={this.handlePrivacyChange}
-          options={[
-          { label: "Visible", value: TeamPrivacyConstants.VISIBLE, help: "Can be seen by all members within the organization" },
-          { label: "Secret", value: TeamPrivacyConstants.SECRET, help: "Can only only be seen by organization administrators and members of this team" }
-          ]}
-        />
+        <Panel.Section>
+          <FormRadioGroup
+            name="team-privacy"
+            label="Visibility"
+            help="Something"
+            value={this.props.privacy}
+            errors={errors.findForField("privacy")}
+            onChange={this.handlePrivacyChange}
+            options={[
+              { label: "Visible", value: TeamPrivacyConstants.VISIBLE, help: "Can be seen by all members within the organization", badge: "Recommended" },
+              { label: "Secret", value: TeamPrivacyConstants.SECRET, help: "Can only only be seen by organization administrators and members of this team" }
+            ]}
+          />
+        </Panel.Section>
 
-        <FormInputLabel label="Default" />
+        <Panel.Section>
+          <FormInputLabel label="Default" />
 
-        <FormCheckbox
-          name="team-is-default-team"
-          label="Automatically add new users to this team"
-          help="Users will automatically be added to this team when they sign in with SSO"
-          checked={this.props.isDefaultTeam}
-          onChange={this.handleIsDefaultTeamChange}
-        />
+          <FormCheckbox
+            name="team-is-default-team"
+            label="Automatically add new users to this team"
+            help="Users will automatically be added to this team when they sign in with SSO"
+            checked={this.props.isDefaultTeam}
+            onChange={this.handleIsDefaultTeamChange}
+          />
+        </Panel.Section>
 
-      </div>
+        {this.renderUUIDSection()}
+
+        <Panel.Footer>
+          <Button loading={this.props.saving ? this.props.button : false} theme="success">{this.props.button}</Button>
+        </Panel.Footer>
+      </Panel>
     );
+  }
+
+  renderUUIDSection() {
+    if(this.props.uuid) {
+      return (
+        <Panel.Section>
+          <FormInputLabel label="UUID" />
+
+          <code className="block bg-silver p2 rounded">{this.props.uuid}</code>
+          <p className="dark-gray p0 mt1"> You can use this <code>UUID</code> to reference this team when using the <a href="/docs/rest-api/pipelines#create-a-pipeline" className="blue hover-navy">Create a Pipeline</a> REST API</p>
+        </Panel.Section>
+      )
+    }
   }
 
   handleTeamNameChange = (evt) => {

--- a/app/components/team/Form.js
+++ b/app/components/team/Form.js
@@ -21,7 +21,6 @@ class TeamForm extends React.Component {
     onChange: PropTypes.func,
     saving: PropTypes.bool,
     button: PropTypes.string.isRequired,
-    uuid: PropTypes.string,
     autofocus: PropTypes.bool
   };
 
@@ -81,26 +80,11 @@ class TeamForm extends React.Component {
           />
         </Panel.Section>
 
-        {this.renderUUIDSection()}
-
         <Panel.Footer>
           <Button loading={this.props.saving ? this.props.button : false} theme="success">{this.props.button}</Button>
         </Panel.Footer>
       </Panel>
     );
-  }
-
-  renderUUIDSection() {
-    if (this.props.uuid) {
-      return (
-        <Panel.Section>
-          <FormInputLabel label="UUID" />
-
-          <code className="block bg-silver p2 rounded">{this.props.uuid}</code>
-          <p className="dark-gray p0 mt1"> You can use this <code>UUID</code> to reference this team when using the <a href="/docs/rest-api/pipelines#create-a-pipeline" className="blue hover-navy">Create a Pipeline</a> REST API</p>
-        </Panel.Section>
-      );
-    }
   }
 
   handleTeamNameChange = (evt) => {

--- a/app/components/team/Form.js
+++ b/app/components/team/Form.js
@@ -26,7 +26,7 @@ class TeamForm extends React.Component {
   };
 
   componentDidMount() {
-    if(this.props.autofocus) {
+    if (this.props.autofocus) {
       this.nameTextField.focus();
     }
   }
@@ -93,7 +93,7 @@ class TeamForm extends React.Component {
   }
 
   renderUUIDSection() {
-    if(this.props.uuid) {
+    if (this.props.uuid) {
       return (
         <Panel.Section>
           <FormInputLabel label="UUID" />
@@ -101,7 +101,7 @@ class TeamForm extends React.Component {
           <code className="block bg-silver p2 rounded">{this.props.uuid}</code>
           <p className="dark-gray p0 mt1"> You can use this <code>UUID</code> to reference this team when using the <a href="/docs/rest-api/pipelines#create-a-pipeline" className="blue hover-navy">Create a Pipeline</a> REST API</p>
         </Panel.Section>
-      )
+      );
     }
   }
 

--- a/app/components/team/Form.js
+++ b/app/components/team/Form.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import FormCheckbox from '../shared/FormCheckbox';
-import FormInputLabel from '../shared/FormInputLabel';
 import FormRadioGroup from '../shared/FormRadioGroup';
 import FormTextField from '../shared/FormTextField';
 import Panel from '../shared/Panel';

--- a/app/components/team/Form.js
+++ b/app/components/team/Form.js
@@ -72,12 +72,10 @@ class TeamForm extends React.Component {
         </Panel.Section>
 
         <Panel.Section>
-          <FormInputLabel label="Default" />
-
           <FormCheckbox
             name="team-is-default-team"
-            label="Automatically add new users to this team"
-            help="Users will automatically be added to this team when they sign in with SSO"
+            label="Default team"
+            help="Automatically add new users to this team when they join the organization."
             checked={this.props.isDefaultTeam}
             onChange={this.handleIsDefaultTeamChange}
           />

--- a/app/components/team/TeamNew.js
+++ b/app/components/team/TeamNew.js
@@ -44,22 +44,17 @@ class TeamNew extends React.Component {
             <PageHeader.Title>Create a Team</PageHeader.Title>
           </PageHeader>
 
-          <Panel>
-            <Panel.Section>
-              <TeamForm
-                onChange={this.handleFormChange}
-                errors={this.state.errors}
-                name={this.state.name}
-                description={this.state.description}
-                privacy={this.state.privacy}
-                isDefaultTeam={this.state.isDefaultTeam}
-              />
-            </Panel.Section>
-
-            <Panel.Footer>
-              <Button loading={this.state.saving ? "Creating team…" : false} theme="success">Create Team</Button>
-            </Panel.Footer>
-          </Panel>
+          <TeamForm
+            onChange={this.handleFormChange}
+            errors={this.state.errors}
+            name={this.state.name}
+            description={this.state.description}
+            privacy={this.state.privacy}
+            isDefaultTeam={this.state.isDefaultTeam}
+            autofocus={true}
+            saving={this.state.saving}
+            button={this.state.saving ? "Creating team…" : "Create Team"}
+          />
         </form>
       </DocumentTitle>
     );

--- a/app/components/team/TeamNew.js
+++ b/app/components/team/TeamNew.js
@@ -4,8 +4,6 @@ import { createFragmentContainer, graphql, commitMutation } from 'react-relay/co
 import DocumentTitle from 'react-document-title';
 
 import PageHeader from '../shared/PageHeader';
-import Panel from '../shared/Panel';
-import Button from '../shared/Button';
 import TeamForm from './Form';
 
 import GraphQLErrors from '../../constants/GraphQLErrors';


### PR DESCRIPTION
Things I've done in this PR:

- [x] Break teams form into sections
- [x] Add "Required" to the Team Name input
- [x] Add UUID to the "Edit" version of the form
- [x] Only focus on the "Name" when creating a team (don't autofocus on edit)
- [x] Added "Recommended" to the "Visibility" option
- [x] Don't redirect away from the "Settings" tab when saving a team - just flash.

Here's a screen grab of the "New" page:

![screen shot 2017-07-10 at 2 46 22 pm](https://user-images.githubusercontent.com/25882/28003144-8e304fac-657e-11e7-8979-5477a27ffa1d.png)

And the "Edit" page:

![screen shot 2017-07-10 at 2 46 43 pm](https://user-images.githubusercontent.com/25882/28003154-a131d1c0-657e-11e7-873d-e1ae5a5f375f.png)
