### PR TITLE
Expose the error states possible for a PipelineSchedule in the UI

### DIFF
--- a/app/components/pipeline/schedules/Edit.js
+++ b/app/components/pipeline/schedules/Edit.js
@@ -20,6 +20,7 @@ class Edit extends React.Component {
       commit: PropTypes.string,
       branch: PropTypes.string,
       message: PropTypes.string,
+      enabled: PropTypes.bool.isRequired,
       env: PropTypes.arrayOf(PropTypes.string),
       pipeline: PropTypes.shape({
         slug: PropTypes.string.isRequired,
@@ -55,6 +56,7 @@ class Edit extends React.Component {
                 commit={this.props.pipelineSchedule.commit}
                 branch={this.props.pipelineSchedule.branch}
                 message={this.props.pipelineSchedule.message}
+                enabled={this.props.pipelineSchedule.enabled}
                 env={this.props.pipelineSchedule.env.join("\n")}
                 ref={(form) => this.form = form}
               />
@@ -116,6 +118,7 @@ export default Relay.createContainer(Edit, {
         commit
         branch
         message
+        enabled
         env
         pipeline {
           ${Form.getFragment('pipeline')}

--- a/app/components/pipeline/schedules/Form.js
+++ b/app/components/pipeline/schedules/Form.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 
+import FormCheckbox from '../../shared/FormCheckbox';
 import FormTextField from '../../shared/FormTextField';
 import FormTextarea from '../../shared/FormTextarea';
 import ValidationErrors from '../../../lib/ValidationErrors';
@@ -13,11 +14,16 @@ class Form extends React.Component {
     commit: PropTypes.string,
     branch: PropTypes.string,
     message: PropTypes.string,
+    enabled: PropTypes.bool,
     env: PropTypes.string,
     errors: PropTypes.array,
     pipeline: PropTypes.shape({
       defaultBranch: PropTypes.string.isRequired
     }).isRequired
+  };
+
+  static defaultProps = {
+    enabled: true
   };
 
   componentDidMount() {
@@ -83,6 +89,14 @@ class Form extends React.Component {
           defaultValue={this.props.env}
           ref={(envTextField) => this.envTextField = envTextField}
         />
+
+        <FormCheckbox
+          label="Enabled"
+          help="Whether the schedule should run."
+          errors={errors.findForField("enabled")}
+          defaultChecked={this.props.enabled}
+          ref={(enabledCheckbox) => this.enabledCheckbox = enabledCheckbox}
+        />
       </div>
     );
   }
@@ -94,6 +108,7 @@ class Form extends React.Component {
       message: this.messageTextField.value,
       commit: this.commitTextField.value,
       branch: this.branchTextField.value,
+      enabled: this.enabledCheckbox._checkbox.checked, // ugh, I'm sorry
       env: this.envTextField.value
     };
   }

--- a/app/components/pipeline/schedules/Index/index.js
+++ b/app/components/pipeline/schedules/Index/index.js
@@ -66,7 +66,7 @@ class Index extends React.Component {
         <div className="mb4 p2 border border-red rounded red flex items-center">
           <span className="m1">
             {plural ? 'Several of your schedules have' : 'One of your schedules has'} been automatically disabled due to {plural ? 'errors' : 'an error'}.
-            Please review the schedule{plural && 's'} to allow {plural ? 'them' : 'it'} to continue creating builds. 
+            Please review the schedule{plural && 's'} to allow {plural ? 'them' : 'it'} to continue creating builds.
           </span>
         </div>
       );

--- a/app/components/pipeline/schedules/Index/index.js
+++ b/app/components/pipeline/schedules/Index/index.js
@@ -66,7 +66,6 @@ class Index extends React.Component {
         <div className="mb4 p2 border border-red rounded red flex items-center">
           <span className="m1">
             {plural ? 'Several of your schedules have' : 'One of your schedules has'} been automatically disabled due to {plural ? 'errors' : 'an error'}.
-            Please review the schedule{plural && 's'} to allow {plural ? 'them' : 'it'} to continue creating builds.
           </span>
         </div>
       );

--- a/app/components/pipeline/schedules/Index/row.js
+++ b/app/components/pipeline/schedules/Index/row.js
@@ -35,7 +35,6 @@ class Row extends React.PureComponent {
             <span className="dark-gray regular">
               {this.props.pipelineSchedule.cronline}
             </span>
-            {this.props.pipelineSchedule.enabled || " (Disabled)"}
           </div>
           <div className="flex flex-none flex-stretch items-center my1 pr3 dark-gray">
             <code className="dark-gray">{this.props.pipelineSchedule.commit}</code>
@@ -48,13 +47,12 @@ class Row extends React.PureComponent {
   }
 
   renderLabel() {
-    if (this.props.pipelineSchedule.label) {
-      return (
-        <div className="m0 semi-bold mb1">
-          <Emojify text={this.props.pipelineSchedule.label} />
-        </div>
-      );
-    }
+    return (
+      <div className="m0 semi-bold mb1">
+        {this.props.pipelineSchedule.label && <Emojify text={this.props.pipelineSchedule.label} />}
+        {this.props.pipelineSchedule.enabled || <span className="mx1 regular small border border-red rounded red px1">Disabled</span>}
+      </div>
+    );
   }
 }
 

--- a/app/components/pipeline/schedules/Index/row.js
+++ b/app/components/pipeline/schedules/Index/row.js
@@ -50,7 +50,17 @@ class Row extends React.PureComponent {
     return (
       <div className="m0 semi-bold mb1">
         {this.props.pipelineSchedule.label && <Emojify text={this.props.pipelineSchedule.label} />}
-        {this.props.pipelineSchedule.enabled || <span className="mx1 regular small border border-red rounded red px1">Disabled</span>}
+        {this.props.pipelineSchedule.enabled || (
+          <span
+            style={{
+              fontSize: 12,
+              verticalAlign: 'middle'
+            }}
+            className="mx1 regular border border-red rounded red px1"
+          >
+            Disabled
+          </span>
+        )}
       </div>
     );
   }

--- a/app/components/pipeline/schedules/Index/row.js
+++ b/app/components/pipeline/schedules/Index/row.js
@@ -13,6 +13,7 @@ class Row extends React.PureComponent {
       label: PropTypes.string,
       commit: PropTypes.string,
       branch: PropTypes.string,
+      enabled: PropTypes.bool.isRequired,
       pipeline: PropTypes.shape({
         slug: PropTypes.string.isRequired,
         organization: PropTypes.shape({
@@ -31,7 +32,10 @@ class Row extends React.PureComponent {
         <div className="flex flex-stretch items-center line-height-1" style={{ minHeight: '3em' }}>
           <div className="flex-auto">
             {this.renderLabel()}
-            <span className="dark-gray regular">{this.props.pipelineSchedule.cronline}</span>
+            <span className="dark-gray regular">
+              {this.props.pipelineSchedule.cronline}
+            </span>
+            {this.props.pipelineSchedule.enabled || " (Disabled)"}
           </div>
           <div className="flex flex-none flex-stretch items-center my1 pr3 dark-gray">
             <code className="dark-gray">{this.props.pipelineSchedule.commit}</code>
@@ -46,7 +50,9 @@ class Row extends React.PureComponent {
   renderLabel() {
     if (this.props.pipelineSchedule.label) {
       return (
-        <div className="m0 semi-bold mb1"><Emojify text={this.props.pipelineSchedule.label} /></div>
+        <div className="m0 semi-bold mb1">
+          <Emojify text={this.props.pipelineSchedule.label} />
+        </div>
       );
     }
   }
@@ -61,6 +67,7 @@ export default Relay.createContainer(Row, {
         label
         commit
         branch
+        enabled
         pipeline {
           slug
           organization {

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -147,15 +147,22 @@ class Show extends React.Component {
           This schedule was automatically disabled <FriendlyTime capitalized={false} value={pipelineSchedule.failedAt} /> because {pipelineSchedule.failedMessage}.<br />
           If their access was restored, this schedule can be re-enabled.
         </span>
-        <Button
-          className="m1"
-          theme="error"
-          outline={true}
-          loading={this.state.reEnabling ? "Re-Enabling…" : false}
-          onClick={this.handleScheduleReEnableClick}
-        >
-          Re-Enable
-        </Button>
+        {permissions(pipelineSchedule.permissions).check(
+          {
+            allowed: "pipelineScheduleUpdate",
+            render: () => (
+              <Button
+                className="m1"
+                theme="error"
+                outline={true}
+                loading={this.state.reEnabling ? "Re-Enabling…" : false}
+                onClick={this.handleScheduleReEnableClick}
+              >
+                Re-Enable
+              </Button>
+            )
+          }
+        )}
       </div>
     );
   }

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -86,6 +86,7 @@ class Show extends React.Component {
               <Emojify
                 text={pipelineSchedule.label || "No description"}
               />
+              {pipelineSchedule.enabled || <span className="mx1 regular small border border-red rounded red px1">Disabled</span>}
             </PageHeader.Title>
             <PageHeader.Description>
               {pipelineSchedule.cronline}

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -150,13 +150,12 @@ class Show extends React.Component {
       return null;
     }
 
-    // NOTE: Currently the only `failedMessage` possible is "no longer has
+    // NOTE: Currently the only `failedMessage` possible is "no longer had
     // access to create builds," so this formatting is built around that.
     return (
       <div className="mb4 p2 border border-red rounded red flex items-center">
         <span className="m1">
           This schedule was automatically disabled <FriendlyTime capitalized={false} value={pipelineSchedule.failedAt} /> because {pipelineSchedule.failedMessage}.
-          If their access was restored, this schedule can be re-enabled.
         </span>
         {permissions(pipelineSchedule.permissions).check(
           {

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -144,7 +144,7 @@ class Show extends React.Component {
     return (
       <div className="mb4 p2 border border-red rounded red flex items-center">
         <span className="m1">
-          This schedule was automatically disabled <FriendlyTime capitalized={false} value={pipelineSchedule.failedAt} /> because {pipelineSchedule.failedMessage}.<br />
+          This schedule was automatically disabled <FriendlyTime capitalized={false} value={pipelineSchedule.failedAt} /> because {pipelineSchedule.failedMessage}.
           If their access was restored, this schedule can be re-enabled.
         </span>
         {permissions(pipelineSchedule.permissions).check(

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -86,7 +86,17 @@ class Show extends React.Component {
               <Emojify
                 text={pipelineSchedule.label || "No description"}
               />
-              {pipelineSchedule.enabled || <span className="mx1 regular small border border-red rounded red px1">Disabled</span>}
+              {pipelineSchedule.enabled || (
+                <span
+                  style={{
+                    fontSize: 12,
+                    verticalAlign: 'middle'
+                  }}
+                  className="mx1 regular border border-red rounded red px1"
+                >
+                  Disabled
+                </span>
+              )}
             </PageHeader.Title>
             <PageHeader.Description>
               {pipelineSchedule.cronline}

--- a/app/components/pipeline/schedules/Show/index.js
+++ b/app/components/pipeline/schedules/Show/index.js
@@ -141,7 +141,7 @@ class Show extends React.Component {
     return (
       <Panel className="mb4 p3 border-red red">
         <span>
-          This schedule was disabled because {pipelineSchedule.failedMessage}.<br/>
+          This schedule was disabled because {pipelineSchedule.failedMessage}.<br />
           If their access has been restored, this schedule can be edited and saved to re-enable it.
         </span>
       </Panel>

--- a/app/components/shared/FormCheckbox.js
+++ b/app/components/shared/FormCheckbox.js
@@ -9,6 +9,7 @@ export default class FormCheckbox extends React.PureComponent {
   static propTypes = {
     label: PropTypes.node.isRequired,
     name: PropTypes.string,
+    defaultChecked: PropTypes.bool,
     checked: PropTypes.bool,
     help: PropTypes.node,
     disabled: PropTypes.bool,
@@ -23,6 +24,7 @@ export default class FormCheckbox extends React.PureComponent {
           <input
             name={this.props.name}
             type="checkbox"
+            defaultChecked={this.props.defaultChecked}
             checked={this.props.checked}
             onChange={this.props.onChange}
             className="absolute checkbox"

--- a/app/mutations/PipelineScheduleCreate.js
+++ b/app/mutations/PipelineScheduleCreate.js
@@ -69,6 +69,7 @@ class PipelineScheduleCreate extends Relay.Mutation {
       message: this.props.message,
       commit: this.props.commit,
       branch: this.props.branch,
+      enabled: this.props.enabled,
       env: this.props.env
     };
   }

--- a/app/mutations/PipelineScheduleUpdate.js
+++ b/app/mutations/PipelineScheduleUpdate.js
@@ -53,6 +53,7 @@ class PipelineScheduleUpdate extends Relay.Mutation {
       message: this.props.message,
       commit: this.props.commit,
       branch: this.props.branch,
+      enabled: this.props.enabled,
       env: this.props.env
     };
   }


### PR DESCRIPTION
Previously, PipelineSchedules would be disabled and there was no indication other than no builds being generated, and the "next build" in the UI becoming further and further in the past that it was disabled. This exposes both the "disabled" state and failure messages in the UI, and allows re-enabling it from the error message itself.

<img width="868" alt="screen shot 2018-05-03 at 6 57 21 pm" src="https://user-images.githubusercontent.com/282113/39610253-f07bd70c-4f03-11e8-991f-f3371e53b061.png">

<img width="864" alt="screen shot 2018-05-03 at 6 57 27 pm" src="https://user-images.githubusercontent.com/282113/39610255-f095a146-4f03-11e8-937c-6cd560c13e2e.png">

This PR does not address taking ownership of a Schedule in order to re-authorise the schedule itself, but this would be a good next step.