### PR TITLE
Extra build job message on Agents page

### DIFF
--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -17,6 +17,8 @@ import Panel from '../shared/Panel';
 import permissions from '../../lib/permissions';
 import { getLabelForConnectionState } from './shared';
 
+import { formatNumber } from '../../lib/number';
+
 import AgentStopMutation from '../../mutations/AgentStop';
 
 const ExtrasTable = styled.table`
@@ -292,7 +294,7 @@ class AgentShow extends React.Component {
       content = (
         <div>
           {content}
-          (and {remainder} more)
+          (and {formatNumber(remainder)} more)
         </div>
       );
     }


### PR DESCRIPTION
This adds an "and n more" message to the bottom of the job list if there are more than the 10 we display, so it's clear when an Agent has done more work than we're showing.