### PR TITLE
Always show the teams button in organization settings

### DIFF
--- a/app/components/organization/SettingsMenu.js
+++ b/app/components/organization/SettingsMenu.js
@@ -91,8 +91,7 @@ class SettingsMenu extends React.Component {
         )
       },
       {
-        allowed: "teamAdmin",
-        and: () => Features.organizationHasTeams,
+        always: true,
         render: (idx) => (
           <Menu.Button
             key={idx}


### PR DESCRIPTION
This allows anyone who can get to the organisation settings to see the teams button.