### PR TITLE
Fix agent searching for upper case tag names/values

### DIFF
--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -126,10 +126,12 @@ class Agents extends React.PureComponent {
     // Parse the search. We only want to do this once, outside of the agent
     // loop, in case they have lots of agents
     const queries = localSearchQuery.map((string) => {
+      const [key, value] = string.split('=');
+
       return {
         string: string.toLowerCase(),
-        metaDataKey: string.split('=')[0],
-        metaDataValue: string.split('=')[1] // may be undefined
+        metaDataKey: key,
+        metaDataValue: value // may be undefined
       };
     });
 
@@ -141,7 +143,7 @@ class Agents extends React.PureComponent {
 
     const anyQueryMatchesMetaData = (agent) => {
       return agent.metaData.some((metaDataKeyValue) => {
-        const [key, value] = metaDataKeyValue.toLowerCase().split('=');
+        const [key, value] = metaDataKeyValue.split('=');
 
         return queries.some((query) => {
           // Simple string match


### PR DESCRIPTION
If you start an agent with tag `tag=Value` and then try to search for it in the agents UI, you can only match it with `tag=value` — if you type `tag=Value` then it shows "0 matching agents"

![tag-search](https://user-images.githubusercontent.com/153/30097451-1266f026-9321-11e7-9c72-f3385caed067.gif)

This fixes the problem by making, which makes the search case sensitive in the same way the step agent targeting rules are.

![tag-searching-fixed](https://user-images.githubusercontent.com/153/30097602-b9e48f84-9321-11e7-8ddb-a5a01c2c8119.gif)

Search is still slightly different to agent targeting, in that partial matches are allowed, and you can search for an agent name case insensitively. But I think this is an improvement.

The alternative is to make tag searching completely case insensitive. But I'm afraid that might lead people to think that agent targeting rules are the same?