### PR TITLE
SSO2: Respect `view` permissions in the navigation header

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -233,6 +233,12 @@ class Navigation extends React.PureComponent<Props, State> {
   renderOrganizationButtons(paddingLeft) {
     const organization = this.props.organization;
 
+    // This is already checked in `renderOrganizationMenu`, but we check here
+    // again to make flow play nice.
+    if (!organization) {
+      return;
+    }
+
     return permissions(organization.permissions).collect(
       {
         allowed: "pipelineView",

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -239,7 +239,7 @@ class Navigation extends React.PureComponent<Props, State> {
         render: () => {
           return (
             <NavigationButton key={1} className="py0" style={{ paddingLeft: paddingLeft }} href={this.getOrganizationPipelinesUrl(organization)} linkIf={true}>Pipelines</NavigationButton>
-          )
+          );
         }
       },
       {
@@ -250,7 +250,7 @@ class Navigation extends React.PureComponent<Props, State> {
               {'Agents'}
               <Badge className="hover-lime-child"><AgentsCount organization={organization} /></Badge>
             </NavigationButton>
-          )
+          );
         }
       },
       // The settings page will redirect to the first section the user has access
@@ -264,7 +264,11 @@ class Navigation extends React.PureComponent<Props, State> {
           organizationBillingUpdate: false,
           teamAdmin: true
         },
-        render: () => <NavigationButton key={3} className="py0" href={`/organizations/${organization.slug}/teams`}>Settings</NavigationButton>
+        render: () => {
+          return (
+            <NavigationButton key={3} className="py0" href={`/organizations/${organization.slug}/teams`}>Settings</NavigationButton>
+          );
+        }
       },
       {
         // If any of these permissions are allowed, render the buttons

--- a/app/lib/RelayPreloader.js
+++ b/app/lib/RelayPreloader.js
@@ -164,6 +164,12 @@ const QUERIES = {
           count
         }
         permissions {
+          pipelineView {
+            allowed
+          }
+          agentView {
+            allowed
+          }
           organizationUpdate {
             allowed
           }

--- a/app/lib/permissions.js
+++ b/app/lib/permissions.js
@@ -38,7 +38,6 @@ class PermissionManager {
   areAnyPermissionsAllowed(keys) {
     if (Array.isArray) {
       for (const name of keys) {
-        console.log(name);
         if (this.find(name).allowed) {
           return true;
         }
@@ -60,7 +59,7 @@ class PermissionManager {
   areAllPermissionsAllowed(permissions) {
     if (typeof (permissions) == 'object') {
       for (const name in permissions) {
-        if (this.find(name).allowed != permissions[name]) {
+        if (this.find(name).allowed !== permissions[name]) {
           return false;
         }
       }

--- a/app/lib/permissions.js
+++ b/app/lib/permissions.js
@@ -36,7 +36,7 @@ class PermissionManager {
   // look across all the permissions, alternativly you can pass an array to
   // just check those permissions.
   areAnyPermissionsAllowed(keys) {
-    if (Array.isArray) {
+    if (Array.isArray(keys)) {
       for (const name of keys) {
         if (this.find(name).allowed) {
           return true;

--- a/app/lib/permissions.js
+++ b/app/lib/permissions.js
@@ -32,24 +32,43 @@ class PermissionManager {
     return thisPermissionAllowed && !othersAllowed;
   }
 
-  // Returns true if _any_ of the permissions in the hash are allowed -
-  // otherwise returns false.
-  areAnyPermissionsAllowed() {
-    for (const name in this.permissions) {
-      if (this.find(name).allowed) {
-        return true;
+  // Returns true if _any_ of the permissions are allowed. Passing `true` will
+  // look across all the permissions, alternativly you can pass an array to
+  // just check those permissions.
+  areAnyPermissionsAllowed(keys) {
+    if (Array.isArray) {
+      for (const name of keys) {
+        console.log(name);
+        if (this.find(name).allowed) {
+          return true;
+        }
+      }
+    } else {
+      for (const name in this.permissions) {
+        if (this.find(name).allowed) {
+          return true;
+        }
       }
     }
 
     return false;
   }
 
-  // Returns true if _all of the permissions in the hash are allowed -
-  // otherwise returns false.
-  areAllPermissionsAllowed() {
-    for (const name in this.permissions) {
-      if (!this.find(name).allowed) {
-        return false;
+  // Returns true if all of the permissions in the hash are allowed - otherwise
+  // returns false. An optional hash can be passed to specific which
+  // permissions should be checked, and their expected values.
+  areAllPermissionsAllowed(permissions) {
+    if (typeof (permissions) == 'object') {
+      for (const name in permissions) {
+        if (this.find(name).allowed != permissions[name]) {
+          return false;
+        }
+      }
+    } else {
+      for (const name in this.permissions) {
+        if (!this.find(name).allowed) {
+          return false;
+        }
       }
     }
 
@@ -85,11 +104,11 @@ class PermissionManager {
     if (config.always) {
       return config.render(...args);
     } else if (config.all) {
-      if (this.areAllPermissionsAllowed()) {return config.render(...args);}
+      if (this.areAllPermissionsAllowed(config.all)) {return config.render(...args);}
     } else if (config.allowed) {
       if (this.isPermissionAllowed(config.allowed)) {return config.render(...args);}
     } else if (config.any) {
-      if (this.areAnyPermissionsAllowed()) {return config.render(...args);}
+      if (this.areAnyPermissionsAllowed(config.any)) {return config.render(...args);}
     } else if (config.only) {
       if (this.isPermissionOnlyOneAllowed(config.only)) {return config.render(...args);}
     } else {

--- a/app/lib/permissions.js
+++ b/app/lib/permissions.js
@@ -54,7 +54,7 @@ class PermissionManager {
   }
 
   // Returns true if all of the permissions in the hash are allowed - otherwise
-  // returns false. An optional hash can be passed to specific which
+  // returns false. An optional hash can be passed to specify which
   // permissions should be checked, and their expected values.
   areAllPermissionsAllowed(permissions) {
     if (typeof (permissions) == 'object') {


### PR DESCRIPTION
This change makes sure we check the `pipelineView` and `agentView` permissions in the navigation header.