### PR TITLE
Use browserHistory events for flash clearing instead of the router

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -86,7 +86,7 @@ const renderMain = (route) => {
   }
 };
 
-const onRouterUpdate = () => {
+browserHistory.listen((location) => {
   // Reset flashes on route changes
   FlashesStore.reset();
 
@@ -94,10 +94,10 @@ const onRouterUpdate = () => {
   if (window.Bugsnag) {
     window.Bugsnag.refresh();
   }
-};
+});
 
 export default (
-  <Router history={browserHistory} onUpdate={onRouterUpdate} render={applyRouterMiddleware(useRelay)} environment={Relay.Store}>
+  <Router history={browserHistory} render={applyRouterMiddleware(useRelay)} environment={Relay.Store}>
     <Route path="/:organization/:pipeline/builds/:number" component={BuildCommentsList} queries={{ viewer: ViewerQuery.query, build: BuildQuery.query }} prepareParams={BuildQuery.prepareParams} />
 
     <Route path="/" component={Main} getQueries={getMainQueries} render={renderMain}>

--- a/app/routes.js
+++ b/app/routes.js
@@ -86,7 +86,7 @@ const renderMain = (route) => {
   }
 };
 
-browserHistory.listen((location) => {
+browserHistory.listen(() => {
   // Reset flashes on route changes
   FlashesStore.reset();
 


### PR DESCRIPTION
I discovered that `onUpdate` actually runs when the page loads, as well
as on every route change. This means that we end up clearing flashes
when page loads, and in some cases - they don't even show at all
(depending on how fast the browser is).

By using `browserHistory` we _only_ get events when the route is changed
in Javascript, not when the page loads :ok_hand: