### PR TITLE
Add a detailed job history for Agents

### DIFF
--- a/app/components/agent/Jobs.js
+++ b/app/components/agent/Jobs.js
@@ -1,7 +1,7 @@
 // @flow
+/* eslint-disable react/prop-types */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import { Link } from 'react-router';
 import DocumentTitle from 'react-document-title';
@@ -40,7 +40,7 @@ type Props = {
 
 type State = {
   loading: boolean
-}
+};
 
 class AgentJobs extends React.PureComponent<Props, State> {
   state = {

--- a/app/components/agent/Jobs.js
+++ b/app/components/agent/Jobs.js
@@ -1,0 +1,138 @@
+// @flow
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Relay from 'react-relay/classic';
+import { Link } from 'react-router';
+import DocumentTitle from 'react-document-title';
+
+import FriendlyTime from '../shared/FriendlyTime';
+import JobLink from '../shared/JobLink';
+import JobState from '../icons/JobState';
+import PageWithContainer from '../shared/PageWithContainer';
+import Panel from '../shared/Panel';
+import ShowMoreFooter from '../shared/ShowMoreFooter';
+
+const PAGE_SIZE = 25;
+
+type Props = {
+  agent: {
+    uuid: string,
+    name: string,
+    jobs: {
+      count: number,
+      edges: Array<{
+        node: {
+          uuid: string,
+          state: string,
+          passed: boolean,
+          startedAt?: string
+        }
+      }>
+    },
+    organization: {
+      slug: string,
+      name: string
+    }
+  },
+  relay: Object
+};
+
+type State = {
+  loading: boolean
+}
+
+class AgentJobs extends React.PureComponent<Props, State> {
+  state = {
+    loading: false
+  };
+
+  render() {
+    return (
+      <DocumentTitle title={`${this.props.agent.name} / Recent Jobs · ${this.props.agent.organization.name}`}>
+        <PageWithContainer>
+          <Panel className="sm-col-9 lg-col-6 mx-auto">
+            <Panel.Header>
+              <Link
+                to={`/organizations/${this.props.agent.organization.slug}/agents/${this.props.agent.uuid}`}
+                className="black text-decoration-none hover-underline"
+              >
+                {this.props.agent.name}
+              </Link>
+              {` / Recent Jobs`}
+            </Panel.Header>
+            {this.props.agent.jobs.edges.map(({ node: job }) => (
+              <Panel.Row key={job.uuid}>
+                <div className="flex">
+                  <JobState.Small
+                    job={job}
+                    className="flex-none mr2"
+                  />
+                  <div className="flex-auto md-flex">
+                    <JobLink className="block flex-auto" job={job} />
+                    <FriendlyTime className="flex-none dark-gray" value={job.startedAt} />
+                  </div>
+                </div>
+              </Panel.Row>
+            ))}
+            <ShowMoreFooter
+              connection={this.props.agent.jobs}
+              label="jobs"
+              loading={this.state.loading}
+              onShowMore={this.handleShowMoreJobs}
+            />
+          </Panel>
+        </PageWithContainer>
+      </DocumentTitle>
+    );
+  }
+
+  handleShowMoreJobs = () => {
+    this.setState({ loading: true });
+
+    this.props.relay.setVariables(
+      {
+        pageSize: this.props.relay.variables.pageSize + PAGE_SIZE
+      },
+      (readyState) => {
+        if (readyState.done) {
+          this.setState({ loading: false });
+        }
+      }
+    );
+  };
+}
+
+export default Relay.createContainer(AgentJobs, {
+  initialVariables: {
+    pageSize: PAGE_SIZE
+  },
+
+  fragments: {
+    agent: () => Relay.QL`
+      fragment on Agent {
+        uuid
+        name
+        organization {
+          name
+          slug
+        }
+        jobs(first: $pageSize) {
+          ${ShowMoreFooter.getFragment('connection')}
+          edges {
+            node {
+              ...on JobTypeCommand {
+                uuid
+                state
+                passed
+                startedAt
+              }
+              ${JobLink.getFragment('job')}
+            }
+          }
+          count
+        }
+      }
+    `
+  }
+});

--- a/app/components/agent/Jobs/index.js
+++ b/app/components/agent/Jobs/index.js
@@ -63,7 +63,7 @@ class AgentJobs extends React.PureComponent<Props, State> {
               </Link>
               {` / Recent Jobs`}
             </Panel.Header>
-            {this.renderJobs()}
+            {this.renderJobList()}
             <ShowMoreFooter
               connection={this.props.agent.jobs}
               label="jobs"
@@ -76,10 +76,20 @@ class AgentJobs extends React.PureComponent<Props, State> {
     );
   }
 
-  renderJobs() {
-    return this.props.agent.jobs.edges.map(({ node }) => (
-      <AgentJobRow job={node} key={node.uuid}/>
-    ));
+  renderJobList() {
+    const jobs = this.props.agent.jobs.edges;
+
+    if (jobs.length > 0) {
+      return jobs.map(({ node }) => (
+        <AgentJobRow job={node} key={node.uuid}/>
+      ));
+    } else {
+      return (
+        <Panel.Section className="dark-gray">
+          This agent has not run any jobs
+        </Panel.Section>
+      );
+    }
   }
 
   handleShowMoreJobs = () => {

--- a/app/components/agent/Jobs/index.js
+++ b/app/components/agent/Jobs/index.js
@@ -6,9 +6,6 @@ import Relay from 'react-relay/classic';
 import { Link } from 'react-router';
 import DocumentTitle from 'react-document-title';
 
-import FriendlyTime from '../../shared/FriendlyTime';
-import JobLink from '../../shared/JobLink';
-import JobState from '../../icons/JobState';
 import PageWithContainer from '../../shared/PageWithContainer';
 import Panel from '../../shared/Panel';
 import ShowMoreFooter from '../../shared/ShowMoreFooter';
@@ -79,17 +76,20 @@ class AgentJobs extends React.PureComponent<Props, State> {
   renderJobList() {
     const jobs = this.props.agent.jobs.edges;
 
-    if (jobs.length > 0) {
-      return jobs.map(({ node }) => (
-        <AgentJobRow job={node} key={node.uuid}/>
-      ));
-    } else {
+    if (jobs.length < 1) {
       return (
         <Panel.Section className="dark-gray">
           This agent has not run any jobs
         </Panel.Section>
       );
     }
+
+    return jobs.map((edge) => (
+      <AgentJobRow
+        job={edge.node}
+        key={edge.node.uuid}
+      />
+    ));
   }
 
   handleShowMoreJobs = () => {

--- a/app/components/agent/Jobs/index.js
+++ b/app/components/agent/Jobs/index.js
@@ -6,12 +6,14 @@ import Relay from 'react-relay/classic';
 import { Link } from 'react-router';
 import DocumentTitle from 'react-document-title';
 
-import FriendlyTime from '../shared/FriendlyTime';
-import JobLink from '../shared/JobLink';
-import JobState from '../icons/JobState';
-import PageWithContainer from '../shared/PageWithContainer';
-import Panel from '../shared/Panel';
-import ShowMoreFooter from '../shared/ShowMoreFooter';
+import FriendlyTime from '../../shared/FriendlyTime';
+import JobLink from '../../shared/JobLink';
+import JobState from '../../icons/JobState';
+import PageWithContainer from '../../shared/PageWithContainer';
+import Panel from '../../shared/Panel';
+import ShowMoreFooter from '../../shared/ShowMoreFooter';
+
+import AgentJobRow from './row';
 
 const PAGE_SIZE = 25;
 
@@ -61,20 +63,7 @@ class AgentJobs extends React.PureComponent<Props, State> {
               </Link>
               {` / Recent Jobs`}
             </Panel.Header>
-            {this.props.agent.jobs.edges.map(({ node: job }) => (
-              <Panel.Row key={job.uuid}>
-                <div className="flex">
-                  <JobState.Small
-                    job={job}
-                    className="flex-none mr2"
-                  />
-                  <div className="flex-auto md-flex">
-                    <JobLink className="block flex-auto" job={job} />
-                    <FriendlyTime className="flex-none dark-gray" value={job.startedAt} />
-                  </div>
-                </div>
-              </Panel.Row>
-            ))}
+            {this.renderJobs()}
             <ShowMoreFooter
               connection={this.props.agent.jobs}
               label="jobs"
@@ -85,6 +74,12 @@ class AgentJobs extends React.PureComponent<Props, State> {
         </PageWithContainer>
       </DocumentTitle>
     );
+  }
+
+  renderJobs() {
+    return this.props.agent.jobs.edges.map(({ node }) => (
+      <AgentJobRow job={node} key={node.uuid}/>
+    ));
   }
 
   handleShowMoreJobs = () => {
@@ -121,13 +116,7 @@ export default Relay.createContainer(AgentJobs, {
           ${ShowMoreFooter.getFragment('connection')}
           edges {
             node {
-              ...on JobTypeCommand {
-                uuid
-                state
-                passed
-                startedAt
-              }
-              ${JobLink.getFragment('job')}
+              ${AgentJobRow.getFragment('job')}
             }
           }
           count

--- a/app/components/agent/Jobs/row.js
+++ b/app/components/agent/Jobs/row.js
@@ -1,0 +1,57 @@
+// @flow
+/* eslint-disable react/prop-types */
+
+import React from 'react';
+import Relay from 'react-relay/classic';
+import { Link } from 'react-router';
+
+import FriendlyTime from '../../shared/FriendlyTime';
+import JobLink from '../../shared/JobLink';
+import JobState from '../../icons/JobState';
+import Panel from '../../shared/Panel';
+
+type Props = {
+  job: {
+    uuid: string,
+    state: string,
+    passed: boolean,
+    startedAt?: string
+  }
+};
+
+class AgentJobRow extends React.PureComponent<Props> {
+  render() {
+    const job = this.props.job;
+
+    return (
+      <Panel.Row>
+        <div className="flex">
+          <JobState.Small
+            job={job}
+            className="flex-none mr2"
+          />
+          <div className="flex-auto md-flex">
+            <JobLink className="block flex-auto" job={job} />
+            <FriendlyTime className="flex-none dark-gray" value={job.startedAt} />
+          </div>
+        </div>
+      </Panel.Row>
+    );
+  }
+}
+
+export default Relay.createContainer(AgentJobRow, {
+  fragments: {
+    job: () => Relay.QL`
+      fragment on Job {
+        ${JobLink.getFragment('job')}
+        ...on JobTypeCommand {
+          uuid
+          state
+          passed
+          startedAt
+        }
+      }
+    `
+  }
+});

--- a/app/components/agent/Jobs/row.js
+++ b/app/components/agent/Jobs/row.js
@@ -3,7 +3,6 @@
 
 import React from 'react';
 import Relay from 'react-relay/classic';
-import { Link } from 'react-router';
 
 import FriendlyTime from '../../shared/FriendlyTime';
 import JobState from '../../icons/JobState';

--- a/app/components/agent/Jobs/row.js
+++ b/app/components/agent/Jobs/row.js
@@ -14,6 +14,7 @@ type Props = {
     uuid: string,
     state: string,
     passed: boolean,
+    scheduledAt: string,
     startedAt?: string,
     url: string
   }
@@ -32,7 +33,10 @@ class AgentJobRow extends React.PureComponent<Props> {
           />
           <div className="flex-auto">
             <JobTitle className="block flex-auto" job={job} />
-            <FriendlyTime className="flex-none dark-gray" value={job.startedAt} />
+            <FriendlyTime
+              className="flex-none dark-gray"
+              value={job.startedAt || job.scheduledAt}
+            />
           </div>
         </div>
       </Panel.RowLink>
@@ -48,6 +52,7 @@ export default Relay.createContainer(AgentJobRow, {
         uuid
         state
         passed
+        scheduledAt
         startedAt
         url
       }

--- a/app/components/agent/Jobs/row.js
+++ b/app/components/agent/Jobs/row.js
@@ -6,8 +6,8 @@ import Relay from 'react-relay/classic';
 import { Link } from 'react-router';
 
 import FriendlyTime from '../../shared/FriendlyTime';
-import JobLink from '../../shared/JobLink';
 import JobState from '../../icons/JobState';
+import JobTitle from '../../shared/JobTitle';
 import Panel from '../../shared/Panel';
 
 type Props = {
@@ -15,7 +15,8 @@ type Props = {
     uuid: string,
     state: string,
     passed: boolean,
-    startedAt?: string
+    startedAt?: string,
+    url: string
   }
 };
 
@@ -24,18 +25,18 @@ class AgentJobRow extends React.PureComponent<Props> {
     const job = this.props.job;
 
     return (
-      <Panel.Row>
-        <div className="flex">
+      <Panel.RowLink href={job.url}>
+        <div className="flex regular line-height-3">
           <JobState.Small
             job={job}
             className="flex-none mr2"
           />
-          <div className="flex-auto md-flex">
-            <JobLink className="block flex-auto" job={job} />
+          <div className="flex-auto">
+            <JobTitle className="block flex-auto" job={job} />
             <FriendlyTime className="flex-none dark-gray" value={job.startedAt} />
           </div>
         </div>
-      </Panel.Row>
+      </Panel.RowLink>
     );
   }
 }
@@ -43,14 +44,13 @@ class AgentJobRow extends React.PureComponent<Props> {
 export default Relay.createContainer(AgentJobRow, {
   fragments: {
     job: () => Relay.QL`
-      fragment on Job {
-        ${JobLink.getFragment('job')}
-        ...on JobTypeCommand {
-          uuid
-          state
-          passed
-          startedAt
-        }
+      fragment on JobTypeCommand {
+        ${JobTitle.getFragment('job')}
+        uuid
+        state
+        passed
+        startedAt
+        url
       }
     `
   }

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -41,7 +41,7 @@ const ExtrasTable = styled.table`
 class AgentShow extends React.Component {
   static propTypes = {
     agent: PropTypes.shape({
-      id: PropTypes.string,
+      uuid: PropTypes.string,
       name: PropTypes.string,
       connectionState: PropTypes.string,
       job: PropTypes.object,
@@ -66,7 +66,7 @@ class AgentShow extends React.Component {
   componentDidMount() {
     // Only bother setting up the delayed load and refresher if we've got an
     // actual agent to play with.
-    if (this.props.agent && this.props.agent.id) {
+    if (this.props.agent && this.props.agent.uuid) {
       // This will cause a full refresh of the data every 3 seconds. This seems
       // very low, but chances are people aren't really looking at this page
       // for long periods of time.
@@ -315,7 +315,7 @@ class AgentShow extends React.Component {
     // If we don't have an agent object, or we do but it doesn't have an id
     // (perhaps Relay gave us an object but it's empty) then we can safely
     // assume that it's a 404.
-    if (!this.props.agent || !this.props.agent.id) {
+    if (!this.props.agent || !this.props.agent.uuid) {
       return (
         <DocumentTitle title={`Agents / No Agent Found`}>
           <PageWithContainer>
@@ -406,7 +406,7 @@ export default Relay.createContainer(AgentShow, {
       fragment on Agent {
         ${AgentStateIcon.getFragment('agent')}
         ${AgentStopMutation.getFragment('agent')}
-        id
+        uuid
         name
         organization {
           name
@@ -416,7 +416,6 @@ export default Relay.createContainer(AgentShow, {
         connectionState
         disconnectedAt
         hostname
-        id
         ipAddress
         job {
           ...on JobTypeCommand {

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -278,7 +278,15 @@ class AgentShow extends React.Component {
       );
     }
 
-    extras.push(this.renderExtraItem('Recent Jobs', content));
+    extras.push(this.renderExtraItem(
+      <Link
+        to={`/organizations/${this.props.agent.organization.slug}/agents/${this.props.agent.uuid}/jobs`}
+        className="blue hover-navy text-decoration-none hover-underline"
+      >
+        Recent Jobs
+      </Link>,
+      content
+    ));
   }
 
   handleStopButtonClick = (evt) => {

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -169,14 +169,6 @@ class AgentShow extends React.Component {
       extras.push(this.renderExtraItem('Priority', agent.priority));
     }
 
-    if (agent.isRunningJob) {
-      extras.push(this.renderExtraItem(
-        'Running',
-        // if we have access to the job, show a link
-        this.renderJob(agent.job)
-      ));
-    }
-
     this.renderExtraJobs(agent, extras);
 
     if (agent.connectedAt) {
@@ -283,7 +275,7 @@ class AgentShow extends React.Component {
         to={`/organizations/${this.props.agent.organization.slug}/agents/${this.props.agent.uuid}/jobs`}
         className="blue hover-navy text-decoration-none hover-underline"
       >
-        Recent Jobs
+        Jobs
       </Link>,
       content
     ));

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
+import { Link } from 'react-router';
 import styled from 'styled-components';
 import DocumentTitle from 'react-document-title';
 import { seconds } from 'metrick/duration';
 
 import AgentStateIcon from './state-icon';
 import Badge from '../shared/Badge';
-import BuildState from '../icons/BuildState';
-import BuildStates from '../../constants/BuildStates';
 import Button from '../shared/Button';
 import FlashesStore from '../../stores/FlashesStore';
 import FriendlyTime from '../shared/FriendlyTime';
 import JobLink from '../shared/JobLink';
+import JobState from '../icons/JobState';
 import PageWithContainer from '../shared/PageWithContainer';
 import Panel from '../shared/Panel';
 import permissions from '../../lib/permissions';
@@ -96,34 +96,6 @@ class AgentShow extends React.Component {
     );
   };
 
-  getBuildStateForJob(job) {
-    // Naïvely transliterate Job state to Build state
-    switch (job.state) {
-      case "FINISHED":
-        return (
-          job.passed
-            ? BuildStates.PASSED
-            : BuildStates.FAILED
-        );
-      case "PENDING":
-      case "WAITING":
-      case "UNBLOCKED":
-      case "LIMITED":
-      case "ASSIGNED":
-      case "ACCEPTED":
-        return BuildStates.SCHEDULED;
-      case "TIMING_OUT":
-      case "TIMED_OUT":
-      case "WAITING_FAILED":
-      case "BLOCKED_FAILED":
-      case "UNBLOCKED_FAILED":
-      case "BROKEN":
-        return BuildStates.FAILED;
-      default:
-        return job.state;
-    }
-  }
-
   renderJob(job) {
     if (!job) {
       return 'A job owned by another team';
@@ -131,8 +103,8 @@ class AgentShow extends React.Component {
 
     return (
       <span style={{ display: 'inline-block', marginLeft: '1.4em' }}>
-        <BuildState.XSmall
-          state={this.getBuildStateForJob(job)}
+        <JobState.XSmall
+          job={job}
           style={{ marginLeft: '-1.4em', marginRight: '.4em' }}
         />
         <JobLink job={job} />
@@ -296,7 +268,12 @@ class AgentShow extends React.Component {
       content = (
         <div>
           {content}
-          (and {formatNumber(remainder)} more)
+          <Link
+            to={`/organizations/${this.props.agent.organization.slug}/agents/${this.props.agent.uuid}/jobs`}
+            className="blue hover-navy text-decoration-none hover-underline"
+          >
+            (and {formatNumber(remainder)} more)
+          </Link>
         </div>
       );
     }

--- a/app/components/icons/BuildState.js
+++ b/app/components/icons/BuildState.js
@@ -172,4 +172,3 @@ Object.keys(SIZE_DEFINITIONS).forEach((size) => {
 });
 
 export default exported;
-

--- a/app/components/icons/JobState.js
+++ b/app/components/icons/JobState.js
@@ -1,31 +1,33 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import BuildStates from '../../constants/BuildStates';
+import JobStates from '../../constants/JobStates';
 
 import BuildState from './BuildState';
 
 const getBuildStateForJob = (job) => {
   // Naïvely transliterate Job state to Build state
   switch (job.state) {
-    case 'FINISHED':
+    case JobStates.FINISHED:
       return (
         job.passed
           ? BuildStates.PASSED
           : BuildStates.FAILED
       );
-    case 'PENDING':
-    case 'WAITING':
-    case 'UNBLOCKED':
-    case 'LIMITED':
-    case 'ASSIGNED':
-    case 'ACCEPTED':
+    case JobStates.PENDING:
+    case JobStates.WAITING:
+    case JobStates.UNBLOCKED:
+    case JobStates.LIMITED:
+    case JobStates.ASSIGNED:
+    case JobStates.ACCEPTED:
       return BuildStates.SCHEDULED;
-    case 'TIMING_OUT':
-    case 'TIMED_OUT':
-    case 'WAITING_FAILED':
-    case 'BLOCKED_FAILED':
-    case 'UNBLOCKED_FAILED':
-    case 'BROKEN':
+    case JobStates.TIMING_OUT:
+    case JobStates.TIMED_OUT:
+    case JobStates.WAITING_FAILED:
+    case JobStates.BLOCKED_FAILED:
+    case JobStates.UNBLOCKED_FAILED:
+    case JobStates.BROKEN:
       return BuildStates.FAILED;
     default:
       return job.state;
@@ -44,6 +46,12 @@ Object.keys(BuildState).forEach((size) => {
     />
   );
   component.displayName = `JobState.${size}`;
+  component.propTypes = {
+    job: PropTypes.shape({
+      state: PropTypes.oneOf(Object.keys(JobStates)).isRequired,
+      passed: PropTypes.bool.isRequired
+    }).isRequired
+  };
 
   exported[size] = component;
 });

--- a/app/components/icons/JobState.js
+++ b/app/components/icons/JobState.js
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import BuildStates from '../../constants/BuildStates';
+
+import BuildState from './BuildState';
+
+const getBuildStateForJob = (job) => {
+  // Naïvely transliterate Job state to Build state
+  switch (job.state) {
+    case 'FINISHED':
+      return (
+        job.passed
+          ? BuildStates.PASSED
+          : BuildStates.FAILED
+      );
+    case 'PENDING':
+    case 'WAITING':
+    case 'UNBLOCKED':
+    case 'LIMITED':
+    case 'ASSIGNED':
+    case 'ACCEPTED':
+      return BuildStates.SCHEDULED;
+    case 'TIMING_OUT':
+    case 'TIMED_OUT':
+    case 'WAITING_FAILED':
+    case 'BLOCKED_FAILED':
+    case 'UNBLOCKED_FAILED':
+    case 'BROKEN':
+      return BuildStates.FAILED;
+    default:
+      return job.state;
+  }
+};
+
+const exported = {};
+
+Object.keys(BuildState).forEach((size) => {
+  const BuildStateComponent = BuildState[size];
+
+  const component = ({ job, ...props }) => (
+    <BuildStateComponent
+      {...props}
+      state={getBuildStateForJob(job)}
+    />
+  );
+  component.displayName = `JobState.${size}`;
+
+  exported[size] = component;
+});
+
+export default exported;

--- a/app/components/shared/JobLink.js
+++ b/app/components/shared/JobLink.js
@@ -1,27 +1,23 @@
+// @flow
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import classNames from 'classnames';
 
 import Emojify from './Emojify';
+import JobTitle from './JobTitle';
 
-class JobLink extends React.PureComponent {
-  static propTypes = {
-    job: PropTypes.shape({
-      label: PropTypes.string,
-      command: PropTypes.string,
-      url: PropTypes.string,
-      build: PropTypes.shape({
-        number: PropTypes.number,
-        pipeline: PropTypes.shape({
-          name: PropTypes.string
-        })
-      })
-    }),
-    className: PropTypes.string,
-    style: PropTypes.object
-  };
+type Props = {
+  job: {
+    url: string
+  },
+  className: string,
+  style: Object
+};
 
+class JobLink extends React.PureComponent<Props> {
   render() {
     const { job, className, style } = this.props;
 
@@ -34,9 +30,7 @@ class JobLink extends React.PureComponent {
         )}
         style={style}
       >
-        <Emojify text={job.build.pipeline.name} />
-        {` - Build #${job.build.number} / `}
-        <Emojify text={job.label || job.command} />
+        <JobTitle job={job} />
       </a>
     );
   }
@@ -46,15 +40,8 @@ export default Relay.createContainer(JobLink, {
   fragments: {
     job: () => Relay.QL`
       fragment on JobTypeCommand {
-        label
-        command
+        ${JobTitle.getFragment('job')}
         url
-        build {
-          number
-          pipeline {
-            name
-          }
-        }
       }
     `
   }

--- a/app/components/shared/JobLink.js
+++ b/app/components/shared/JobLink.js
@@ -2,11 +2,9 @@
 /* eslint-disable react/prop-types */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import classNames from 'classnames';
 
-import Emojify from './Emojify';
 import JobTitle from './JobTitle';
 
 type Props = {

--- a/app/components/shared/JobTitle.js
+++ b/app/components/shared/JobTitle.js
@@ -1,0 +1,54 @@
+// @flow
+/* eslint-disable react/prop-types */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Relay from 'react-relay/classic';
+
+import Emojify from './Emojify';
+
+type Props = {
+  job: {
+    label: string,
+    command: string,
+    build: {
+      number: number,
+      pipeline: {
+        name: string
+      }
+    }
+  }
+};
+
+class JobTitle extends React.PureComponent<Props> {
+  render() {
+    const { job, ...props } = this.props;
+
+    return (
+      <span {...props}>
+        <Emojify className="semi-bold" text={job.label || job.command} />
+        {` in `}
+        <Emojify className="semi-bold" text={job.build.pipeline.name} />
+        {` `}
+        <span className="semi-bold">#{job.build.number}</span>
+      </span>
+    );
+  }
+}
+
+export default Relay.createContainer(JobTitle, {
+  fragments: {
+    job: () => Relay.QL`
+      fragment on JobTypeCommand {
+        label
+        command
+        build {
+          number
+          pipeline {
+            name
+          }
+        }
+      }
+    `
+  }
+});

--- a/app/components/shared/JobTitle.js
+++ b/app/components/shared/JobTitle.js
@@ -2,7 +2,6 @@
 /* eslint-disable react/prop-types */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 
 import Emojify from './Emojify';

--- a/app/routes.js
+++ b/app/routes.js
@@ -18,6 +18,7 @@ import OrganizationShow from './components/organization/Show';
 import OrganizationSettingsSection from './components/organization/SettingsSection';
 import AgentIndex from './components/agent/Index';
 import AgentShow from './components/agent/Show';
+import AgentJobs from './components/agent/Jobs';
 import TeamIndex from './components/team/Index';
 import TeamNew from './components/team/TeamNew';
 import TeamShow from './components/team/Show';
@@ -121,6 +122,7 @@ export default (
         <Route path="agents">
           <IndexRoute component={AgentIndex} queries={{ viewer: ViewerQuery.query, organization: OrganizationQuery.query }} render={renderSectionLoading} />
           <Route path=":agent" component={AgentShow} queries={{ agent: AgentQuery.query }} prepareParams={AgentQuery.prepareParams} render={renderSectionLoading} />
+          <Route path=":agent/jobs" component={AgentJobs} queries={{ agent: AgentQuery.query }} prepareParams={AgentQuery.prepareParams} render={renderSectionLoading} />
         </Route>
         <Route path="audit-log" component={OrganizationSettingsSection} queries={{ organization: OrganizationQuery.query }}>
           <Route component={AuditLogSection} queries={{ organization: OrganizationQuery.query }}>


### PR DESCRIPTION
This adds a detailed history of jobs run on each Agent. Each job is shown, along with the time it was assigned to the agent.

<img width="572" alt="screen shot 2017-11-20 at 12 05 08 pm" src="https://user-images.githubusercontent.com/282113/32997988-26fb9078-cdeb-11e7-925b-c17a79fbf016.png">

It has full pagination support:

<img width="559" alt="screen shot 2017-11-20 at 12 05 19 pm" src="https://user-images.githubusercontent.com/282113/32997989-2729f08a-cdeb-11e7-8c2a-0c953d21db3c.png">

The zero-job case is handled as shown (though in the zero-job case there is no link to this view, so it will only be shown to those savvy enough to go exploring):

<img width="559" alt="screen shot 2017-11-20 at 12 05 27 pm" src="https://user-images.githubusercontent.com/282113/32997990-275fea5a-cdeb-11e7-8c0f-132f925627a6.png">

Clicking anywhere in the panel will take the user to the build page the job is from, with the job log opened.

The existing “Recent Jobs” section has been updated to match, and include two links to the new page (the “and n more” text, and the title which is included for when the overflow text isn’t shown):

<img width="565" alt="screen shot 2017-11-20 at 12 04 58 pm" src="https://user-images.githubusercontent.com/282113/32997986-26cafd78-cdeb-11e7-82fa-252b4aa3240b.png">

fixes buildkite/feedback#286