### PR TITLE
Have a consistent style for the team selectors

### DIFF
--- a/app/components/member/MemberTeamRow.js
+++ b/app/components/member/MemberTeamRow.js
@@ -23,7 +23,7 @@ class MemberTeamRow extends React.Component {
       <div className="col-12 md-col-6 lg-col-4 py1">
         <label className="block cursor-pointer px1 pb1">
           <div className="flex items-start">
-            <div className="pl2 pr2" style={{ lineHeight: 1.75 }}>
+            <div className="pr2" style={{ lineHeight: 1.75 }}>
               <input
                 type="checkbox"
                 checked={this.props.checked}
@@ -53,7 +53,7 @@ class MemberTeamRow extends React.Component {
     }
 
     return (
-      <div className="m0 p0 dark-gray h5">
+      <div className="m0 p0 dark-gray h5 regular" style={{ lineHeight: 1.4 }}>
         <Emojify text={this.props.team.description} />
       </div>
     );

--- a/app/components/team/Labels.js
+++ b/app/components/team/Labels.js
@@ -19,9 +19,9 @@ class TeamLabels extends React.PureComponent {
           <Badge outline={true}>Secret</Badge>
         </div>
       );
-    } else {
-      return null;
     }
+    return null;
+
   }
 }
 


### PR DESCRIPTION
They both look the same now on the "New Pipeline" page, and on the "Invite Users" page:

<img width="902" alt="screen shot 2017-07-12 at 2 40 56 pm" src="https://user-images.githubusercontent.com/25882/28102059-238c9a1e-6710-11e7-9fac-f4ab34964752.png">

<img width="982" alt="screen shot 2017-07-12 at 2 41 18 pm" src="https://user-images.githubusercontent.com/25882/28102071-2f337504-6710-11e7-996d-95e31651fd5c.png">

I also removed the left hand padding because I the indentation was kinda bugging when I was looking at it. We don't really have other fields that are indented so I thought perhaps this looks a bit more consistent?