### PR TITLE
Load bass early so our rules override

### DIFF
--- a/app/css/main.css
+++ b/app/css/main.css
@@ -1,4 +1,7 @@
 @import 'reset';
+
+@import 'basscss';
+
 @import 'btn';
 @import 'btn-primary';
 @import 'btn-outline';
@@ -29,8 +32,6 @@
 @import 'colors';
 @import 'outline';
 @import 'annotation-body';
-
-@import 'basscss';
 
 @import 'container';
 @import 'cursor';


### PR DESCRIPTION
I was trying to use the `caps` class and add `letter-spacing-0` to reset the letter spacing but it didn't work because the bass rules are later and the cascade made me cry.

So maybe these belong up here, just after the reset?