### PR TITLE
Tweak Teams pager header icon size

### DIFF
--- a/app/components/member/Index.js
+++ b/app/components/member/Index.js
@@ -72,7 +72,6 @@ class MemberIndex extends React.PureComponent {
             <PageHeader.Icon>
               <Icon
                 icon="users"
-                className="align-middle mr2"
                 style={{ width: 40, height: 40 }}
               />
             </PageHeader.Icon>

--- a/app/components/member/Show.js
+++ b/app/components/member/Show.js
@@ -55,7 +55,6 @@ class Show extends React.PureComponent {
             <PageHeader.Icon>
               <UserAvatar
                 user={this.props.organizationMember.user}
-                className="align-middle mr2"
                 style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
               />
             </PageHeader.Icon>

--- a/app/components/shared/PageHeader/description.js
+++ b/app/components/shared/PageHeader/description.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export default class Description extends React.PureComponent {
+  static displayName = 'PageHeader.Description';
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
+  };
+
+  render() {
+    const { className, children } = this.props;
+
+    return (
+      <div className={classNames('dark-gray mt1 max-width-2', className)}>
+        {children}
+      </div>
+    );
+  }
+}

--- a/app/components/shared/PageHeader/icon.js
+++ b/app/components/shared/PageHeader/icon.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import styled from 'styled-components';
+
+const DivWithSlightRightMargin = styled('div').attrs({
+  className: 'align-middle'
+})`
+  /* Slightly less than the mr3 (15px) */
+  margin-right: 13px;
+`;
+
+export default class Icon extends React.PureComponent {
+  static displayName = 'PageHeader.Icon';
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
+  };
+
+  render() {
+    const { className, children } = this.props;
+
+    return (
+      <DivWithSlightRightMargin className={classNames('flex items-center align-middle', className)}>
+        {children}
+      </DivWithSlightRightMargin>
+    );
+  }
+}

--- a/app/components/shared/PageHeader/index.js
+++ b/app/components/shared/PageHeader/index.js
@@ -4,6 +4,9 @@ import classNames from 'classnames';
 
 import Title from './title';
 import Button from './button';
+import Description from './description';
+import Menu from './menu';
+import Icon from './icon';
 
 class PageHeader extends React.Component {
   static propTypes = {
@@ -53,29 +56,8 @@ class PageHeader extends React.Component {
 
 PageHeader.Title = Title;
 PageHeader.Button = Button;
-
-const SIMPLE_COMPONENTS = {
-  Description: 'dark-gray mt1 max-width-2',
-  Icon: 'flex items-center',
-  Menu: 'flex items-center'
-};
-
-Object.keys(SIMPLE_COMPONENTS).forEach((componentName) => {
-  const defaultStyle = SIMPLE_COMPONENTS[componentName];
-
-  const Component = (props) => (
-    <div className={classNames(defaultStyle, props.className)}>
-      {props.children}
-    </div>
-  );
-
-  Component.displayName = `PageHeader.${componentName}`;
-  Component.propTypes = {
-    children: PropTypes.node.isRequired,
-    className: PropTypes.string
-  };
-
-  PageHeader[componentName] = Component;
-});
+PageHeader.Description = Description;
+PageHeader.Menu = Menu;
+PageHeader.Icon = Icon;
 
 export default PageHeader;

--- a/app/components/shared/PageHeader/menu.js
+++ b/app/components/shared/PageHeader/menu.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export default class Menu extends React.PureComponent {
+  static displayName = 'PageHeader.Menu';
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
+  };
+
+  render() {
+    const { className, children } = this.props;
+
+    return (
+      <div className={classNames('flex items-center', className)}>
+        {children}
+      </div>
+    );
+  }
+}

--- a/app/components/sso/Index.js
+++ b/app/components/sso/Index.js
@@ -31,7 +31,6 @@ class SSOIndex extends React.PureComponent {
             <PageHeader.Icon>
               <Icon
                 icon="sso"
-                className="align-middle mr2"
                 style={{ width: 40, height: 40 }}
               />
             </PageHeader.Icon>

--- a/app/components/team/Index.js
+++ b/app/components/team/Index.js
@@ -68,8 +68,8 @@ class TeamIndex extends React.PureComponent {
             <PageHeader.Icon>
               <Icon
                 icon="teams"
-                className="align-middle mr2"
-                style={{ width: 40, height: 40 }}
+                // This icon needs to be slightly smaller
+                style={{ width: 34, height: 34, marginTop: 3, marginLeft: 3 }}
               />
             </PageHeader.Icon>
             <PageHeader.Title>


### PR DESCRIPTION
Whilst doing the screenshots for the announcement, the icon size and margin for the Teams section was bugging me. So this PR reduces the icon size in the header, and tweaks the margins.

Before:

<img width="357" alt="before-1" src="https://user-images.githubusercontent.com/153/28117638-9d2bf7b6-6751-11e7-8b84-161aebee66ec.png">

<img width="257" alt="before-2" src="https://user-images.githubusercontent.com/153/28117643-9dbd92e8-6751-11e7-9395-d3430432f589.png">

After:

<img width="288" alt="after-1" src="https://user-images.githubusercontent.com/153/28117650-9fd5e918-6751-11e7-8db3-9d1ff5fa5f30.png">

<img width="297" alt="after-2" src="https://user-images.githubusercontent.com/153/28117649-9fd1eba6-6751-11e7-9b8e-70a8ccf019ac.png">