### PR TITLE
Improve UI resilience

### DIFF
--- a/app/components/Main.js
+++ b/app/components/Main.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 import DocumentTitle from 'react-document-title';
 

--- a/app/components/Main.js
+++ b/app/components/Main.js
@@ -11,22 +11,19 @@ import Flashes from './layout/Flashes';
 
 type Props = {
   children: React$Node,
-  viewer: Object,
+  viewer?: Object,
   organization?: Object
 };
 
 class Main extends React.PureComponent<Props> {
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    viewer: PropTypes.object.isRequired,
-    organization: PropTypes.object
-  };
-
   render() {
     return (
       <DocumentTitle title="Buildkite">
         <div>
-          <Navigation organization={this.props.organization} viewer={this.props.viewer} />
+          <Navigation
+            organization={this.props.organization}
+            viewer={this.props.viewer}
+          />
           <Flashes />
           {this.props.children}
           <Footer viewer={this.props.viewer} />

--- a/app/components/layout/Flashes/flash.js
+++ b/app/components/layout/Flashes/flash.js
@@ -1,18 +1,19 @@
+// @flow
+
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import FlashesStore from '../../../stores/FlashesStore';
 
-class Flash extends React.PureComponent {
-  static propTypes = {
-    flash: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      message: PropTypes.node.isRequired
-    }),
-    onRemoveClick: PropTypes.func.isRequired
-  };
+type Props = {
+  flash: {
+    type: string,
+    message: React$Node
+  },
+  onRemoveClick: Function
+};
 
+class Flash extends React.PureComponent<Props> {
   render() {
     const classes = classNames("flex items-center mb2 border rounded border-dark-gray", {
       "border-red red": this.props.flash.type === FlashesStore.ERROR,
@@ -21,8 +22,19 @@ class Flash extends React.PureComponent {
 
     return (
       <div className={classes}>
-        <div className="flex-auto px4 py3" data-flash-message={true}>{this.props.flash.message}</div>
-        <button className="btn px4 py3" onClick={this.handleCloseClick} data-flash-close={true}>Close</button>
+        <div
+          className="flex-auto px4 py3"
+          data-flash-message={true}
+        >
+          {this.props.flash.message}
+        </div>
+        <button
+          className="btn px4 py3"
+          onClick={this.handleCloseClick}
+          data-flash-close={true}
+        >
+          Close
+        </button>
       </div>
     );
   }

--- a/app/components/layout/Flashes/flash.js
+++ b/app/components/layout/Flashes/flash.js
@@ -3,13 +3,10 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import FlashesStore from '../../../stores/FlashesStore';
+import FlashesStore, { type FlashItem } from '../../../stores/FlashesStore';
 
 type Props = {
-  flash: {
-    type: string,
-    message: React$Node
-  },
+  flash: FlashItem,
   onRemoveClick: Function
 };
 

--- a/app/components/layout/Flashes/index.js
+++ b/app/components/layout/Flashes/index.js
@@ -2,21 +2,15 @@
 
 import React from 'react';
 
-import FlashesStore from '../../../stores/FlashesStore';
+import FlashesStore, { type FlashItem } from '../../../stores/FlashesStore';
 import PusherStore from '../../../stores/PusherStore';
 
 import Flash from './flash';
 
 const FLASH_CONN_ERROR_ID = 'FLASH_CONN_ERROR';
 
-type Flash = {
-  id: number | 'FLASH_CONN_ERROR',
-  type: "error" | "success" | "info",
-  message: React$Node
-};
-
 type State = {
-  flashes: Array<Flash>,
+  flashes: Array<FlashItem>,
   lastConnected: boolean
 };
 
@@ -46,7 +40,7 @@ class Flashes extends React.PureComponent<null, State> {
     PusherStore.off('connected', this.handleConnectionSuccess);
   }
 
-  handleStoreChange = (payload: Flash) => {
+  handleStoreChange = (payload: FlashItem) => {
     this.setState({ flashes: this.state.flashes.concat(payload) });
   };
 
@@ -96,7 +90,7 @@ class Flashes extends React.PureComponent<null, State> {
 
   // hide connection error flash (if it exists!) when reconnected
   handleConnectionSuccess = () => {
-    const newState: { flashes?: Array<Flash>, lastConnected: boolean } = {
+    const newState: { flashes?: Array<FlashItem>, lastConnected: boolean } = {
       // make it known that we got a good connection!
       lastConnected: true
     };
@@ -128,7 +122,7 @@ class Flashes extends React.PureComponent<null, State> {
     return null;
   }
 
-  handleFlashRemove = (flash: Flash) => {
+  handleFlashRemove = (flash: FlashItem) => {
     this.setState({
       flashes: this.state.flashes.filter(
         (nextFlash) => flash.id !== nextFlash.id

--- a/app/components/layout/Flashes/index.js
+++ b/app/components/layout/Flashes/index.js
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 
 import FlashesStore from '../../../stores/FlashesStore';
@@ -7,7 +9,18 @@ import Flash from './flash';
 
 const FLASH_CONN_ERROR_ID = 'FLASH_CONN_ERROR';
 
-class Flashes extends React.PureComponent {
+type Flash = {
+  id: number | 'FLASH_CONN_ERROR',
+  type: "error" | "success" | "info",
+  message: React$Node
+};
+
+type State = {
+  flashes: Array<Flash>,
+  lastConnected: boolean
+};
+
+class Flashes extends React.PureComponent<null, State> {
   state = {
     flashes: [],
     lastConnected: true // assume we were connected when the page loaded
@@ -33,7 +46,7 @@ class Flashes extends React.PureComponent {
     PusherStore.off('connected', this.handleConnectionSuccess);
   }
 
-  handleStoreChange = (payload) => {
+  handleStoreChange = (payload: Flash) => {
     this.setState({ flashes: this.state.flashes.concat(payload) });
   };
 
@@ -83,7 +96,7 @@ class Flashes extends React.PureComponent {
 
   // hide connection error flash (if it exists!) when reconnected
   handleConnectionSuccess = () => {
-    const newState = {
+    const newState: { flashes?: Array<Flash>, lastConnected: boolean } = {
       // make it known that we got a good connection!
       lastConnected: true
     };
@@ -115,7 +128,7 @@ class Flashes extends React.PureComponent {
     return null;
   }
 
-  handleFlashRemove = (flash) => {
+  handleFlashRemove = (flash: Flash) => {
     this.setState({
       flashes: this.state.flashes.filter(
         (nextFlash) => flash.id !== nextFlash.id

--- a/app/components/layout/Flashes/index.js
+++ b/app/components/layout/Flashes/index.js
@@ -14,7 +14,7 @@ type State = {
   lastConnected: boolean
 };
 
-class Flashes extends React.PureComponent<null, State> {
+class Flashes extends React.PureComponent<{}, State> {
   state = {
     flashes: [],
     lastConnected: true // assume we were connected when the page loaded

--- a/app/components/layout/Footer/index.js
+++ b/app/components/layout/Footer/index.js
@@ -1,20 +1,21 @@
+// @flow
+
 import React from 'react';
-import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 
 import Link from './link';
 import Icon from '../../shared/Icon';
 
-class Footer extends React.PureComponent {
-  static propTypes = {
-    viewer: PropTypes.shape({
-      unreadChangelogs: PropTypes.shape({
-        count: PropTypes.number
-      })
-    }),
-    relay: PropTypes.object.isRequired
-  };
+type Props = {
+  viewer?: {
+    unreadChangelogs?: {
+      count: number
+    }
+  },
+  relay: Object
+};
 
+class Footer extends React.PureComponent<Props> {
   componentDidMount() {
     this.props.relay.setVariables({ isMounted: true });
   }

--- a/app/stores/FlashesStore.js
+++ b/app/stores/FlashesStore.js
@@ -1,3 +1,13 @@
+// @flow
+
+type FlashType = "error" | "success" | "info";
+
+export type FlashItem = {
+  id: number | 'FLASH_CONN_ERROR',
+  type: FlashType,
+  message: Object
+};
+
 import EventEmitter from 'eventemitter3';
 
 class FlashesStore extends EventEmitter {
@@ -9,27 +19,29 @@ class FlashesStore extends EventEmitter {
     this.INFO = "info";
   }
 
-  preload(flashes) {
+  preload(flashes: Array<FlashItem>) {
     for (const flash of flashes) {
       this.preloaded.push({ id: (new Date()).valueOf(), ...flash });
     }
   }
 
-  flash(type, message) {
+  flash(type: FlashType, message: Object) {
+    let returnMessage: Object | string = message;
+
     // See if the message is actually a GraphQL exception
     if (message.source && message.message) {
-      if (message.source.errors[0] && message.source.errors[0].message) {
+      if (message.source.errors && message.source.errors[0] && message.source.errors[0].message) {
         if (message.source.type === "unknown_error") {
-          message = "Sorry, there’s been an unexpected error and our engineers have been notified";
+          returnMessage = "Sorry, there’s been an unexpected error and our engineers have been notified";
         } else {
-          message = message.source.errors[0].message;
+          returnMessage = message.source.errors[0].message;
         }
       } else {
-        message = "An unknown error occured";
+        returnMessage = "An unknown error occured";
       }
     }
 
-    this.emit('flash', { id: (new Date()).valueOf(), type: type, message: message });
+    this.emit('flash', { id: (new Date()).valueOf(), type: type, message: returnMessage });
   }
 
   reset() {

--- a/app/stores/FlashesStore.js
+++ b/app/stores/FlashesStore.js
@@ -11,6 +11,8 @@ export type FlashItem = {
 import EventEmitter from 'eventemitter3';
 
 class FlashesStore extends EventEmitter {
+  preloaded: Array<FlashItem>;
+
   constructor() {
     super(...arguments);
     this.preloaded = [];


### PR DESCRIPTION
This fixes a few minor oversights in our UI, where it’s not checking for the presence of objects before rendering based on them. There are a few situations where the viewer or organization information might be missing, so this updates components which would previously fail to render in this state to handle them gracefully. This state is usually encountered by staff during support, though.