### PR TITLE
"Share" button in the GraphQL Console

### DIFF
--- a/app/components/user/graphql/GraphQLExplorerConsole.js
+++ b/app/components/user/graphql/GraphQLExplorerConsole.js
@@ -3,6 +3,7 @@
 import * as React from "react";
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql, commitMutation } from "react-relay/compat";
+import type { RelayProp } from 'react-relay';
 
 import Button from "../../shared/Button";
 import Dropdown from "../../shared/Dropdown";
@@ -48,6 +49,8 @@ type State = {
 
 class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
   operationsDropdownComponent: ?Dropdown
+  shareLinkTextInput: ?HTMLInputElement
+  shareLinkSelected: ?boolean
 
   state = {
     results: null,
@@ -79,7 +82,8 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
       currentOperationName: defaultState.currentOperationName,
       allOperationNames: defaultState.allOperationNames,
       executing: false,
-      sharing: false
+      sharing: false,
+      shareLink: null
     };
   }
 

--- a/app/components/user/graphql/GraphQLExplorerConsole.js
+++ b/app/components/user/graphql/GraphQLExplorerConsole.js
@@ -108,6 +108,7 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
   invalidateShareLink() {
     this.shareLinkSelected = false;
     this.setState({ shareLink: null });
+    this.context.router.replace("/user/graphql/console");
   }
 
   componentDidUpdate() {
@@ -120,15 +121,15 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
   render() {
     return (
       <div>
-        <div className="mb3 flex">
-          <div className="flex flex-auto items-center">
+        <div className="mb3 flex justify-start">
+          <div className="flex items-center">
             <Button onClick={this.handleExecuteClick} loading={this.state.executing && "Executing…"}>Execute</Button>
             {this.renderOperationsDropdown()}
           </div>
 
-          <div className="flex items-center">
+          <div className="flex flex-auto justify-end items-center pl2">
             {this.renderShareLink()}
-            <Button onClick={this.handleShareClick} theme={"default"} outline={true} loading={this.state.sharing && "Creating share link..."}>Share</Button>
+            <Button onClick={this.handleShareClick} theme={"default"} outline={true} loading={this.state.sharing && "Creating share link…"}>Share</Button>
           </div>
         </div>
 
@@ -207,14 +208,16 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
 
   renderShareLink() {
     if (this.state.shareLink) {
+      const estimatedWidth = this.state.shareLink.length * 7.42;
+
       return (
-        <div className="mr2">
+        <div className="flex-auto mr2" style={{maxWidth: estimatedWidth}}>
           <input
             ref={(textInput) => this.shareLinkTextInput = textInput}
             type="text"
             readOnly={true}
             value={this.state.shareLink}
-            style={{width: 370, fontSize: "inherit"}}
+            style={{width: "100%", fontSize: "inherit"}}
             className="p2 rounded border border-gray bg-silver"
             onClick={this.handleShareLinkClick}
           />
@@ -255,6 +258,7 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
 
     setTimeout(() => {
       this.setState({ sharing: false, shareLink: "https://buildkite.com/user/graphql/console/e92428e1-506d-4fdb-b258-d77a1e79d6de" });
+      this.context.router.replace("/user/graphql/console/e92428e1-506d-4fdb-b258-d77a1e79d6de");
     }, 2000);
   };
 

--- a/app/components/user/graphql/GraphQLExplorerConsole.js
+++ b/app/components/user/graphql/GraphQLExplorerConsole.js
@@ -7,7 +7,6 @@ import { createFragmentContainer, graphql, commitMutation } from "react-relay/co
 import Button from "../../shared/Button";
 import Dropdown from "../../shared/Dropdown";
 
-import GraphQLErrors from '../../../constants/GraphQLErrors';
 import FlashesStore from '../../../stores/FlashesStore';
 
 import GraphQLExplorerConsoleEditor from "./GraphQLExplorerConsoleEditor";
@@ -29,6 +28,11 @@ type Props = {
     organizations: {
       edges: Array<OrganizationEdge>
     }
+  },
+  relay: RelayProp,
+  graphQLSnippet?: {
+    query: string,
+    operationName: ?string
   }
 };
 
@@ -220,18 +224,18 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
       const estimatedWidth = this.state.shareLink.length * 7.42;
 
       return (
-        <div className="flex-auto mr2" style={{maxWidth: estimatedWidth}}>
+        <div className="flex-auto mr2" style={{ maxWidth: estimatedWidth }}>
           <input
             ref={(textInput) => this.shareLinkTextInput = textInput}
             type="text"
             readOnly={true}
             value={this.state.shareLink}
-            style={{width: "100%", fontSize: "inherit"}}
+            style={{ width: "100%", fontSize: "inherit" }}
             className="p2 rounded border border-gray bg-silver"
             onClick={this.handleShareLinkClick}
           />
         </div>
-      )
+      );
     }
   }
 

--- a/app/components/user/graphql/GraphQLExplorerConsole.js
+++ b/app/components/user/graphql/GraphQLExplorerConsole.js
@@ -7,6 +7,9 @@ import { createFragmentContainer, graphql, commitMutation } from "react-relay/co
 import Button from "../../shared/Button";
 import Dropdown from "../../shared/Dropdown";
 
+import GraphQLErrors from '../../../constants/GraphQLErrors';
+import FlashesStore from '../../../stores/FlashesStore';
+
 import GraphQLExplorerConsoleEditor from "./GraphQLExplorerConsoleEditor";
 import GraphQLExplorerConsoleResultsViewer from "./GraphQLExplorerConsoleResultsViewer";
 
@@ -110,9 +113,11 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
   }
 
   invalidateShareLink() {
-    this.shareLinkSelected = false;
-    this.setState({ shareLink: null });
-    this.context.router.replace("/user/graphql/console");
+    if (this.state.shareLink) {
+      this.shareLinkSelected = false;
+      this.setState({ shareLink: null });
+      this.context.router.replace("/user/graphql/console");
+    }
   }
 
   componentDidUpdate() {
@@ -298,14 +303,10 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
 
   handleMutationError = (error) => {
     if (error) {
-      if (error.source && error.source.type === GraphQLErrors.RECORD_VALIDATION_ERROR) {
-        this.setState({ errors: error.source.errors });
-      } else {
-        alert(error);
-      }
+      FlashesStore.flash(FlashesStore.ERROR, error);
     }
 
-    this.setState({ saving: false });
+    this.setState({ sharing: false });
   };
 
   handleMutationComplete = (response) => {

--- a/app/components/user/graphql/GraphQLExplorerConsole.js
+++ b/app/components/user/graphql/GraphQLExplorerConsole.js
@@ -34,7 +34,9 @@ type State = {
   query?: string,
   currentOperationName?: ?string,
   allOperationNames?: ?Array<string>,
-  executing: boolean
+  executing: boolean,
+  sharing: boolean,
+  shareLink: ?string
 };
 
 class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
@@ -45,7 +47,9 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
     query: "",
     currentOperationName: "",
     allOperationNames: null,
-    executing: false
+    executing: false,
+    sharing: false,
+    shareLink: null
   };
 
   static contextTypes = {
@@ -63,7 +67,8 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
       query: defaultState.query,
       currentOperationName: defaultState.currentOperationName,
       allOperationNames: defaultState.allOperationNames,
-      executing: false
+      executing: false,
+      sharing: false
     };
   }
 
