### PR TITLE
Style tweaks for nicer annotations

### DIFF
--- a/app/css/annotation-body.css
+++ b/app/css/annotation-body.css
@@ -3,7 +3,7 @@
 
 .annotation-body pre {
   padding: 10px;
-  margin-bottom: 10px;
+  margin: 1em 0;
 }
 
 .annotation-body details summary {
@@ -11,5 +11,9 @@
 }
 
 .annotation-body details[open] summary {
-  margin-bottom: 10px;
+  margin-bottom: 1em;
+}
+
+.annotation-body details[open] {
+  margin-bottom: 1em;
 }


### PR DESCRIPTION
Slightly tweak our annotation styles to give `<details>` siblings sligthly nicer padding, like a `<p>` when open, straight adjacent otherwise.

### Before

![image](https://user-images.githubusercontent.com/14028/40582123-d6eaf04e-61ae-11e8-95c1-129bcee991c1.png)

![image](https://user-images.githubusercontent.com/14028/40582127-ee8fedc6-61ae-11e8-8e5e-303bb01081d7.png)

![image](https://user-images.githubusercontent.com/14028/40582125-dc5e26c2-61ae-11e8-9268-b0383d188c2b.png)

![image](https://user-images.githubusercontent.com/14028/40582126-e1af8602-61ae-11e8-88a0-c5354b8ff336.png)

### After 

![image](https://user-images.githubusercontent.com/14028/40582113-a209ad20-61ae-11e8-8902-355e49e6b301.png)

![image](https://user-images.githubusercontent.com/14028/40582114-a6a04c72-61ae-11e8-997b-b227dbe65e61.png)

![image](https://user-images.githubusercontent.com/14028/40582115-ac0fd394-61ae-11e8-9d44-3a616f393c19.png)

![image](https://user-images.githubusercontent.com/14028/40582118-b0daabb0-61ae-11e8-95aa-03fcb03be9d9.png)
