### PR TITLE
SSO2: Added "Single Sign-On" options to the UI

### DIFF
--- a/app/components/member/Edit/form.js
+++ b/app/components/member/Edit/form.js
@@ -3,12 +3,10 @@ import PropTypes from 'prop-types';
 import Relay from 'react-relay/classic';
 
 import Button from '../../shared/Button';
-import FormCheckbox from '../../shared/FormCheckbox';
 import FormRadioGroup from '../../shared/FormRadioGroup';
 import Panel from '../../shared/Panel';
 
 import FlashesStore from '../../../stores/FlashesStore';
-import ValidationErrors from '../../../lib/ValidationErrors';
 
 import OrganizationMemberUpdateMutation from '../../../mutations/OrganizationMemberUpdate';
 
@@ -27,6 +25,11 @@ class Form extends React.PureComponent {
       permissions: PropTypes.object.isRequired,
       user: PropTypes.shape({
         name: PropTypes.string.isRequired
+      }).isRequired,
+      organization: PropTypes.shape({
+        ssoProviders: PropTypes.shape({
+          count: PropTypes.number.isRequired
+        }).isRequired
       }).isRequired
     })
   };
@@ -134,22 +137,22 @@ class Form extends React.PureComponent {
   handleSSOModeChange = (evt) => {
     this.setState({
       ssoMode: evt.target.value
-    })
+    });
   }
 
   handleUpdateOrganizationMemberClick = () => {
     // Show the updating indicator
     this.setState({ updating: true });
 
-    let variables = {
+    const variables = {
       organizationMember: this.props.organizationMember,
       role: this.state.role
-    }
+    };
 
     if (this.isSSOEnabled()) {
       variables.sso = {
         mode: this.state.ssoMode
-      }
+      };
     }
 
     const mutation = new OrganizationMemberUpdateMutation(variables);

--- a/app/components/member/InvitationRow.js
+++ b/app/components/member/InvitationRow.js
@@ -73,7 +73,7 @@ class InvitationRow extends React.PureComponent {
   }
 
   renderLabels() {
-    let nodes = [];
+    const nodes = [];
 
     if (this.props.organizationInvitation.sso.mode === OrganizationMemberSSOModeConstants.OPTIONAL) {
       nodes.push(

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -38,7 +38,10 @@ class MemberNew extends React.PureComponent {
             }).isRequired
           })
         ).isRequired
-      })
+      }),
+      ssoProviders: PropTypes.shape({
+        count: PropTypes.number.isRequired
+      }).isRequired
     }).isRequired,
     relay: PropTypes.object.isRequired
   };

--- a/app/components/member/Row.js
+++ b/app/components/member/Row.js
@@ -56,7 +56,7 @@ class MemberRow extends React.PureComponent {
   }
 
   renderLabels() {
-    let nodes = [];
+    const nodes = [];
 
     if (this.props.organizationMember.sso.mode === OrganizationMemberSSOModeConstants.OPTIONAL) {
       nodes.push(

--- a/app/mutations/OrganizationInvitationCreate.js
+++ b/app/mutations/OrganizationInvitationCreate.js
@@ -52,7 +52,8 @@ export default class OrganizationInvitationCreate extends Relay.Mutation {
       organizationID: this.props.organization.id,
       emails: this.props.emails,
       teams: this.props.teams,
-      role: this.props.role
+      role: this.props.role,
+      sso: this.props.sso
     };
   }
 }

--- a/app/mutations/OrganizationMemberUpdate.js
+++ b/app/mutations/OrganizationMemberUpdate.js
@@ -43,10 +43,10 @@ export default class OrganizationMemberUpdate extends Relay.Mutation {
   }
 
   getVariables() {
-    let variables = {
+    const variables = {
       id: this.props.organizationMember.id,
       role: this.props.role
-    }
+    };
 
     if (this.props.sso) {
       variables.sso = this.props.sso;

--- a/app/mutations/OrganizationMemberUpdate.js
+++ b/app/mutations/OrganizationMemberUpdate.js
@@ -22,6 +22,9 @@ export default class OrganizationMemberUpdate extends Relay.Mutation {
       fragment on OrganizationMemberUpdatePayload {
         organizationMember {
           role
+          sso {
+            mode
+          }
           user {
             name
           }
@@ -40,6 +43,15 @@ export default class OrganizationMemberUpdate extends Relay.Mutation {
   }
 
   getVariables() {
-    return { id: this.props.organizationMember.id, role: this.props.role };
+    let variables = {
+      id: this.props.organizationMember.id,
+      role: this.props.role
+    }
+
+    if (this.props.sso) {
+      variables.sso = this.props.sso;
+    }
+
+    return variables;
   }
 }


### PR DESCRIPTION
Nothing too interesting. This change adds a "Single Sign-On" section to invitations and member edit allowing you to modify the `sso.mode` attribute.

I also updated the "Administrator" section (was a checkbox) to be inline with the "Role" section we use on the invitation screen.

Here's the new member edit page:

<img width="865" alt="image" src="https://user-images.githubusercontent.com/25882/43890502-89f93216-9bf9-11e8-88a1-ae75b0c9cd24.png">

And the invitation page:

<img width="809" alt="image" src="https://user-images.githubusercontent.com/25882/43890531-9d01f604-9bf9-11e8-91a4-d9093e4ab3a9.png">

The new "Single Sign-On" section doesn't appear unless you've configured an SSO2 provider.