@@ -100,12 +105,26 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
     });
   }
 
+  componentDidUpdate() {
+    if (this.shareLinkTextInput && !this.shareLinkSelected) {
+      this.shareLinkTextInput.select();
+      this.shareLinkSelected = true;
+    }
+  }
+
   render() {
     return (
       <div>
-        <div className="mb3 flex items-center">
-          <Button onClick={this.handleExecuteClick} loading={this.state.executing && "Executing…"}>Execute</Button>
-          {this.renderOperationsDropdown()}
+        <div className="mb3 flex">
+          <div className="flex flex-auto items-center">
+            <Button onClick={this.handleExecuteClick} loading={this.state.executing && "Executing…"}>Execute</Button>
+            {this.renderOperationsDropdown()}
+          </div>
+
+          <div className="flex items-center">
+            {this.renderShareLink()}
+            <Button onClick={this.handleShareClick} theme={"default"} outline={true} loading={this.state.sharing && "Creating share link..."}>Share</Button>
+          </div>
         </div>
 
         <div className="flex flex-fit border border-gray rounded" style={{ width: "100%" }}>
@@ -113,7 +132,7 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
             <GraphQLExplorerConsoleEditor
               value={this.state.query}
               onChange={this.handleEditorChange}
-              onExecuteQueryPress={this.handleExecutePress}
+              onExecuteQueryPress={this.handleEditorExecutePress}
             />
           </div>
 
@@ -181,6 +200,23 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
     }
   }
 
