### PR TITLE
Fixed production source maps

### DIFF
--- a/webpack/config.js
+++ b/webpack/config.js
@@ -143,19 +143,13 @@ var vendor_modules = [
 
 // If we're building for production, minify the JS
 if (IS_PRODUCTION) {
-  // Configure production source maps
-  plugins.push(new webpack.SourceMapDevToolPlugin(
-    '[file].map',
-    null,
-    '[absolute-resource-path]',
-    '[absolute-resource-path]'
-  ));
-
   // Don't pack react-type-snob in production
   plugins.push(new webpack.IgnorePlugin(/^react-type-snob$/));
 
   // Your basic, run-of-the-mill, JS uglifier
   plugins.push(new webpack.optimize.UglifyJsPlugin({
+    sourceMap: true,
+    parallel: true,
     output: {
       comments: false
     },

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -143,6 +143,14 @@ var vendor_modules = [
 
 // If we're building for production, minify the JS
 if (IS_PRODUCTION) {
+  // Configure production source maps
+  plugins.push(new webpack.SourceMapDevToolPlugin(
+    '[file].map',
+    null,
+    '[absolute-resource-path]',
+    '[absolute-resource-path]'
+  ));
+
   // Don't pack react-type-snob in production
   plugins.push(new webpack.IgnorePlugin(/^react-type-snob$/));
 


### PR DESCRIPTION
Source maps haven’t worked properly on Production for a bit.

This ultimately means errors we’re getting in Bugsnag haven’t been particularly easy to read!

This re-enables producing proper source maps in prod.

On one hand, it feels weird to present this to end users, but then again this only reveals exactly the code we’re already shipping here, so it’s probably fine! There’s [an alternative option](https://docs.bugsnag.com/platforms/browsers/js/source-maps/#source-map-upload) if we only wanted to push these up specifically for the benefit of Bugsnag, too.