### PR TITLE
Tab layout tweaks

### DIFF
--- a/app/components/member/Show.js
+++ b/app/components/member/Show.js
@@ -51,7 +51,7 @@ class Show extends React.PureComponent {
     return (
       <DocumentTitle title={`Users · ${this.props.organizationMember.user.name}`}>
         <div>
-          <PageHeader>
+          <PageHeader followedByTabs={true}>
             <PageHeader.Icon>
               <UserAvatar
                 user={this.props.organizationMember.user}

--- a/app/components/shared/PageHeader/index.js
+++ b/app/components/shared/PageHeader/index.js
@@ -7,7 +7,8 @@ import Button from './button';
 
 class PageHeader extends React.Component {
   static propTypes = {
-    children: PropTypes.node.isRequired
+    children: PropTypes.node.isRequired,
+    followedByTabs: PropTypes.bool
   };
 
   renderAffix(affixContent) {
@@ -36,7 +37,12 @@ class PageHeader extends React.Component {
     });
 
     return (
-      <section className="flex flex-wrap items-top mb2">
+      <section
+        className={classNames("flex flex-wrap items-top", {
+          "mb2": !this.props.followedByTabs,
+          "mb0": this.props.followedByTabs
+        })}
+      >
         {this.renderAffix(pre)}
         <div className="flex-auto mb2" style={{ flexBasis: 160 }}>{content}</div>
         {this.renderAffix(post)}

--- a/app/components/shared/TabControl/Tab.js
+++ b/app/components/shared/TabControl/Tab.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import styled from 'styled-components';
 
+import Badge from '../Badge';
+
 import cssVariables from '../../../css';
 
 import { formatNumber } from '../../../lib/number';
@@ -10,14 +12,20 @@ import { formatNumber } from '../../../lib/number';
 const ACTIVE_CLASS_NAME = 'active';
 
 const TabButton = styled(Link).attrs({
-  className: 'px3 pt2 pb1 border-bottom block text-decoration-none black',
+  className: 'px4 pt2 border-bottom block text-decoration-none black',
   activeClassName: ACTIVE_CLASS_NAME
 })`
-  border-bottom-width: 4px;
+  border-bottom-width: 3px;
   border-color: transparent;
+  transition: border-color 120ms;
+  margin-bottom: -1px;
+  height: 44px; /* Needed because the badge causes the height to increase */
 
   &.${ACTIVE_CLASS_NAME} {
     border-color: ${cssVariables['--lime']};
+  }
+  &:hover:not(&.${ACTIVE_CLASS_NAME}) {
+    border-color: ${cssVariables['--light-lime']};
   }
 `;
 
@@ -31,13 +39,15 @@ class Tab extends React.PureComponent {
     const { badge, children, ...props } = this.props;
 
     const affix = badge
-      ? <span className="dark-gray"> {formatNumber(badge)}</span>
+      ? <Badge outline={true}>{formatNumber(badge)}</Badge>
       : null;
 
     return (
       <li>
         <TabButton {...props}>
-          <span className="semi-bold">{children}</span>{affix}
+          <span className="semi-bold">{children}</span>
+          {' '}
+          {affix}
         </TabButton>
       </li>
     );

--- a/app/components/shared/TabControl/index.js
+++ b/app/components/shared/TabControl/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Tab from './Tab';
 
 const TabControl = styled.ul.attrs({
-  className: 'flex m0 mb3 p0 border-bottom border-gray'
+  className: 'flex m0 mb4 p0 border-bottom border-gray'
 })`
   list-style: none;
   list-style-type: none;

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -52,6 +52,7 @@
   --teal: #39CCCC;
   --green: #2ECC40;
   --olive: #3D9970;
+  --light-lime: #D5EBA4;
   --lime: #7EAF25;
   --dark-lime: #5C7F24;
 


### PR DESCRIPTION
This makes a bunch of styling updates to the `<TabControl>`:

* Coloured/active bottom border goes over the grey line
* Hover styles
* Padding/margin tweaks

I'm still not 100% happy with bottom margin on it, but it seems like works best with panel bodies that also have buttons right below it.

Before:

![before](https://user-images.githubusercontent.com/153/28049302-c8fa9532-6639-11e7-9468-78e3a4aedc3e.gif)

After:

![after](https://user-images.githubusercontent.com/153/28049304-cb8f3730-6639-11e7-8a74-b23fbee73486.gif)