### PR TITLE
ES6ify pipeline header components

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -48,7 +48,7 @@ window["Webpack"] = {
     "components/build/AvatarWithUnknownEmailPrompt": require("./components/build/AvatarWithUnknownEmailPrompt").default,
     "components/build/StateSwitcher": require("./components/build/StateSwitcher").default,
     "components/build/AnnotationsList": require("./components/build/AnnotationsList").default,
-    "components/build/Header/pipeline": require("./components/build/Header/pipeline").default,
+    "components/build/Header": require("./components/build/Header").default,
     "components/icons/BuildState": require("./components/icons/BuildState").default,
     "components/layout/Footer": require("./components/layout/Footer").default,
     "components/layout/Navigation": require("./components/layout/Navigation").default,

--- a/app/app.js
+++ b/app/app.js
@@ -48,6 +48,7 @@ window["Webpack"] = {
     "components/build/AvatarWithUnknownEmailPrompt": require("./components/build/AvatarWithUnknownEmailPrompt").default,
     "components/build/StateSwitcher": require("./components/build/StateSwitcher").default,
     "components/build/AnnotationsList": require("./components/build/AnnotationsList").default,
+    "components/build/Header/pipeline": require("./components/build/Header/pipeline").default,
     "components/icons/BuildState": require("./components/icons/BuildState").default,
     "components/layout/Footer": require("./components/layout/Footer").default,
     "components/layout/Navigation": require("./components/layout/Navigation").default,

--- a/app/app.js
+++ b/app/app.js
@@ -83,6 +83,7 @@ window["Webpack"] = {
     "lib/number": require("./lib/number"),
     "lib/parseEmoji": require("./lib/parseEmoji").default,
     "lib/RelayPreloader": require("./lib/RelayPreloader").default,
+    "lib/BootstrapTooltipMixin": require('./lib/BootstrapTooltipMixin').default,
     "queries/Agent": require("./queries/Agent"),
     "queries/Build": require("./queries/Build"),
     "queries/Organization": require("./queries/Organization"),

--- a/app/components/build/Header/index.js
+++ b/app/components/build/Header/index.js
@@ -17,7 +17,7 @@ import { shortCommit } from '../../../lib/commits';
 
 import Pipeline from './pipeline';
 
-class BuildHeaderComponent extends React.Component {
+class BuildHeaderComponent extends React.PureComponent {
   static propTypes = {
     build: PropTypes.shape({
       number: PropTypes.number.isRequired,

--- a/app/components/build/Header/index.js
+++ b/app/components/build/Header/index.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import { RootContainer } from 'react-relay';
+import { RootContainer } from 'react-relay/classic';
 
 import * as BuildQuery from '../../../queries/Build';
 import * as ViewerQuery from '../../../queries/Viewer';

--- a/app/components/build/Header/index.js
+++ b/app/components/build/Header/index.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import createReactClass from 'create-react-class';
 import { RootContainer } from 'react-relay';
 
 import * as BuildQuery from '../../../queries/Build';
@@ -18,10 +17,8 @@ import { shortCommit } from '../../../lib/commits';
 
 import Pipeline from './pipeline';
 
-const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/prefer-es6-class
-  displayName: 'BuildHeaderComponent',
-
-  propTypes: {
+class BuildHeaderComponent extends React.Component {
+  static propTypes = {
     build: PropTypes.shape({
       number: PropTypes.number.isRequired,
       state: PropTypes.string.isRequired,
@@ -57,23 +54,23 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
     showRebuild: PropTypes.bool,
     showProject: PropTypes.bool,
     showUnknownEmailPrompt: PropTypes.bool
-  },
+  };
 
   componentDidMount() {
     jQuery(ReactDOM.findDOMNode(this)).on('ajax:error', this._onAjaxError);   // eslint-disable-line react/no-find-dom-node
-  },
+  }
 
   componentWillUnmount() {
     jQuery(ReactDOM.findDOMNode(this)).off('ajax:error', this._onAjaxError);  // eslint-disable-line react/no-find-dom-node
-  },
+  }
 
-  _onAjaxError(event, xhr) {
+  _onAjaxError = (event, xhr) => {
     if (xhr.responseJSON != null) {
       alert(xhr.responseJSON['message']);
     }
-  },
+  };
 
-  bootstrapState() {
+  bootstrapState = () => {
     switch (this.props.build.state) {
       case 'failed':
       case 'danger':
@@ -88,9 +85,9 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
       default:
         return 'default';
     }
-  },
+  };
 
-  icon() {
+  icon = () => {
     switch (this.props.build.state) {
       case 'failed':
         return 'fa fa-times';
@@ -110,9 +107,9 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
       case 'not_run':
         return 'fa fa-minus-square';
     }
-  },
+  };
 
-  buildInfoNode() {
+  buildInfoNode = () => {
     const { build } = this.props;
 
     return (
@@ -124,9 +121,9 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
         </span>
       </span>
     );
-  },
+  };
 
-  commitInfoNode() {
+  commitInfoNode = () => {
     let branchNode, commitNode, pullRequestNode;
     const { build } = this.props;
 
@@ -204,17 +201,17 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
     }
 
     return null;
-  },
+  };
 
-  timeAgoNode() {
+  timeAgoNode = () => {
     return (
       <small className="build-secondary-time text-muted">
         <BuildStatusDescription build={this.props.build} />
       </small>
     );
-  },
+  };
 
-  sourceLabel(source) {
+  sourceLabel = (source) => {
     switch (source) {
       case 'webhook':
         return 'Webhook';
@@ -229,9 +226,9 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
       default:
         return 'Unknown';
     }
-  },
+  };
 
-  metaInformation() {
+  metaInformation = () => {
     let rebuiltFromNode;
     let triggeredFromNode;
 
@@ -285,7 +282,7 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
         {triggeredFromNode}
       </div>
     );
-  },
+  };
 
   render() {
     const { build } = this.props;
@@ -409,9 +406,9 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
         </div>
       </div>
     );
-  },
+  }
 
-  _projectNode() {
+  _projectNode = () => {
     if (this.props.showProject) {
       return (
         <div style={{ marginBottom: 10 }}>
@@ -422,9 +419,9 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
       );
 
     }
-  },
+  };
 
-  _avatarNode() {
+  _avatarNode = () => {
     // Only show the avatar node if `showUnknownEmailPrompt` has been turned on,
     // and we don't have an associated authorUuid (which is only present if
     // there's an actual user on the build)
@@ -459,8 +456,8 @@ const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/pre
         style={{ width: 32, height: 32 }}
       />
     );
-  }
-});
+  };
+}
 
 export default BuildHeaderComponent;
 

--- a/app/components/build/Header/index.js
+++ b/app/components/build/Header/index.js
@@ -1,0 +1,435 @@
+/* global Buildkite, jQuery */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+import CreateReactClass from 'create-react-class';
+import { RootContainer } from 'react-relay';
+
+import * as BuildQuery from '../../../queries/Build';
+import * as ViewerQuery from '../../../queries/Viewer';
+
+import BuildStatusDescription from '../../shared/BuildStatusDescription';
+import UserAvatar from '../../shared/UserAvatar';
+import AvatarWithUnknownEmailPrompt from '../AvatarWithUnknownEmailPrompt';
+import Emojify from '../../shared/Emojify';
+
+import { shortCommit } from '../../../lib/commits';
+
+import Pipeline from './pipeline';
+
+const BuildHeaderComponent = CreateReactClass({
+  displayName: 'BuildHeaderComponent',
+
+  propTypes: {
+    build: PropTypes.object.isRequired,
+    showRebuild: PropTypes.bool,
+    showProject: PropTypes.bool,
+    showUnknownEmailPrompt: PropTypes.bool
+  },
+
+  componentDidMount() {
+    jQuery(ReactDOM.findDOMNode(this)).on('ajax:error', this._onAjaxError);   // eslint-disable-line react/no-find-dom-node
+  },
+
+  componentWillUnmount() {
+    jQuery(ReactDOM.findDOMNode(this)).off('ajax:error', this._onAjaxError);  // eslint-disable-line react/no-find-dom-node
+  },
+
+  _onAjaxError(event, xhr) {
+    if (xhr.responseJSON != null) {
+      alert(xhr.responseJSON['message']);
+    }
+  },
+
+  bootstrapState() {
+    switch (this.props.build.state) {
+      case 'failed':
+      case 'danger':
+      case 'canceled':
+      case 'canceling':
+        return 'danger';
+      case 'passed':
+      case 'blocked':
+        return 'success';
+      case 'started':
+        return 'warning';
+      default:
+        return 'default';
+    }
+  },
+
+  icon() {
+    switch (this.props.build.state) {
+      case 'failed':
+        return 'fa fa-times';
+      case 'canceled':
+        return 'fa fa-warning';
+      case 'canceling':
+        return 'fa fa-warning';
+      case 'passed':
+        return 'fa fa-check';
+      case 'started':
+        return 'fa fa-refresh fa-spin';
+      case 'blocked':
+        return 'fa fa-pause';
+      case 'scheduled':
+        return 'fa fa-clock-o';
+      case 'skipped':
+      case 'not_run':
+        return 'fa fa-minus-square';
+    }
+  },
+
+  buildInfoNode() {
+    const { build } = this.props;
+
+    return (
+      <span className="build-header__build-number">
+        <span className="number">
+          <a className="no-highlight-link" href={build.path}>
+            Build #{build.number}
+          </a>
+        </span>
+      </span>
+    );
+  },
+
+  commitInfoNode() {
+    let branchNode, commitNode, pullRequestNode;
+    const { build } = this.props;
+
+    if (build.commitId) {
+      if (build.commitUrl) {
+        const providerIconClass = `provider-icon fa fa-${build.project.provider.id}`;
+        commitNode = (<span title={build.commitId}>
+          <i className={providerIconClass} />
+          <a href={build.commitUrl} className="no-highlight-link">
+            {shortCommit(build.commitId)}
+          </a>
+        </span>);
+      } else {
+        commitNode = (<span title={build.commitId}>
+          {shortCommit(build.commitId)}
+        </span>);
+      }
+    }
+
+    // Do we have a branch?
+    if (build.branchName) {
+      branchNode = (
+        <a className="no-highlight-link" href={build.branchPath}>
+          {build.branchName}
+        </a>
+      );
+    }
+
+    if (build.pullRequest) {
+      pullRequestNode = (
+        <a className="no-highlight-link" href={build.pullRequest.url}>
+          Pull Request #{build.pullRequest.id}
+        </a>
+      );
+    }
+
+    if (branchNode && commitNode && pullRequestNode) {
+      return (
+        <span className="build-header__build-commit">
+          <span className="branch">
+            {branchNode}
+          </span>
+          {" "}
+          <code className="commit">
+            {commitNode}
+          </code>
+          {" "}
+          <span className="pull-request">
+            (
+            {pullRequestNode}
+            )
+          </span>
+        </span>
+      );
+    } else if (branchNode && commitNode) {
+      return (
+        <span className="build-header__build-commit">
+          <span className="branch">
+            {branchNode}
+          </span>
+          {" "}
+          <code className="commit">
+            {commitNode}
+          </code>
+        </span>
+      );
+    } else if (commitNode) {
+      return (
+        <span className="build-header__build-commit">
+          <code className="commit">
+            {commitNode}
+          </code>
+        </span>
+      );
+    }
+
+    return null;
+  },
+
+  timeAgoNode() {
+    return (
+      <small className="build-secondary-time text-muted">
+        <BuildStatusDescription build={this.props.build} />
+      </small>
+    );
+  },
+
+  sourceLabel(source) {
+    switch (source) {
+      case 'webhook':
+        return 'Webhook';
+      case 'ui':
+        return 'Web';
+      case 'api':
+        return 'API';
+      case 'trigger_job':
+        return 'Pipeline';
+      case 'schedule':
+        return 'Pipeline Schedule';
+      default:
+        return 'Unknown';
+    }
+  },
+
+  metaInformation() {
+    let rebuiltFromNode;
+    let triggeredFromNode;
+
+    const sourceNode = (
+      <small className="text-muted">
+        {`Triggered from ${this.sourceLabel(this.props.build.source)}`}
+      </small>
+    );
+
+    let className = 'build-meta-info';
+
+    if (this.props.build.rebuiltFrom) {
+      className += ' with-rebuild-information';
+
+      rebuiltFromNode = (
+        <small className="text-muted">
+          <br />
+          {'Rebuilt from '}
+          <a href={this.props.build.rebuiltFrom.url}>
+            {`#${this.props.build.rebuiltFrom.number}`}
+          </a>
+        </small>
+      );
+    }
+
+    if (this.props.build.triggeredFrom && this.props.build.triggeredFrom.url) {
+      const jobName = this.props.build.triggeredFrom.name || `Job #${this.props.build.triggeredFrom.uuid}`;
+
+      className += ' with-rebuild-information truncate';
+
+      triggeredFromNode = (
+        <small className="text-muted">
+          <br />
+          <a href={this.props.build.triggeredFrom.url}>
+            <span>
+              {this.props.build.triggeredFrom.project.name}
+              {' - Build #'}
+              {this.props.build.triggeredFrom.build.number}
+              {' / '}
+              <Emojify text={jobName} />
+            </span>
+          </a>
+        </small>
+      );
+    }
+
+    return (
+      <div className={className} style={{ width: 300 }}>
+        {sourceNode}
+        {rebuiltFromNode}
+        {triggeredFromNode}
+      </div>
+    );
+  },
+
+  render() {
+    const { build } = this.props;
+
+    const panelClassName = `panel panel-${this.bootstrapState()} build-panel build-state-${build.state} ${this.props.showProject ? 'mb4' : undefined}`;
+
+    let rebuildNode;
+
+    if (this.props.showRebuild && ((build.state === 'canceling') || build.finishedAt)) {
+      if (build.permissions.rebuild.allowed) {
+        rebuildNode = (
+          <a
+            className="twbs-btn twbs-btn-default build-rebuild-button ml2"
+            data-method="post"
+            href={build.rebuildPath}
+            rel="nofollow"
+          >
+            <i className="fa fa-refresh" />
+            <span>Rebuild</span>
+          </a>
+        );
+      } else if (build.permissions.rebuild.reason !== 'anonymous') {
+        rebuildNode = (
+          <a
+            className="twbs-btn twbs-btn-default build-rebuild-button ml2"
+            data-method="post"
+            disabled={true}
+            href={build.rebuildPath}
+            data-toggle="tooltip"
+            title={build.permissions.rebuild.message}
+            rel="nofollow"
+          >
+            <i className="fa fa-refresh" />
+            <span>Rebuild</span>
+          </a>
+        );
+      }
+    }
+
+    let cancelNode;
+
+    const { RemoteButtonComponent, BuildMessageComponent, BuildHeaderDurationComponent } = Buildkite;
+
+    if (build.state === 'scheduled' || build.state === 'started' || build.state === 'blocked') {
+      if (build.permissions.cancel.allowed) {
+        cancelNode = (
+          <RemoteButtonComponent
+            url={build.cancelPath}
+            method="post"
+            loadingText="Canceling…"
+            className="twbs-btn twbs-btn-danger build-cancel-button ml2"
+          >
+            <span>Cancel</span>
+          </RemoteButtonComponent>
+        );
+      } else if (build.permissions.cancel.reason !== 'anonymous') {
+        cancelNode = (
+          <a
+            href="#"
+            disabled={true}
+            data-toggle="tooltip"
+            title={build.permissions.cancel.message}
+            className="twbs-btn twbs-btn-danger build-cancel-button ml2"
+            rel="nofollow"
+          >
+            <span>Cancel</span>
+          </a>
+        );
+      }
+    }
+
+    return (
+      <div>
+        {this._projectNode()}
+        <div className={panelClassName}>
+          <div className="panel-heading clearfix">
+            <div className="flex build-header-inner">
+              <div className="flex-auto build-commit">
+                <h3 className="panel-title">
+                  <a href={build.path}>
+                    <BuildMessageComponent message={build.message} />
+                  </a>
+                </h3>
+                <div className="build-header__build-links">
+                  {this.buildInfoNode()}
+                  {this.commitInfoNode()}
+                </div>
+              </div>
+              <div className="build-info flex-none flex items-center">
+                <div className="build-duration mr2">
+                  <BuildHeaderDurationComponent build={build} />
+                </div>
+                <div className="build-status-icon-container">
+                  <div className="build-status-icon flex items-center justify-center">
+                    <i className={this.icon()} />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <Pipeline build={build} />
+          <div className="panel-footer" style={{ padding: '10px 13px' }}>
+            <div className="flex relative">
+              <div className="absolute top-0 left-0" />
+              <div className="build-author-avatar" style={{ width: 32 + 8 }}>
+                {this._avatarNode()}
+              </div>
+              <div className="build-author">
+                <div>
+                  {build.authorName}
+                </div>
+                {this.timeAgoNode()}
+              </div>
+              <div className="flex-auto">
+                {this.metaInformation()}
+              </div>
+              {rebuildNode}
+              {cancelNode}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+
+  _projectNode() {
+    if (this.props.showProject) {
+      return (
+        <div style={{ marginBottom: 10 }}>
+          <a href={this.props.build.project.url} className="dark-gray">
+            {`${this.props.build.account.name} / ${this.props.build.project.name}`}
+          </a>
+        </div>
+      );
+
+    }
+  },
+
+  _avatarNode() {
+    // Only show the avatar node if `showUnknownEmailPrompt` has been turned on,
+    // and we don't have an associated authorUuid (which is only present if
+    // there's an actual user on the build)
+    if (this.props.showUnknownEmailPrompt && !this.props.build.authorUuid) {
+      return (
+        <RootContainer
+          Component={AvatarWithUnknownEmailPrompt}
+          route={{
+            name: 'BuildHeaderEmailPromptRoute',
+            queries: {
+              viewer: ViewerQuery.query,
+              build: BuildQuery.query
+            },
+            params: BuildQuery.prepareParams({
+              organization: this.props.build.account.slug,
+              pipeline: this.props.build.project.slug,
+              number: this.props.build.number
+            })
+          }}
+        />
+      );
+    }
+
+    const user = {
+      name: this.props.build.authorName,
+      avatar: { url: this.props.build.authorAvatar }
+    };
+
+    return (
+      <UserAvatar
+        user={user}
+        style={{ width: 32, height: 32 }}
+      />
+    );
+  }
+});
+
+export default BuildHeaderComponent;
+

--- a/app/components/build/Header/index.js
+++ b/app/components/build/Header/index.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import CreateReactClass from 'create-react-class';
+import createReactClass from 'create-react-class';
 import { RootContainer } from 'react-relay';
 
 import * as BuildQuery from '../../../queries/Build';
@@ -18,11 +18,11 @@ import { shortCommit } from '../../../lib/commits';
 
 import Pipeline from './pipeline';
 
-const BuildHeaderComponent = CreateReactClass({
+const BuildHeaderComponent = createReactClass({
   displayName: 'BuildHeaderComponent',
 
   propTypes: {
-    build: PropTypes.object.isRequired,
+    build: PropTypes.shape({}).isRequired,
     showRebuild: PropTypes.bool,
     showProject: PropTypes.bool,
     showUnknownEmailPrompt: PropTypes.bool

--- a/app/components/build/Header/index.js
+++ b/app/components/build/Header/index.js
@@ -18,11 +18,42 @@ import { shortCommit } from '../../../lib/commits';
 
 import Pipeline from './pipeline';
 
-const BuildHeaderComponent = createReactClass({
+const BuildHeaderComponent = createReactClass({ // eslint-disable-line react/prefer-es6-class
   displayName: 'BuildHeaderComponent',
 
   propTypes: {
-    build: PropTypes.shape({}).isRequired,
+    build: PropTypes.shape({
+      number: PropTypes.number.isRequired,
+      state: PropTypes.string.isRequired,
+      source: PropTypes.string.isRequired,
+      authorName: PropTypes.string.isRequired,
+      authorAvatar: PropTypes.string.isRequired,
+      authorUuid: PropTypes.string,
+      project: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        url: PropTypes.string.isRequired,
+        slug: PropTypes.string.isRequired
+      }).isRequired,
+      account: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        slug: PropTypes.string.isRequired
+      }).isRequired,
+      rebuiltFrom: PropTypes.shape({
+        url: PropTypes.string.isRequired,
+        number: PropTypes.number.isRequired
+      }),
+      triggeredFrom: PropTypes.shape({
+        uuid: PropTypes.string.isRequired,
+        url: PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
+        project: PropTypes.shape({
+          name: PropTypes.string.isRequired
+        }).isRequired,
+        build: PropTypes.shape({
+          number: PropTypes.number.isRequired
+        }).isRequired
+      })
+    }).isRequired,
     showRebuild: PropTypes.bool,
     showProject: PropTypes.bool,
     showUnknownEmailPrompt: PropTypes.bool

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -75,7 +75,7 @@ const BuildHeaderPipelineComponent = CreateReactClass({
 
     const jobs = this.state.showBroken
       ? this.props.build.jobs
-      : this.props.build.jobs.filter(({ state }) => state !== "broken");
+      : this.props.build.jobs.filter(({ state }) => state !== 'broken');
 
     return jobs.map((job) => this.pipelineStep(job));
   },
@@ -85,15 +85,15 @@ const BuildHeaderPipelineComponent = CreateReactClass({
 
     const { BuildHeaderPipelineManualStepComponent, BuildHeaderPipelineTriggerStepComponent } = Buildkite;
 
-    if (job.type === "script") {
-      if (job.state === "broken") {
+    if (job.type === 'script') {
+      if (job.state === 'broken') {
         return (
           <div
             key={job.id}
             data-toggle="tooltip"
             title={job.tooltip}
             className={stepClassName}
-            style={{ maxWidth: "15em" }}
+            style={{ maxWidth: '15em' }}
           >
             {this.jobName(job)}
           </div>
@@ -108,12 +108,12 @@ const BuildHeaderPipelineComponent = CreateReactClass({
           href={href}
           onClick={this.handleScriptJobClick(job)}
           className={stepClassName}
-          style={{ maxWidth: "15em" }}
+          style={{ maxWidth: '15em' }}
         >
           {this.jobName(job)}
         </a>
       );
-    } else if (job.type === "waiter") {
+    } else if (job.type === 'waiter') {
       if (job.continueOnFailure) {
         return (
           <div
@@ -139,7 +139,7 @@ const BuildHeaderPipelineComponent = CreateReactClass({
           <Icon icon="chevron-right" style={{ height: 15, width: 15 }} />
         </div>
       );
-    } else if (job.type === "manual") {
+    } else if (job.type === 'manual') {
       return (
         <BuildHeaderPipelineManualStepComponent
           key={job.id}
@@ -148,7 +148,7 @@ const BuildHeaderPipelineComponent = CreateReactClass({
           stepClassName={stepClassName}
         />
       );
-    } else if (job.type === "trigger") {
+    } else if (job.type === 'trigger') {
       return (
         <BuildHeaderPipelineTriggerStepComponent
           key={job.id}
@@ -203,7 +203,7 @@ const BuildHeaderPipelineComponent = CreateReactClass({
     }
 
     return (
-      <span className="monospace" style={{ fontSize: "0.9em" }}>
+      <span className="monospace" style={{ fontSize: '0.9em' }}>
         {jobCommandOneliner(job.command)}
       </span>
     );
@@ -217,3 +217,4 @@ const BuildHeaderPipelineComponent = CreateReactClass({
 });
 
 export default BuildHeaderPipelineComponent;
+

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -21,10 +21,12 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
 
   propTypes: {
     build: PropTypes.shape({
+      id: PropTypes.string.isRequired,
       path: PropTypes.string.isRequired,
       jobs: PropTypes.arrayOf(PropTypes.shape({
         state: PropTypes.string.isRequired
-      }))
+      })),
+      jobsCount: PropTypes.number.isRequired
     }).isRequired
   },
 

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -2,14 +2,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import CreateReactClass from 'create-react-class';
+import createReactClass from 'create-react-class';
 
 import Emojify from '../../shared/Emojify';
 import Icon from '../../shared/Icon';
 
 import jobCommandOneliner from '../../../lib/jobCommandOneliner';
 
-const BuildHeaderPipelineComponent = CreateReactClass({
+const BuildHeaderPipelineComponent = createReactClass({
   displayName: 'BuildHeaderPipelineComponent',
 
   mixins: [Buildkite.BootstrapTooltipMixin],
@@ -19,7 +19,7 @@ const BuildHeaderPipelineComponent = CreateReactClass({
   },
 
   propTypes: {
-    build: PropTypes.object.isRequired
+    build: PropTypes.shape({}).isRequired
   },
 
   render() {

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -1,0 +1,217 @@
+/* global Buildkite */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import CreateReactClass from 'create-react-class';
+
+import Emojify from '../../shared/Emojify';
+import Icon from '../../shared/Icon';
+
+import jobCommandOneliner from '../../../lib/jobCommandOneliner';
+
+const { BuildHeaderPipelineManualStepComponent, BuildHeaderPipelineTriggerStepComponent } = Buildkite;
+
+const BuildHeaderPipelineComponent = CreateReactClass({
+  mixins: [Buildkite.BootstrapTooltipMixin],
+
+  getInitialState() {
+    return { showBroken: false };
+  },
+
+  propTypes: {
+    build: PropTypes.object.isRequired
+  },
+
+  render() {
+    const brokenJobs = this.brokenJobCount();
+    const action = this.state.showBroken ? "Hide" : "Show";
+    const icon = this.state.showBroken ? "eye-strikethrough" : "eye";
+    const suffix = brokenJobs > 1 ? "jobs" : "job";
+
+    const toggleBrokenNode = brokenJobs > 0
+      ? (
+        <button
+          className="btn dark-gray hover-black regular mt0 ml0 pt0 pl0"
+          onClick={this.handleToggleBrokenStepsClick}
+        >
+          <div
+            title={`${action} ${brokenJobs} skipped ${suffix}`}
+            data-toggle="tooltip"
+            data-animation="false"
+          >
+            <Icon icon={icon} className="relative" style={{ top: -3 }} />
+          </div>
+        </button>
+      )
+      : null;
+
+    return (
+      <div className="flex">
+        <div className="build-pipeline-container clearfix flex-auto">
+          {this.stepNodes()}
+        </div>
+        <div className="flex-none" style={{ paddingTop: 18 }}>
+          {toggleBrokenNode}
+        </div>
+      </div>
+    );
+  },
+
+  brokenJobCount() {
+    return this.props.build.jobs
+      .filter((job) => (
+        (job.state === 'broken') && (job.type !== 'waiter')
+      )).length;
+  },
+
+  stepNodes() {
+    if (this.props.build.jobs.length === 0) {
+      return (
+        <p className="text-danger" style={{ margin: '10px 0 5px' }}>
+          There are no build steps for this pipeline. To add a step, go to your Pipeline Settings.
+        </p>
+      );
+    }
+
+    const jobs = this.state.showBroken
+      ? this.props.build.jobs
+      : this.props.build.jobs.filter(({ state }) => state !== "broken");
+
+    return jobs.map((job) => this.pipelineStep(job));
+  },
+
+  pipelineStep(job) {
+    const stepClassName = this.stepClassName(job);
+
+    if (job.type === "script") {
+      if (job.state === "broken") {
+        return (
+          <div
+            key={job.id}
+            data-toggle="tooltip"
+            title={job.tooltip}
+            className={stepClassName}
+            style={{ maxWidth: "15em" }}
+          >
+            {this.jobName(job)}
+          </div>
+        );
+      }
+
+      const href = `${this.props.build.path}#${job.id}`;
+
+      return (
+        <a
+          key={job.id}
+          href={href}
+          onClick={this.handleScriptJobClick(job)}
+          className={stepClassName}
+          style={{ maxWidth: "15em" }}
+        >
+          {this.jobName(job)}
+        </a>
+      );
+    } else if (job.type === "waiter") {
+      if (job.continueOnFailure) {
+        return (
+          <div
+            key={job.id}
+            className={`${stepClassName} dark-gray relative`}
+            title="Wait for all previous steps to finish including failures"
+          >
+            <i
+              className="fa fa-times absolute"
+              style={{ fontSize: 12, top: 3, right: 3 }}
+            />
+            <Icon icon="chevron-right" style={{ height: 15, width: 15 }} />
+          </div>
+        );
+      }
+
+      return (
+        <div
+          key={job.id}
+          className={`${stepClassName} dark-gray`}
+          title="Wait for all previous steps to pass"
+        >
+          <Icon icon="chevron-right" style={{ height: 15, width: 15 }} />
+        </div>
+      );
+    } else if (job.type === "manual") {
+      return (
+        <BuildHeaderPipelineManualStepComponent
+          key={job.id}
+          build={this.props.build}
+          job={job}
+          stepClassName={stepClassName}
+        />
+      );
+    } else if (job.type === "trigger") {
+      return (
+        <BuildHeaderPipelineTriggerStepComponent
+          key={job.id}
+          build={this.props.build}
+          job={job}
+          stepClassName={stepClassName}
+        />
+      );
+    }
+
+    return (
+      <div key={job.id} className={stepClassName}>
+        {job.type}
+      </div>
+    );
+  },
+
+  stepClassName(job) {
+    const state = job.state === 'finished' && (job.type === 'script' || job.type === 'trigger')
+      ? (
+        job.passed
+          ? 'passed'
+          : 'failed'
+      )
+      : job.state;
+
+    return [
+      'build-pipeline-job',
+      `build-pipeline-job-${job.type.replace(/_/g, '-')}`,
+      `build-pipeline-state-${state}`,
+      'truncate',
+      'align-middle'
+    ].join(' ');
+  },
+
+  handleScriptJobClick(job) {
+    return function(evt) {
+      // return if the user did a middle-click, right-click, or used a modifier
+      // key (like ctrl-click, meta-click, shift-click, etc.)
+      if ((evt.button !== 0) || evt.altKey || evt.ctrlKey || evt.metaKey || evt.shiftKey) {
+        return;
+      }
+
+      evt.preventDefault();
+      return Buildkite.NewDispatcher.handleViewAction({ actionType: "JOB_TOGGLE", job, source: "BUILD_HEADER" });
+    };
+  },
+
+  jobName(job) {
+    if (job.name) {
+      return <Emojify text={job.name} />;
+    }
+
+    return (
+      <span className="monospace" style={{ fontSize: "0.9em" }}>
+        {jobCommandOneliner(job.command)}
+      </span>
+    );
+  },
+
+  handleToggleBrokenStepsClick(evt) {
+    evt.preventDefault();
+    evt.target.blur();
+    return this.setState({ showBroken: !this.state.showBroken });
+  }
+});
+
+export default BuildHeaderPipelineComponent;

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -83,7 +83,24 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
       ? this.props.build.jobs
       : this.props.build.jobs.filter(({ state }) => state !== 'broken');
 
-    return jobs.map((job) => this.pipelineStep(job));
+    const renderedJobs = jobs.map((job) => this.pipelineStep(job));
+
+    // If the build has hidden jobs (such as on the project show / build index
+    // page, we want to add a "..." build step that links to the build so you
+    // can see all the steps)
+    if (this.props.build.jobs.length !== this.props.build.jobsCount) {
+      renderedJobs.push(
+        <a
+          key={`${this.props.build.id}-more-jobs`}
+          href={this.props.build.path}
+          className="build-pipeline-job truncate align-middle"
+        >
+          ...
+        </a>
+      );
+    }
+
+    return renderedJobs;
   },
 
   pipelineStep(job) {

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -8,11 +8,12 @@ import Emojify from '../../shared/Emojify';
 import Icon from '../../shared/Icon';
 
 import jobCommandOneliner from '../../../lib/jobCommandOneliner';
+import BootstrapTooltipMixin from '../../../lib/BootstrapTooltipMixin';
 
 const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line react/prefer-es6-class
   displayName: 'BuildHeaderPipelineComponent',
 
-  mixins: [Buildkite.BootstrapTooltipMixin],
+  mixins: [BootstrapTooltipMixin],
 
   getInitialState() {
     return { showBroken: false };

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -9,9 +9,9 @@ import Icon from '../../shared/Icon';
 
 import jobCommandOneliner from '../../../lib/jobCommandOneliner';
 
-const { BuildHeaderPipelineManualStepComponent, BuildHeaderPipelineTriggerStepComponent } = Buildkite;
-
 const BuildHeaderPipelineComponent = CreateReactClass({
+  displayName: 'BuildHeaderPipelineComponent',
+
   mixins: [Buildkite.BootstrapTooltipMixin],
 
   getInitialState() {
@@ -82,6 +82,8 @@ const BuildHeaderPipelineComponent = CreateReactClass({
 
   pipelineStep(job) {
     const stepClassName = this.stepClassName(job);
+
+    const { BuildHeaderPipelineManualStepComponent, BuildHeaderPipelineTriggerStepComponent } = Buildkite;
 
     if (job.type === "script") {
       if (job.state === "broken") {

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -9,7 +9,7 @@ import Icon from '../../shared/Icon';
 
 import jobCommandOneliner from '../../../lib/jobCommandOneliner';
 
-const BuildHeaderPipelineComponent = createReactClass({
+const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line react/prefer-es6-class
   displayName: 'BuildHeaderPipelineComponent',
 
   mixins: [Buildkite.BootstrapTooltipMixin],
@@ -19,7 +19,12 @@ const BuildHeaderPipelineComponent = createReactClass({
   },
 
   propTypes: {
-    build: PropTypes.shape({}).isRequired
+    build: PropTypes.shape({
+      path: PropTypes.string.isRequired,
+      jobs: PropTypes.arrayOf(PropTypes.shape({
+        state: PropTypes.string.isRequired
+      }))
+    }).isRequired
   },
 
   render() {

--- a/app/lib/BootstrapTooltipMixin.js
+++ b/app/lib/BootstrapTooltipMixin.js
@@ -1,0 +1,40 @@
+/* global jQuery */
+
+import ReactDOM from 'react-dom';
+
+export default {
+  componentDidMount() {
+    this._tooltiperize();
+  },
+
+  componentDidUpdate() {
+    this._tooltiperize();
+  },
+
+  _tooltiperize() {
+    const component = ReactDOM.findDOMNode(this); // eslint-disable-line react/no-find-dom-node
+
+    // If the root node of the react component is the tooltipper, just apply the
+    // plugin to that and not bother about looking at children.
+    if (component.getAttribute('data-toggle') === 'tooltip') {
+      this._fixTooltip(component);
+    } else {
+      jQuery(component)
+        .find("[data-toggle='tooltip']")
+        .each((idx, child) => this._fixTooltip(child));
+    }
+  },
+
+  _fixTooltip(element) {
+    const $element = jQuery(element);
+
+    const showing = !!$element.attr('aria-describedby');
+
+    $element.data('animation', false);
+    $element.tooltip('destroy').tooltip();
+    $element.data('original-title', $element.attr('title'));
+
+    $element.tooltip(showing ? 'show' : 'hide');
+  }
+};
+


### PR DESCRIPTION
This was part of a scheme to try to move these components’ data requirements to GraphQL.

This part ended up taking a bit longer than I’d hoped, but I guess it might still be a step in the right direction.

Components were converted using [Decaffeinate](http://decaffeinate-project.org), and [react-codemod](https://github.com/reactjs/react-codemod), with guest star [Prettier](https://prettier.io), and some hand-massaging to add PropTypes and make it pass our rigorous ESLint suite.

`BootstrapTooltipMixin` also made the jump despite being _quite_ legacy because it was required by one of the components I needed to move, and it otherwise isn’t loaded in time for the ES6 code to use it.