### PR TITLE
Only show User > Settings > Teams if Teams enabled

### DIFF
--- a/app/components/member/Show.js
+++ b/app/components/member/Show.js
@@ -90,7 +90,7 @@ class Show extends React.PureComponent {
       },
       {
         always: "teamAdmin",
-        and: () => (Features.TeamsLaunch || Features.organizationHasTeams),
+        and: () => (Features.TeamsLaunch && Features.organizationHasTeams),
         render: (idx) => (
           <TabControl.Tab
             key={idx}

--- a/app/components/member/Show.js
+++ b/app/components/member/Show.js
@@ -90,7 +90,7 @@ class Show extends React.PureComponent {
       },
       {
         always: "teamAdmin",
-        and: () => (Features.TeamsLaunch && Features.organizationHasTeams),
+        and: () => (Features.organizationHasTeams),
         render: (idx) => (
           <TabControl.Tab
             key={idx}


### PR DESCRIPTION
If the Teams feature flag is on, but the organization has it disabled, you see a "Teams" tab in a user’s settings…

<img width="350" alt="teams" src="https://user-images.githubusercontent.com/153/28099026-15384e58-66fd-11e7-9afc-38bdfb692938.png">

This fixes the logic so that they need to have teams enabled for the Teams tab to show on users.

<img width="447" alt="teams-settings" src="https://user-images.githubusercontent.com/153/28099047-393c838c-66fd-11e7-896a-a71e37fc1838.png">