### PR TITLE
Add text-decoration-none to pipeline steps.

### DIFF
--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -95,7 +95,7 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
         <a
           key={`${this.props.build.id}-more-jobs`}
           href={this.props.build.path}
-          className="build-pipeline-job truncate align-middle"
+          className="build-pipeline-job text-decoration-none truncate align-middle"
         >
           ...
         </a>


### PR DESCRIPTION
There's currently a few bugs with the text-decoration on pipeline steps. Disabling text-decoration seems to fix it.

Bug 1 - Drag and dropping emoji from a pipeline steps shows an underline.
Bug 2 - Clicking on text pipeline steps seems to randomly show an underline.

Example error:
<img width="169" alt="image" src="https://user-images.githubusercontent.com/122602/32681493-9e398f60-c624-11e7-95ee-8e37a4562cad.png">
