### PR TITLE
Send the current team to the new pipeline page

### DIFF
--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -161,7 +161,7 @@ class OrganizationPipelines extends React.Component {
     }
 
     return (
-      <Welcome organization={this.props.organization} />
+      <Welcome organization={this.props.organization} team={this.props.team} />
     );
   }
 

--- a/app/components/organization/Show.js
+++ b/app/components/organization/Show.js
@@ -93,8 +93,8 @@ class OrganizationShow extends React.Component {
 
     // Attach the current team to the "New Pipeline" URL
     let newPipelineURL = `/organizations/${this.props.organization.slug}/pipelines/new`;
-    if(this.props.location.query.team) {
-      newPipelineURL += `?team=${this.props.location.query.team}`
+    if (this.props.location.query.team) {
+      newPipelineURL += `?team=${this.props.location.query.team}`;
     }
 
     return (

--- a/app/components/organization/Show.js
+++ b/app/components/organization/Show.js
@@ -91,6 +91,12 @@ class OrganizationShow extends React.Component {
       return null;
     }
 
+    // Attach the current team to the "New Pipeline" URL
+    let newPipelineURL = `/organizations/${this.props.organization.slug}/pipelines/new`;
+    if(this.props.location.query.team) {
+      newPipelineURL += `?team=${this.props.location.query.team}`
+    }
+
     return (
       <Button
         theme="default"
@@ -100,7 +106,7 @@ class OrganizationShow extends React.Component {
           width: 34,
           height: 34
         }}
-        href={`/organizations/${this.props.organization.slug}/pipelines/new`}
+        href={newPipelineURL}
         title="New Pipeline"
       >
         <Icon icon="plus" title="New Pipeline" />

--- a/app/components/organization/Welcome.js
+++ b/app/components/organization/Welcome.js
@@ -9,7 +9,8 @@ class Welcome extends React.PureComponent {
     organization: PropTypes.shape({
       slug: PropTypes.string.isRequired,
       permissions: PropTypes.object.isRequired
-    })
+    }),
+    team: PropTypes.string
   };
 
   render() {
@@ -30,6 +31,12 @@ class Welcome extends React.PureComponent {
   }
 
   renderWelcomeMessage() {
+    // Attach the current team to the "New Pipeline" URL
+    let newPipelineURL = `/organizations/${this.props.organization.slug}/pipelines/new`;
+    if(this.props.team) {
+      newPipelineURL += `?team=${this.props.team}`
+    }
+
     return (
       <div className="center p4">
         <PipelineIcon />
@@ -45,7 +52,7 @@ class Welcome extends React.PureComponent {
         <p>
           <a
             className="mt4 btn btn-primary bg-lime hover-white white rounded"
-            href={`/organizations/${this.props.organization.slug}/pipelines/new`}
+            href={newPipelineURL}
           >
             New Pipeline
           </a>

--- a/app/components/organization/Welcome.js
+++ b/app/components/organization/Welcome.js
@@ -33,8 +33,8 @@ class Welcome extends React.PureComponent {
   renderWelcomeMessage() {
     // Attach the current team to the "New Pipeline" URL
     let newPipelineURL = `/organizations/${this.props.organization.slug}/pipelines/new`;
-    if(this.props.team) {
-      newPipelineURL += `?team=${this.props.team}`
+    if (this.props.team) {
+      newPipelineURL += `?team=${this.props.team}`;
     }
 
     return (


### PR DESCRIPTION
When you hit the "New Pipeline" button when scoping the pipelines to a team, it'll send the team slug to the "New Pipeline" page so we can preselect it.

The preselection doesn't work yet, but this just sends it as a param.

![screen shot 2017-07-10 at 4 26 37 pm](https://user-images.githubusercontent.com/25882/28005176-90ac4ea8-658c-11e7-87ae-6e6f74d2631f.png)