### PR TITLE
Add overflow scroll to autocomplete dialog

### DIFF
--- a/app/components/shared/Autocomplete/Dialog/index.js
+++ b/app/components/shared/Autocomplete/Dialog/index.js
@@ -100,7 +100,7 @@ class AutocompleteDialog extends React.PureComponent {
     }
 
     return (
-      <div className="block" style={{ width: "100%", minHeight: 300 }}>
+      <div className="block" style={{ width: "100%", minHeight: 300, maxHeight: '50vh', overflow: 'auto' }}>
         <ul className="list-reset m0 p0">
           {suggestions}
         </ul>

--- a/app/components/shared/Autocomplete/Dialog/index.js
+++ b/app/components/shared/Autocomplete/Dialog/index.js
@@ -100,7 +100,7 @@ class AutocompleteDialog extends React.PureComponent {
     }
 
     return (
-      <div className="block" style={{ width: "100%", height: '50vh', overflow: 'auto' }}>
+      <div className="block" style={{ width: "100%", maxHeight: 250, height: '50vh', overflow: 'auto' }}>
         <ul className="list-reset m0 p0">
           {suggestions}
         </ul>

--- a/app/components/shared/Autocomplete/Dialog/index.js
+++ b/app/components/shared/Autocomplete/Dialog/index.js
@@ -100,7 +100,7 @@ class AutocompleteDialog extends React.PureComponent {
     }
 
     return (
-      <div className="block" style={{ width: "100%", minHeight: 300, maxHeight: '50vh', overflow: 'auto' }}>
+      <div className="block" style={{ width: "100%", height: '50vh', overflow: 'auto' }}>
         <ul className="list-reset m0 p0">
           {suggestions}
         </ul>


### PR DESCRIPTION
If you have a large number of users, the dialog is a bit unwieldy. And it's height suggests almost helps to reinforce the misconception that it might contain all users? (another issue)

![team-selector-before](https://user-images.githubusercontent.com/153/28102721-7206b2a2-6714-11e7-99db-27186968a5a7.gif)

This fixes the height to half the viewport height, and adds a overflow scroll:

![teams-after](https://user-images.githubusercontent.com/153/28102722-7270230e-6714-11e7-985a-a9e073b6e0ca.gif)

I wanted to treat the empty case differently… say, for a small account, or if there are "no more users to add", but unfortunately I couldn't wrangle the components, so will leave that for another PR.

![boo-1](https://user-images.githubusercontent.com/153/28102972-5d8a7a6e-6716-11e7-8ad2-2deaf2d31348.png)

![boo-2](https://user-images.githubusercontent.com/153/28102975-5e46b5b2-6716-11e7-8504-636dcbcd207a.png)