### PR TITLE
Immutable Retry Groups UI (Part 2)

### DIFF
--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -46,7 +46,7 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
   renderHiddenJobsButton() {
     // Figure out how many hidden jobs we have (if any?)
     const hiddenJobsCount = this.hiddenJobsCount();
-    if (hiddenJobsCount == 0) {
+    if (hiddenJobsCount === 0) {
       return null;
     }
 
@@ -67,7 +67,7 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
           <Icon icon={icon} className="relative" style={{ top: -3 }} />
         </div>
       </button>
-    )
+    );
   },
 
   hiddenJobsCount() {
@@ -140,7 +140,7 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
             style={{ height: 12, width: 12, top: -2, marginRight: 5 }}
             className="relative"
           />
-        )
+        );
       }
 
       return (

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -127,6 +127,17 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
 
       const href = `${this.props.build.path}#${job.id}`;
 
+      let retriedIcon;
+      if (job.retriedInJobUuid) {
+        retriedIcon = (
+          <Icon
+            icon="retry"
+            style={{ height: 12, width: 12, top: -2, marginRight: 5 }}
+            className="relative"
+          />
+        )
+      }
+
       return (
         <a
           key={job.id}
@@ -135,6 +146,7 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
           className={stepClassName}
           style={{ maxWidth: '15em' }}
         >
+          {retriedIcon}
           {this.jobName(job)}
         </a>
       );

--- a/app/components/build/Header/pipeline.js
+++ b/app/components/build/Header/pipeline.js
@@ -16,7 +16,7 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
   mixins: [BootstrapTooltipMixin],
 
   getInitialState() {
-    return { showBroken: false };
+    return { showHiddenJobs: false };
   },
 
   propTypes: {
@@ -31,44 +31,49 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
   },
 
   render() {
-    const brokenJobs = this.brokenJobCount();
-    const action = this.state.showBroken ? "Hide" : "Show";
-    const icon = this.state.showBroken ? "eye-strikethrough" : "eye";
-    const suffix = brokenJobs > 1 ? "jobs" : "job";
-
-    const toggleBrokenNode = brokenJobs > 0
-      ? (
-        <button
-          className="btn dark-gray hover-black regular mt0 ml0 pt0 pl0"
-          onClick={this.handleToggleBrokenStepsClick}
-        >
-          <div
-            title={`${action} ${brokenJobs} skipped ${suffix}`}
-            data-toggle="tooltip"
-            data-animation="false"
-          >
-            <Icon icon={icon} className="relative" style={{ top: -3 }} />
-          </div>
-        </button>
-      )
-      : null;
-
     return (
       <div className="flex">
         <div className="build-pipeline-container clearfix flex-auto">
           {this.stepNodes()}
         </div>
         <div className="flex-none" style={{ paddingTop: 18 }}>
-          {toggleBrokenNode}
+          {this.renderHiddenJobsButton()}
         </div>
       </div>
     );
   },
 
-  brokenJobCount() {
+  renderHiddenJobsButton() {
+    // Figure out how many hidden jobs we have (if any?)
+    const hiddenJobsCount = this.hiddenJobsCount();
+    if (hiddenJobsCount == 0) {
+      return null;
+    }
+
+    const action = this.state.showHiddenJobs ? "Hide" : "Show";
+    const icon = this.state.showHiddenJobs ? "eye-strikethrough" : "eye";
+    const suffix = hiddenJobsCount > 1 ? "jobs" : "job";
+
+    return (
+      <button
+        className="btn dark-gray hover-black regular mt0 ml0 pt0 pl0"
+        onClick={this.handleToggleBrokenStepsClick}
+      >
+        <div
+          title={`${action} ${hiddenJobsCount} hidden ${suffix}`}
+          data-toggle="tooltip"
+          data-animation="false"
+        >
+          <Icon icon={icon} className="relative" style={{ top: -3 }} />
+        </div>
+      </button>
+    )
+  },
+
+  hiddenJobsCount() {
     return this.props.build.jobs
       .filter((job) => (
-        (job.state === 'broken') && (job.type !== 'waiter')
+        ((job.state === 'broken') && (job.type !== 'waiter')) || job.retriedInJobUuid
       )).length;
   },
 
@@ -81,9 +86,9 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
       );
     }
 
-    const jobs = this.state.showBroken
+    const jobs = this.state.showHiddenJobs
       ? this.props.build.jobs
-      : this.props.build.jobs.filter(({ state }) => state !== 'broken');
+      : this.props.build.jobs.filter(({ state, retriedInJobUuid }) => state !== 'broken' && !retriedInJobUuid);
 
     const renderedJobs = jobs.map((job) => this.pipelineStep(job));
 
