### PR TITLE
Hide HTTP Basic Auth passwords in Pipeline Header

### DIFF
--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -204,11 +204,17 @@ class Header extends React.Component {
   }
 
   renderDescription() {
-    if (this.props.pipeline.description) {
-      return <Emojify text={this.props.pipeline.description} />;
+    const { pipeline } = this.props;
+
+    if (pipeline.description) {
+      return <Emojify text={pipeline.description} />;
     }
 
-    return this.props.pipeline.repository.url;
+    // Hide passwords and limit to 8 dots in repository URLs
+    return pipeline.repository.url.replace(
+      /:([^\/@]{1,8})[^\/@]*@/,
+      (match, password) => `:${password.replace(/./g, '•')}@`
+    );
   }
 
   handleActionsDropdownToggle = (visible) => {


### PR DESCRIPTION
This change censors passwords included in repository URLs when they're shown in the Pipeline header.

I noticed that a few customers use HTTP Basic Auth for git authentication, and while that's not dangerous in and of itself, the fact that it means their credentials are shown in the top of their (and my, if I'm doing support for them!) screen on every page made me nervous.

To that end, this change makes any passwords included in a URL be replaced with up to 8 • characters. This doesn't stop people using HTTP basic auth, and hopefully the dots are well-understood enough as meaning "hidden password."

The password can of course still be harvested from the page, either via the JavaScript or GraphQL, but discouraging encoding passwords in our web UI is probably a separate change. :)

**Before:**
<img width="411" alt="password-before" src="https://user-images.githubusercontent.com/282113/29690324-6374aa3a-88db-11e7-9709-518f6b56204c.png">

**After:**
<img width="415" alt="password-after" src="https://user-images.githubusercontent.com/282113/29690326-643c7f38-88db-11e7-930d-61b7d3cbd7ba.png">
