### PR TITLE
Clean up the audit log reveal chevron

### DIFF
--- a/app/components/audit_log/row.js
+++ b/app/components/audit_log/row.js
@@ -4,18 +4,12 @@ import Relay from 'react-relay/classic';
 import styled from 'styled-components';
 
 import FriendlyTime from '../shared/FriendlyTime';
-import Icon from '../shared/Icon';
+import RevealableDownChevron from '../shared/Icon/RevealableDownChevron';
 import Panel from '../shared/Panel';
 import Spinner from '../shared/Spinner';
 
 const TransitionMaxHeight = styled.div`
   transition: max-height 400ms;
-`;
-
-const RotatableIcon = styled(Icon)`
-  transform: rotate(${(props) => props.rotate ? -90 : 90}deg);
-  trasform-origin: center 0;
-  transition: transform 200ms;
 `;
 
 class AuditLogRow extends React.PureComponent {
@@ -70,9 +64,9 @@ class AuditLogRow extends React.PureComponent {
               {this.renderEventSentence()}
             </h2>
             <div className="flex-none">
-              <RotatableIcon
-                icon="chevron-right"
-                rotate={this.state.isExpanded}
+              <RevealableDownChevron
+                className="dark-gray"
+                revealed={this.state.isExpanded}
               />
             </div>
           </div>

--- a/app/components/shared/CollapsableArea.js
+++ b/app/components/shared/CollapsableArea.js
@@ -4,16 +4,10 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { v4 as uuid } from 'uuid';
 
-import Icon from './Icon';
+import RevealableDownChevron from './Icon/RevealableDownChevron';
 
 const TransitionMaxHeight = styled.div`
   transition: max-height 400ms;
-`;
-
-const RotatableIcon = styled(Icon)`
-  transform: rotate(${(props) => props.rotate ? -90 : 90}deg);
-  trasform-origin: center 0;
-  transition: transform 200ms;
 `;
 
 // Helps to create collapsable area's, such as optional sets of form fields.
@@ -54,10 +48,9 @@ export default class CollapsableArea extends React.Component {
           onClick={this.handleButtonClick}
         >
           {this.props.label}
-          <RotatableIcon
-            icon="chevron-right"
-            rotate={!this.props.collapsed}
-            style={{ width: 8, height: 8, marginLeft: 6, marginTop: -1 }}
+          <RevealableDownChevron
+            revealed={!this.props.collapsed}
+            style={{ marginLeft: 6, marginTop: -1 }}
           />
         </button>
         <TransitionMaxHeight

--- a/app/components/shared/Icon/RevealableDownChevron.js
+++ b/app/components/shared/Icon/RevealableDownChevron.js
@@ -22,7 +22,8 @@ export default class RevealableDownChevron extends React.PureComponent {
     revealed: PropTypes.bool,
     size: PropTypes.number,
     strokeWidth: PropTypes.number,
-    className: PropTypes.string
+    className: PropTypes.string,
+    style: PropTypes.object
   };
 
   static defaultProps = {
@@ -39,6 +40,7 @@ export default class RevealableDownChevron extends React.PureComponent {
         size={this.props.size}
         strokeWidth={this.props.strokeWidth}
         className={this.props.className}
+        style={this.props.style}
       />
     );
   }

--- a/app/components/shared/Icon/RevealableDownChevron.js
+++ b/app/components/shared/Icon/RevealableDownChevron.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import Icon from '../Icon';
+
+const RotatableIcon = styled(Icon)`
+  transform: rotate(${(props) => props.revealed ? -90 : 90}deg);
+  trasform-origin: center 0;
+  transition: transform 300ms;
+  will-change: transform;
+  width: ${(props) => props.size}px;
+  height: ${(props) => props.size}px;
+
+  polyline {
+    stroke-width: ${(props) => props.strokeWidth}px;
+  }
+`;
+
+export default class RevealableDownChevron extends React.PureComponent {
+  static propTypes = {
+    revealed: PropTypes.bool,
+    size: PropTypes.number,
+    strokeWidth: PropTypes.number,
+    className: PropTypes.string
+  };
+
+  static defaultProps = {
+    revealed: false,
+    size: 14,
+    strokeWidth: 2
+  }
+
+  render() {
+    return (
+      <RotatableIcon
+        icon="chevron-right"
+        revealed={this.props.revealed}
+        size={this.props.size}
+        strokeWidth={this.props.strokeWidth}
+        className={this.props.className}
+      />
+    );
+  }
+}


### PR DESCRIPTION
This extracts out the copy-pasta rotatable chevron code from Create Build and Audit Logs into a shared icon component, and in the process cleans up the Audit Log chevron sizing.

Before:

<img width="489" alt="before" src="https://user-images.githubusercontent.com/153/28253049-e98b1e50-6ae1-11e7-93f9-a9de5fbdcbab.png">

After:

<img width="542" alt="after" src="https://user-images.githubusercontent.com/153/28253050-ec36f688-6ae1-11e7-8948-a97c17c76eab.png">
