### PR TITLE
Add decoration to test failure annotations

### DIFF
--- a/app/css/annotation-body.css
+++ b/app/css/annotation-body.css
@@ -8,6 +8,8 @@
 
 .annotation-body details summary {
   outline: none !important;
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 .annotation-body details[open] summary {


### PR DESCRIPTION
What this does
---
Makes the annotation titles more obviously clickable:

before (with the text selection cursor):
<img width="538" alt="image" src="https://user-images.githubusercontent.com/3074765/33038322-43d50fbe-ce02-11e7-857b-d9deed2189b6.png">


after (with the hand pointer cursor on hover): 
<img width="600" alt="image" src="https://user-images.githubusercontent.com/3074765/33038277-13c850c4-ce02-11e7-8149-6d479bdba1af.png">


cc @toolmantim @keithpitt 