### PR TITLE
SSO2: Badges

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -181,10 +181,10 @@ class Navigation extends React.PureComponent<Props, State> {
       if (!this.props.organization || (org.node.slug !== this.props.organization.slug)) {
         // If the org needs SSO, show a badge
         let ssoRequiredBadge;
-        if (!org.node.permissions.pipelineView.allowed && org.node.permissions.pipelineView.code == "sso_authorized_required") {
+        if (!org.node.permissions.pipelineView.allowed && org.node.permissions.pipelineView.code === "sso_authorized_required") {
           ssoRequiredBadge = (
             <Badge outline={true} className="regular">SSO Required</Badge>
-          )
+          );
         }
 
         nodes.push(

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -179,13 +179,21 @@ class Navigation extends React.PureComponent<Props, State> {
     this.props.viewer.organizations.edges.forEach((org) => {
       // Don't show the active organization in the selector
       if (!this.props.organization || (org.node.slug !== this.props.organization.slug)) {
+        // If the org needs SSO, show a badge
+        let ssoRequiredBadge;
+        if (!org.node.permissions.pipelineView.allowed && org.node.permissions.pipelineView.code == "sso_authorized_required") {
+          ssoRequiredBadge = (
+            <Badge outline={true} className="regular">SSO Required</Badge>
+          )
+        }
+
         nodes.push(
           <NavigationButton
             key={org.node.slug}
             href={`/${org.node.slug}`}
             className="block"
           >
-            {org.node.name}
+            {org.node.name}{ssoRequiredBadge}
           </NavigationButton>
         );
       }
@@ -516,6 +524,12 @@ export default Relay.createContainer(Navigation, {
               node {
                 slug
                 name
+                permissions {
+                  pipelineView {
+                    allowed
+                    code
+                  }
+                }
               }
             }
           }

--- a/app/components/member/InvitationRow.js
+++ b/app/components/member/InvitationRow.js
@@ -19,7 +19,10 @@ class InvitationRow extends React.PureComponent {
     organizationInvitation: PropTypes.shape({
       uuid: PropTypes.string.isRequired,
       email: PropTypes.string.isRequired,
-      role: PropTypes.string.isRequired
+      role: PropTypes.string.isRequired,
+      sso: PropTypes.shape({
+        mode: PropTypes.string
+      }).isRequired
     }).isRequired
   };
 
@@ -72,12 +75,12 @@ class InvitationRow extends React.PureComponent {
   renderLabels() {
     let nodes = [];
 
-    if (this.props.organizationInvitation.sso.mode == OrganizationMemberSSOModeConstants.OPTIONAL) {
+    if (this.props.organizationInvitation.sso.mode === OrganizationMemberSSOModeConstants.OPTIONAL) {
       nodes.push(
         <div key={1} className="flex ml1">
           <Badge outline={true} className="regular">SSO Optional</Badge>
         </div>
-      )
+      );
     }
 
     if (this.props.organizationInvitation.role === OrganizationMemberRoleConstants.ADMIN) {
@@ -85,7 +88,7 @@ class InvitationRow extends React.PureComponent {
         <div key={2} className="flex ml1">
           <Badge outline={true} className="regular">Administrator</Badge>
         </div>
-      )
+      );
     }
 
     return nodes;

--- a/app/components/member/InvitationRow.js
+++ b/app/components/member/InvitationRow.js
@@ -4,6 +4,7 @@ import Relay from 'react-relay/classic';
 
 import Button from '../shared/Button';
 import Panel from '../shared/Panel';
+import Badge from '../shared/Badge';
 
 import FlashesStore from '../../stores/FlashesStore';
 
@@ -11,6 +12,7 @@ import OrganizationInvitationResend from '../../mutations/OrganizationInvitation
 import OrganizationInvitationRevoke from '../../mutations/OrganizationInvitationRevoke';
 
 import OrganizationMemberRoleConstants from '../../constants/OrganizationMemberRoleConstants';
+import OrganizationMemberSSOModeConstants from '../../constants/OrganizationMemberSSOModeConstants';
 
 class InvitationRow extends React.PureComponent {
   static propTypes = {
@@ -37,9 +39,9 @@ class InvitationRow extends React.PureComponent {
       <Panel.Row key={this.props.organizationInvitation.uuid}>
         <div className="flex flex-stretch items-center">
           <div className="flex-auto">
-            <div className="m0">
+            <div className="m0 flex items-center">
               {this.props.organizationInvitation.email}
-              {this.props.organizationInvitation.role === OrganizationMemberRoleConstants.ADMIN && <span className="dark-gray regular h6 ml1">Administrator</span>}
+              {this.renderLabels()}
             </div>
           </div>
           <div className="flex-none">
@@ -65,6 +67,28 @@ class InvitationRow extends React.PureComponent {
         </div>
       </Panel.Row>
     );
+  }
+
+  renderLabels() {
+    let nodes = [];
+
+    if (this.props.organizationInvitation.sso.mode == OrganizationMemberSSOModeConstants.OPTIONAL) {
+      nodes.push(
+        <div key={1} className="flex ml1">
+          <Badge outline={true} className="regular">SSO Optional</Badge>
+        </div>
+      )
+    }
+
+    if (this.props.organizationInvitation.role === OrganizationMemberRoleConstants.ADMIN) {
+      nodes.push(
+        <div key={2} className="flex ml1">
+          <Badge outline={true} className="regular">Administrator</Badge>
+        </div>
+      )
+    }
+
+    return nodes;
   }
 
   handleResendInvitationClick = () => {
@@ -133,6 +157,9 @@ export default Relay.createContainer(InvitationRow, {
         uuid
         email
         role
+        sso {
+          mode
+        }
         ${OrganizationInvitationResend.getFragment('organizationInvitation')}
         ${OrganizationInvitationRevoke.getFragment('organizationInvitation')}
       }

--- a/app/components/member/Row.js
+++ b/app/components/member/Row.js
@@ -19,6 +19,9 @@ class MemberRow extends React.PureComponent {
     organizationMember: PropTypes.shape({
       uuid: PropTypes.string.isRequired,
       role: PropTypes.string.isRequired,
+      sso: PropTypes.shape({
+        mode: PropTypes.string
+      }).isRequired,
       user: PropTypes.shape({
         name: PropTypes.string.isRequired,
         email: PropTypes.string.isRequired,
@@ -55,12 +58,12 @@ class MemberRow extends React.PureComponent {
   renderLabels() {
     let nodes = [];
 
-    if (this.props.organizationMember.sso.mode == OrganizationMemberSSOModeConstants.OPTIONAL) {
+    if (this.props.organizationMember.sso.mode === OrganizationMemberSSOModeConstants.OPTIONAL) {
       nodes.push(
         <div key={1} className="flex ml1">
           <Badge outline={true} className="regular">SSO Optional</Badge>
         </div>
-      )
+      );
     }
 
     if (this.props.organizationMember.role === OrganizationMemberRoleConstants.ADMIN) {
@@ -68,7 +71,7 @@ class MemberRow extends React.PureComponent {
         <div key={2} className="flex ml1">
           <Badge outline={true} className="regular">Administrator</Badge>
         </div>
-      )
+      );
     }
 
     return nodes;

--- a/app/components/member/Row.js
+++ b/app/components/member/Row.js
@@ -4,8 +4,10 @@ import Relay from 'react-relay/classic';
 
 import Panel from '../shared/Panel';
 import UserAvatar from '../shared/UserAvatar';
+import Badge from '../shared/Badge';
 
 import OrganizationMemberRoleConstants from '../../constants/OrganizationMemberRoleConstants';
+import OrganizationMemberSSOModeConstants from '../../constants/OrganizationMemberSSOModeConstants';
 
 const AVATAR_SIZE = 40;
 
@@ -39,15 +41,37 @@ class MemberRow extends React.PureComponent {
             />
           </div>
           <div className="flex-auto">
-            <div className="m0 semi-bold">
+            <div className="m0 flex items-center semi-bold">
               {this.props.organizationMember.user.name}
-              {this.props.organizationMember.role === OrganizationMemberRoleConstants.ADMIN && <span className="dark-gray regular h6 ml1">Administrator</span>}
+              {this.renderLabels()}
             </div>
             <div className="h6 regular mt1">{this.props.organizationMember.user.email}</div>
           </div>
         </div>
       </Panel.RowLink>
     );
+  }
+
+  renderLabels() {
+    let nodes = [];
+
+    if (this.props.organizationMember.sso.mode == OrganizationMemberSSOModeConstants.OPTIONAL) {
+      nodes.push(
+        <div key={1} className="flex ml1">
+          <Badge outline={true} className="regular">SSO Optional</Badge>
+        </div>
+      )
+    }
+
+    if (this.props.organizationMember.role === OrganizationMemberRoleConstants.ADMIN) {
+      nodes.push(
+        <div key={2} className="flex ml1">
+          <Badge outline={true} className="regular">Administrator</Badge>
+        </div>
+      )
+    }
+
+    return nodes;
   }
 }
 
@@ -62,6 +86,9 @@ export default Relay.createContainer(MemberRow, {
       fragment on OrganizationMember {
         uuid
         role
+        sso {
+          mode
+        }
         user {
           name
           email

--- a/app/constants/OrganizationMemberSSOModeConstants.js
+++ b/app/constants/OrganizationMemberSSOModeConstants.js
@@ -1,0 +1,8 @@
+// @flow
+
+const OrganizationMemberSSOModeConstants = {
+  REQUIRED: "REQUIRED",
+  OPTIONAL: "OPTIONAL"
+};
+
+export default OrganizationMemberSSOModeConstants;


### PR DESCRIPTION
This change adds a few badges about the place.

Invitation rows now have an "Administrator" badge (it used to just be gray words), now it's a badge:

<img width="414" alt="image" src="https://user-images.githubusercontent.com/25882/43211891-395d58e0-9065-11e8-800d-5c705ff6bdd6.png">

I've applied the same treatment here:

<img width="459" alt="image" src="https://user-images.githubusercontent.com/25882/43211904-450a7fb0-9065-11e8-83d8-98f80a542546.png">

The org switcher in the nav will now check to see if can view pipelines inside it, and if it can't (because of SSO) it'll show:

<img width="360" alt="image" src="https://user-images.githubusercontent.com/25882/43212051-9c0de752-9065-11e8-9514-249ed0791daa.png">