@@ -250,7 +255,7 @@ const BuildHeaderPipelineComponent = createReactClass({ // eslint-disable-line r
   handleToggleBrokenStepsClick(evt) {
     evt.preventDefault();
     evt.target.blur();
-    return this.setState({ showBroken: !this.state.showBroken });
+    return this.setState({ showHiddenJobs: !this.state.showHiddenJobs });
   }
 });
 

--- a/app/components/build/Show.js
+++ b/app/components/build/Show.js
@@ -105,6 +105,8 @@ export default class BuildShow extends React.PureComponent<Props, State> {
   }
 
   renderJobList() {
+    let inRetryGroup = false;
+
     // job-list-pipeline is needed by the job components' styles
     return (
       <div className="job-list-pipeline">
@@ -115,11 +117,25 @@ export default class BuildShow extends React.PureComponent<Props, State> {
 
           switch (job.type) {
             case 'script':
+              // Figures out if we're inside a "retry-group" and comes up with
+              // the neccessary class name.
+              let retryGroupClassName;
+              if (!inRetryGroup && job.retriedInJobUuid) { // Start of the group
+                retryGroupClassName = "job-retry-group-first";
+                inRetryGroup = true;
+              } else if (inRetryGroup && job.retriedInJobUuid) { // Middle of the group
+                retryGroupClassName = "job-retry-group-middle";
+              } else if (inRetryGroup && !job.retriedInJobUuid) { // Ends of the group
+                retryGroupClassName = "job-retry-group-last";
+                inRetryGroup = false;
+              }
+
               return (
                 <Buildkite.JobComponent
                   key={job.id}
                   job={job}
                   build={this.state.build}
+                  className={retryGroupClassName}
                 />
               );
 

--- a/app/components/build/Show.js
+++ b/app/components/build/Show.js
@@ -111,42 +111,39 @@ export default class BuildShow extends React.PureComponent<Props, State> {
     return (
       <div className="job-list-pipeline">
         {this.state.build.jobs.map((job) => {
+          // Don't even bother showing broken jobs
           if (job.state === 'broken') {
             return null;
           }
 
-          switch (job.type) {
-            case 'script':
-              // Figures out if we're inside a "retry-group" and comes up with
-              // the neccessary class name.
-              let retryGroupClassName;
-              if (!inRetryGroup && job.retriedInJobUuid) { // Start of the group
-                retryGroupClassName = "job-retry-group-first";
-                inRetryGroup = true;
-              } else if (inRetryGroup && job.retriedInJobUuid) { // Middle of the group
-                retryGroupClassName = "job-retry-group-middle";
-              } else if (inRetryGroup && !job.retriedInJobUuid) { // Ends of the group
-                retryGroupClassName = "job-retry-group-last";
-                inRetryGroup = false;
-              }
+          if (job.type === "script") {
+            // Figures out if we're inside a "retry-group" and comes up with
+            // the neccessary class name.
+            let retryGroupClassName;
+            if (!inRetryGroup && job.retriedInJobUuid) { // Start of the group
+              retryGroupClassName = "job-retry-group-first";
+              inRetryGroup = true;
+            } else if (inRetryGroup && job.retriedInJobUuid) { // Middle of the group
+              retryGroupClassName = "job-retry-group-middle";
+            } else if (inRetryGroup && !job.retriedInJobUuid) { // Ends of the group
+              retryGroupClassName = "job-retry-group-last";
+              inRetryGroup = false;
+            }
 
-              return (
-                <Buildkite.JobComponent
-                  key={job.id}
-                  job={job}
-                  build={this.state.build}
-                  className={retryGroupClassName}
-                />
-              );
-
-            case 'manual':
-              return <Buildkite.BuildManualJobSummaryComponent key={job.id} job={job} />;
-
-            case 'trigger':
-              return <Buildkite.BuildTriggerJobSummaryComponent key={job.id} job={job} />;
-
-            case 'waiter':
-              return <Buildkite.BuildWaiterJobSummaryComponent key={job.id} job={job} />;
+            return (
+              <Buildkite.JobComponent
+                key={job.id}
+                job={job}
+                build={this.state.build}
+                className={retryGroupClassName}
+              />
+            );
+          } else if (job.type === "manual") {
+            return <Buildkite.BuildManualJobSummaryComponent key={job.id} job={job} />;
+          } else if (job.type === "trigger") {
+            return <Buildkite.BuildTriggerJobSummaryComponent key={job.id} job={job} />;
+          } else if (job.type === "waiter") {
+            return <Buildkite.BuildWaiterJobSummaryComponent key={job.id} job={job} />;
           }
         })}
       </div>


### PR DESCRIPTION
This change starts grouping steps/jobs in the UI together if they're part of a "retry group".

Here, jobs in the main list are grouped together:

![screen shot 2018-02-06 at 2 48 57 pm](https://user-images.githubusercontent.com/25882/35845320-e674a982-0b4c-11e8-86ab-eddf4f699544.png)

I've also opted to hide retried jobs by default in the pipeline. I'll post more about this internally.