### PR TITLE
Emojify pipeline names in a few places that were missing it

### DIFF
--- a/app/components/layout/Navigation/MyBuilds/build.js
+++ b/app/components/layout/Navigation/MyBuilds/build.js
@@ -60,9 +60,10 @@ class BuildsDropdownBuild extends React.PureComponent {
               text={shortMessage(this.props.build.message)}
             />
             {' in '}
-            <span className="build-link-message semi-bold black">
-              {this.props.build.pipeline.name}
-            </span>
+            <Emojify
+              className="build-link-message semi-bold black"
+              text={shortMessage(this.props.build.pipeline.name)}
+            />
           </span>
           <span className="block" title={buildTimeAbsolute}>
             <Duration.Full from={buildTime} overrides={{ length: 1 }} tabularNumerals={false} /> ago

--- a/app/components/organization/Pipeline/index.js
+++ b/app/components/organization/Pipeline/index.js
@@ -55,7 +55,9 @@ class Pipeline extends React.Component {
 
         <a href={this.props.pipeline.url} className="flex flex-auto items-center px2 text-decoration-none color-inherit mr3">
           <div className="truncate">
-            <h2 className="inline h3 regular m0 line-height-2">{this.props.pipeline.name}</h2>
+            <h2 className="inline h3 regular m0 line-height-2">
+              <Emojify text={this.props.pipeline.name} />
+            </h2>
             {this.renderDescription()}
           </div>
         </a>

--- a/app/components/shared/JobLink.js
+++ b/app/components/shared/JobLink.js
@@ -34,7 +34,9 @@ class JobLink extends React.PureComponent {
         )}
         style={style}
       >
-        {job.build.pipeline.name} - Build #{job.build.number} / <Emojify text={job.label || job.command} />
+        <Emojify text={job.build.pipeline.name} />
+        {' '}- Build #{job.build.number} /{' '}
+        <Emojify text={job.label || job.command} />
       </a>
     );
   }

--- a/app/components/team/Pipelines/pipeline.js
+++ b/app/components/team/Pipelines/pipeline.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Emojify from '../../shared/Emojify';
+
 export default class Pipeline extends React.PureComponent {
   static displayName = "Team.Pipelines.Pipeline";
 
@@ -16,7 +18,9 @@ export default class Pipeline extends React.PureComponent {
   render() {
     return (
       <div>
-        <strong className="truncate semi-bold block" title={this.props.pipeline.name}>{this.props.pipeline.name}</strong>
+        <strong className="truncate semi-bold block" title={this.props.pipeline.name}>
+          <Emojify text={this.props.pipeline.name} />
+        </strong>
         <small className="truncate dark-gray block" title={this.props.pipeline.repository.url}>{this.props.pipeline.repository.url}</small>
       </div>
     );


### PR DESCRIPTION
Pipeline names were emojified in some places but not all. I grepped for `pipeline.name` and converted the remaining places where emojification wasn't happening, with the exception of things like the document title where emojification doesn't make sense.

Fixes #343

Tested only with unit tests