+  renderShareLink() {
+    if (this.state.shareLink) {
+      return (
+        <div className="mr2">
+          <input
+            ref={(textInput) => this.shareLinkTextInput = textInput}
+            type="text"
+            readOnly={true}
+            value={this.state.shareLink}
+            style={{width: 370, fontSize: "inherit"}}
+            className="p2 rounded border border-gray bg-silver"
+          />
+        </div>
+      )
+    }
+  }
+
   handleOperationSelect = (event, operationName) => {
     event.preventDefault();
 
@@ -193,6 +229,9 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
 
   handleEditorChange = (query) => {
     this.setState(consoleState.setQuery(query));
+
+    this.shareLinkSelected = false;
+    this.setState({ shareLink: null });
   };
 
   handleExecuteClick = (event) => {
@@ -201,8 +240,17 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
     this.executeCurrentQuery();
   };
 
-  handleExecutePress = () => {
+  handleEditorExecutePress = () => {
     this.executeCurrentQuery();
+  };
+
+  handleShareClick = () => {
+    this.shareLinkSelected = false;
+    this.setState({ sharing: true, shareLink: null });
+
+    setTimeout(() => {
+      this.setState({ sharing: false, shareLink: "https://buildkite.com/user/graphql/console/e92428e1-506d-4fdb-b258-d77a1e79d6de" });
+    }, 2000);
   };
 }
 

--- a/app/components/user/graphql/GraphQLExplorerConsole.js
+++ b/app/components/user/graphql/GraphQLExplorerConsole.js
@@ -105,6 +105,11 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
     });
   }
 
