### PR TITLE
Restore bundle analysis functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-and-fix": "eslint --fix .",
     "build": "NODE_ENV=development webpack --config webpack/config.js --progress --bail --cache",
     "build-production": "NODE_ENV=production webpack --config webpack/config.js --progress --bail",
-    "bundle-analyze": "NODE_ENV=production webpack --config webpack/config.js --profile --json",
+    "bundle-analyze": "NODE_ENV=production COLLECT_BUNDLE_STATS=true webpack --config webpack/config.js --bail --profile && webpack-bundle-analyzer bundle-analysis/stats.json dist --no-open --mode static -r bundle-analysis/bundle-analyzer-report.html",
     "webpack-dev-server": "NODE_ENV=development webpack-dev-server --config webpack/config.js --progress --colors --cache --inline --hot --host buildkite.dev --port 4890"
   },
   "devDependencies": {
@@ -57,6 +57,7 @@
     "react-transform-hmr": "^1.0.4",
     "react-type-snob": "^0.0.3",
     "relay-compiler": "^1.1.0",
+    "stats-webpack-plugin": "^0.6.1",
     "style-loader": "^0.18.1",
     "url-loader": "^0.5.7",
     "webpack": "2",

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -144,6 +144,11 @@ if (IS_PRODUCTION) {
   }));
 }
 
+if (process.env.COLLECT_BUNDLE_STATS === 'true') {
+  var StatsPlugin = require('stats-webpack-plugin');
+  plugins.push(new StatsPlugin('../bundle-analysis/stats.json'));
+}
+
 if (IS_PRODUCTION || process.env['BUGSNAG_JS_API_KEY']) {
   // Only load Bugsnag if configured, or we're in Production
   vendor_modules.unshift("bugsnag-js");

--- a/yarn.lock
+++ b/yarn.lock
@@ -7573,6 +7573,12 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+stats-webpack-plugin@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/stats-webpack-plugin/-/stats-webpack-plugin-0.6.1.tgz#5db260514387bc3d4ba6fb85fc4990bd4a71c415"
+  dependencies:
+    lodash "^4.17.4"
+
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"


### PR DESCRIPTION
Working around danielholmes/relay-compiler-webpack-plugin#5 by avoiding stdout for JSON generation, using stats-webpack-plugin.

Related: #365.