### PR TITLE
Use the new permission styles on pipelines too

### DIFF
--- a/app/components/shared/PermissionDescription.js
+++ b/app/components/shared/PermissionDescription.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Icon from './Icon';
+
+export default class PermissionDescription extends React.PureComponent {
+  static propTypes = {
+    allowed: PropTypes.bool.isRequired,
+    permission: PropTypes.string.isRequired
+  };
+
+  render() {
+    const { allowed, permission } = this.props;
+
+    const icon = allowed ? 'permission-small-tick' : 'permission-small-cross';
+    const words = allowed ? `Can ${permission}.` : `Can not ${permission}.`;
+
+    return (
+      <div className="flex mt1" style={{ lineHeight: 1.4 }}>
+        <Icon icon={icon} className="dark-gray flex-none mr1" style={{ marginTop: -3 }} />
+        {words}
+      </div>
+    );
+  }
+}

--- a/app/components/shared/PermissionSelectOptionDescriptions.js
+++ b/app/components/shared/PermissionSelectOptionDescriptions.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class PermissionSelectOptionDescriptions extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired
+  };
+
+  render() {
+    return (
+      <div className="pointer-events-none" style={{ marginTop: 8, marginLeft: -4 }}>
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/app/components/team/Members/role.js
+++ b/app/components/team/Members/role.js
@@ -3,34 +3,10 @@ import PropTypes from 'prop-types';
 
 import Chooser from '../../shared/Chooser';
 import Dropdown from '../../shared/Dropdown';
-import Icon from '../../shared/Icon';
+import PermissionSelectOptionDescriptions from '../../shared/PermissionSelectOptionDescriptions';
+import PermissionDescription from '../../shared/PermissionDescription';
 
 import TeamMemberRoleConstants from '../../../constants/TeamMemberRoleConstants';
-
-const PermissionBlock = ({ children }) => (
-  <div className="pointer-events-none" style={{ marginTop: 8, marginLeft: -4 }}>
-    {children}
-  </div>
-);
-PermissionBlock.propTypes = { children: PropTypes.node };
-
-const Permission = ({ icon, children }) => (
-  <div className="flex mt1" style={{ lineHeight: 1.4 }}>
-    <Icon icon={icon} className="dark-gray flex-none mr1" style={{ marginTop: -3 }} />
-    {children}
-  </div>
-);
-Permission.propTypes = { icon: PropTypes.string.isRequired, children: PropTypes.node };
-
-const Can = ({ permission }) => (
-  <Permission icon="permission-small-tick" title="Tick">Can {permission}.</Permission>
-);
-Can.propTypes = { permission: PropTypes.node.isRequired };
-
-const CanNot = ({ permission }) => (
-  <Permission icon="permission-small-cross" title="Cross">Can not {permission}.</Permission>
-);
-CanNot.propTypes = { permission: PropTypes.node.isRequired };
 
 export default class MemberRole extends React.PureComponent {
   static displayName = "Team.Pipelines.Role";
@@ -57,10 +33,10 @@ export default class MemberRole extends React.PureComponent {
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MAINTAINER}
             label={this.label(TeamMemberRoleConstants.MAINTAINER)}
             description={
-              <PermissionBlock>
-                <Can permission="add and remove pipelines" />
-                <Can permission="add and remove users" />
-              </PermissionBlock>
+              <PermissionSelectOptionDescriptions>
+                <PermissionDescription allowed={true} permission="add and remove pipelines" />
+                <PermissionDescription allowed={true} permission="add and remove users" />
+              </PermissionSelectOptionDescriptions>
             }
           />
           <Chooser.SelectOption
@@ -69,10 +45,10 @@ export default class MemberRole extends React.PureComponent {
             selected={this.props.teamMember.role === TeamMemberRoleConstants.MEMBER}
             label={this.label(TeamMemberRoleConstants.MEMBER)}
             description={
-              <PermissionBlock>
-                <Can permission="and and remove pipelines" />
-                <CanNot permission="add or remove users" />
-              </PermissionBlock>
+              <PermissionSelectOptionDescriptions>
+                <PermissionDescription allowed={true} permission="and and remove pipelines" />
+                <PermissionDescription allowed={false} permission="add or remove users" />
+              </PermissionSelectOptionDescriptions>
             }
           />
         </Chooser>

--- a/app/components/team/Pipelines/access-level.js
+++ b/app/components/team/Pipelines/access-level.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import Chooser from '../../shared/Chooser';
 import Dropdown from '../../shared/Dropdown';
+import PermissionSelectOptionDescriptions from '../../shared/PermissionSelectOptionDescriptions';
+import PermissionDescription from '../../shared/PermissionDescription';
 
 const MANAGE_BUILD_AND_READ = "MANAGE_BUILD_AND_READ";
 const BUILD_AND_READ = "BUILD_AND_READ";
@@ -33,21 +35,37 @@ export default class AccessLevel extends React.PureComponent {
             saving={saving === MANAGE_BUILD_AND_READ}
             selected={selected === MANAGE_BUILD_AND_READ}
             label={this.label(MANAGE_BUILD_AND_READ)}
-            description="Members can edit pipeline settings, view builds and create builds"
+            description={
+              <PermissionSelectOptionDescriptions>
+                <PermissionDescription allowed={true} permission="view and create builds" />
+                <PermissionDescription allowed={true} permission="edit pipeline settings" />
+              </PermissionSelectOptionDescriptions>
+            }
           />
           <Chooser.SelectOption
             value={BUILD_AND_READ}
             saving={saving === BUILD_AND_READ}
             selected={selected === BUILD_AND_READ}
             label={this.label(BUILD_AND_READ)}
-            description="Members can view builds and create builds"
+            description={
+              <PermissionSelectOptionDescriptions>
+                <PermissionDescription allowed={true} permission="view and create builds" />
+                <PermissionDescription allowed={false} permission="edit pipeline settings" />
+              </PermissionSelectOptionDescriptions>
+            }
           />
           <Chooser.SelectOption
             value={READ_ONLY}
             label={this.label(READ_ONLY)}
             saving={saving === READ_ONLY}
             selected={selected === READ_ONLY}
-            description="Members can only view builds"
+            description={
+              <PermissionSelectOptionDescriptions>
+                <PermissionDescription allowed={true} permission="view builds" />
+                <PermissionDescription allowed={false} permission="create builds" />
+                <PermissionDescription allowed={false} permission="edit pipeline settings" />
+              </PermissionSelectOptionDescriptions>
+            }
           />
         </Chooser>
       </Dropdown>


### PR DESCRIPTION
<img width="392" alt="permissions" src="https://user-images.githubusercontent.com/153/28054587-cd0af59e-6658-11e7-9d01-e2d41ba030e3.png">

The idea was to be able to use the `<PermissionsDescription>` component elsewhere too, like on the Invite User permissions chooser.