+  invalidateShareLink() {
+    this.shareLinkSelected = false;
+    this.setState({ shareLink: null });
+  }
+
   componentDidUpdate() {
     if (this.shareLinkTextInput && !this.shareLinkSelected) {
       this.shareLinkTextInput.select();
@@ -211,6 +216,7 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
             value={this.state.shareLink}
             style={{width: 370, fontSize: "inherit"}}
             className="p2 rounded border border-gray bg-silver"
+            onClick={this.handleShareLinkClick}
           />
         </div>
       )
@@ -230,8 +236,7 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
   handleEditorChange = (query) => {
     this.setState(consoleState.setQuery(query));
 
-    this.shareLinkSelected = false;
-    this.setState({ shareLink: null });
+    this.invalidateShareLink();
   };
 
   handleExecuteClick = (event) => {
@@ -245,13 +250,19 @@ class GraphQLExplorerConsole extends React.PureComponent<Props, State> {
   };
 
   handleShareClick = () => {
-    this.shareLinkSelected = false;
-    this.setState({ sharing: true, shareLink: null });
+    this.invalidateShareLink();
+    this.setState({ sharing: true });
 
     setTimeout(() => {
       this.setState({ sharing: false, shareLink: "https://buildkite.com/user/graphql/console/e92428e1-506d-4fdb-b258-d77a1e79d6de" });
     }, 2000);
   };
+
+  handleShareLinkClick = () => {
+    if (this.shareLinkTextInput) {
+      this.shareLinkTextInput.select();
+    }
+  }
 }
 
 export default createFragmentContainer(GraphQLExplorerConsole, {

--- a/app/components/user/graphql/consoleState.js
+++ b/app/components/user/graphql/consoleState.js
@@ -21,6 +21,11 @@ class ConsoleState {
     this.organizationEdges = organizationEdges;
   }
 
+  setGraphQLSnippet(snippet: { query: string, operationName: ?string }) {
+    this.query = snippet.query;
+    this.currentOperationName = snippet.operationName;
+  }
+
   setResults(output: string, performance: string) {
     this.results = {
       output: output,
@@ -43,7 +48,7 @@ class ConsoleState {
 
   getQuery(): string {
     // If there's no query loaded, make one up.
-    if (!this.query) {
+    if (this.query === null || this.query === undefined) {
       // If we've got an organization loaded, let's use the default query that
       // looks at the first organization. If the user isn't part of any
       // organization, we'll use the default that doesn't retrieve organization

--- a/app/graph/schema.json
+++ b/app/graph/schema.json
@@ -738,6 +738,33 @@
               "deprecationReason": null
             },
             {
+              "name": "graphQLSnippet",
+              "description": "Find a GraphQL snippet",
+              "args": [
+                {
+                  "name": "uuid",
+                  "description": "The UUID for this GraphQL snippet",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GraphQLSnippet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "job",
               "description": "Find a build job by its UUID",
               "args": [
@@ -4655,6 +4682,20 @@
               "deprecationReason": null
             },
             {
+              "name": "steps",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PipelineSteps",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "teams",
               "description": "Teams associated with this pipeline",
               "args": [
@@ -4913,6 +4954,43 @@
               "ofType": null
             }
           ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PipelineSteps",
+          "description": "Steps defined on a pipeline",
+          "fields": [
+            {
+              "name": "yaml",
+              "description": "A YAML representation of the pipeline steps",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "YAML",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "YAML",
+          "description": "A blob of YAML",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         },
         {
           "kind": "SCALAR",
@@ -14727,6 +14805,123 @@
         },
         {
           "kind": "OBJECT",
+          "name": "GraphQLSnippet",
+          "description": "A shared GraphQL query",
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": "When this GraphQL snippet was created",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "operationName",
+              "description": "The default operation name for this snippet",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "query",
+              "description": "The query of this GraphQL snippet",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "The URL for the GraphQL snippet",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uuid",
+              "description": "The public UUID for this snippet",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Mutation",
           "description": "The root for mutations in this schema",
           "fields": [
@@ -14995,6 +15190,33 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "EmailResendVerificationPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graphQLSnippetCreate",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "GraphQLSnippetCreateInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GraphQLSnippetCreatePayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -18892,6 +19114,96 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "GraphQLSnippetCreatePayload",
+          "description": "Autogenerated return type of GraphQLSnippetCreate",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graphQLSnippet",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GraphQLSnippet",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "GraphQLSnippetCreateInput",
+          "description": "Autogenerated input type of GraphQLSnippetCreate",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "query",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "operationName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "defaultValue": null
             }

--- a/app/lib/RelayPreloader.js
+++ b/app/lib/RelayPreloader.js
@@ -474,6 +474,14 @@ const QUERIES = {
         }
       }
     }
+  `,
+  "graphql_console/snippet": Relay.QL`
+    query GraphQLSnippet($uuid: String!) {
+      graphQLSnippet(uuid: $uuid) {
+        query
+        operationName
+      }
+    }
   `
 };
 

--- a/app/queries/GraphQLSnippet.js
+++ b/app/queries/GraphQLSnippet.js
@@ -1,0 +1,9 @@
+// @flow
+
+import Relay from 'react-relay/classic';
+
+export const query = () => Relay.QL`
+  query {
+    graphQLSnippet(uuid: $snippet)
+  }
+`;

--- a/app/routes.js
+++ b/app/routes.js
@@ -122,7 +122,10 @@ export default (
 
       <Route path="/user/graphql" component={GraphQLExplorer}>
         <IndexRedirect to="console" />
-        <Route path="console" component={GraphQLExplorerConsole} queries={{ viewer: ViewerQuery.query }} />
+        <Route path="console">
+          <IndexRoute component={GraphQLExplorerConsole} queries={{ viewer: ViewerQuery.query }} />
+          <Route path=":snippet" component={GraphQLExplorerConsole} queries={{ viewer: ViewerQuery.query }} />
+        </Route>
         <Route path="documentation" component={GraphQLExplorerDocumentation} />
         <Route path="examples" component={GraphQLExplorerExamples} />
       </Route>

--- a/app/routes.js
+++ b/app/routes.js
@@ -60,6 +60,7 @@ import * as PipelineScheduleQuery from './queries/PipelineSchedule';
 import * as TeamQuery from './queries/Team';
 import * as ViewerQuery from './queries/Viewer';
 import * as APIAccessTokenCodeQuery from './queries/APIAccessTokenCode';
+import * as GraphQLSnippetQuery from './queries/GraphQLSnippet';
 
 import FlashesStore from './stores/FlashesStore';
 
@@ -124,7 +125,7 @@ export default (
         <IndexRedirect to="console" />
         <Route path="console">
           <IndexRoute component={GraphQLExplorerConsole} queries={{ viewer: ViewerQuery.query }} />
-          <Route path=":snippet" component={GraphQLExplorerConsole} queries={{ viewer: ViewerQuery.query }} />
+          <Route path=":snippet" component={GraphQLExplorerConsole} queries={{ viewer: ViewerQuery.query, graphQLSnippet: GraphQLSnippetQuery.query }} />
         </Route>
         <Route path="documentation" component={GraphQLExplorerDocumentation} />
         <Route path="examples" component={GraphQLExplorerExamples} />


### PR DESCRIPTION
This change adds a "Share" button to the console allowing peeps to share a GraphQL query to others. This is 1000% useful for support and community where peeps are like "how do I do `x` in GraphQL"

![screen shot 2018-03-06 at 10 46 32 am](https://user-images.githubusercontent.com/25882/37011549-a6584896-212b-11e8-9e60-a59c24fc9e4a.png)