### PR TITLE
Handle empty agent versions

### DIFF
--- a/app/components/agent/Index/row.js
+++ b/app/components/agent/Index/row.js
@@ -99,7 +99,9 @@ class AgentRow extends React.PureComponent<Props> {
                 <small className="dark-gray">{metaDataContent}</small>
               </div>
               <div className="flex-none right-align">
-                <div className="black">v{agent.version}</div>
+                <div className="black">
+                  {agent.version ? `v${agent.version}` : 'Unknown Version'}
+                </div>
                 <small className="dark-gray">{agent.hostname}</small>
               </div>
             </div>

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -141,9 +141,7 @@ class AgentShow extends React.Component {
       </div>
     )));
 
-    if (agent.version) {
-      extras.push(this.renderExtraItem('Version', agent.version));
-    }
+    extras.push(this.renderExtraItem('Version', agent.version || 'Unknown'));
 
     if (agent.hostname) {
       extras.push(this.renderExtraItem('Hostname', agent.hostname));


### PR DESCRIPTION
Some customers have custom Agents which do not advertise a version. This updates the bits of the UI which get a little confused about this to handle it correctly.