### PR TITLE
Fix incorrect margin of nested, closed annotation summaries

### DIFF
--- a/app/css/annotation-body.css
+++ b/app/css/annotation-body.css
@@ -6,11 +6,11 @@
   margin: 1em 0;
 }
 
-.annotation-body details summary {
+.annotation-body details > summary {
   cursor: pointer;
 }
 
-.annotation-body details[open] summary {
+.annotation-body details[open] > summary {
   margin-bottom: 1em;
 }
 


### PR DESCRIPTION
As reported by @tessereth, in an annotation body if there's a nested `<detail>` inside a closed `<detail>`, you get this additional margin appearing between them:
<img width="775" alt="screen-shot-2018-05-01-at-5-10-29-pm" src="https://user-images.githubusercontent.com/153/41223906-7003c32c-6dae-11e8-8776-c893ab147120.png">

This fixes it so that we're only adding margin to the correct summary element.