### PR TITLE
Bump OS versions in agent instructions

### DIFF
--- a/app/components/docs/01-ubuntu.mdx
+++ b/app/components/docs/01-ubuntu.mdx
@@ -23,7 +23,7 @@ sudo sed -i "s/xxx/{{ props.token || 'INSERT-YOUR-AGENT-TOKEN-HERE' }}/g" /etc/b
 And then start the agent:
 
 ```bash
-# Ubuntu 15.04+ (systemd)
+# Ubuntu 15.04 and above (systemd)
 sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent
 
 # Older Ubuntu (upstart)
@@ -33,11 +33,11 @@ sudo service buildkite-agent start
 You can view the logs at:
 
 ```bash
-# Ubuntu 15.04+ (systemd)
+# Ubuntu 15.04 and above (systemd)
 journalctl -f -u buildkite-agent
 
 # Older Ubuntu (upstart)
 tail -f /var/log/upstart/buildkite-agent.log
 ```
 
-<p class="rounded bg-silver p2">See the <a href="/docs/agent/ubuntu">Ubuntu agent docs</a> for more details. Supported Ubuntu versions: 13.10, 12.04, 14.04 and 15.04.</p>
+<p class="rounded bg-silver p2">See the <a href="/docs/agent/ubuntu">Ubuntu agent docs</a> for more details. Supported Ubuntu versions: 14.04 and above.</p>

--- a/app/components/docs/02-debian.mdx
+++ b/app/components/docs/02-debian.mdx
@@ -35,7 +35,7 @@ sudo sed -i "s/xxx/{{ props.token || 'INSERT-YOUR-AGENT-TOKEN-HERE' }}/g" /etc/b
 And then start the agent:
 
 ```bash
-# For Debian 8.x (systemd)
+# For Debian 8.x and above (systemd)
 sudo systemctl enable buildkite-agent && systemctl start buildkite-agent
 
 # For Debian 7.x (using upstart)
@@ -48,7 +48,7 @@ sudo /etc/init.d/buildkite-agent start
 You can view the logs at:
 
 ```bash
-# For Debian 8.x (systemd)
+# For Debian 8.x and above (systemd)
 sudo journalctl -f -u buildkite-agent
 
 # For Debian 7.x (using upstart)
@@ -58,4 +58,4 @@ sudo tail -f /var/log/upstart/buildkite-agent.log
 sudo tail -f /var/log/buildkite-agent.log
 ```
 
-<p class="rounded bg-silver p2">See the <a href="/docs/agent/debian">Debian agent docs</a> for more details. Supported Debian versions: 7.x and 8.x.</p>
+<p class="rounded bg-silver p2">See the <a href="/docs/agent/debian">Debian agent docs</a> for more details. Supported Debian versions: 7.x and above.</p>


### PR DESCRIPTION
We still need to support Ubuntu 14.04 which is an LTS release supported until April 2019, but 12.04 is long gone, and ending with 15.04 is embarrassing.

And Debian 9.x has been out since mid last year, and works fine.