### PR TITLE
Use a caching version of moment-duration-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "metrick": "0.2.0",
     "mojibaka": "1.0.2",
     "moment": "2.22.2",
-    "moment-duration-format": "2.2.2",
+    "moment-duration-format": "https://github.com/ticky/moment-duration-format.git#951b8be1d1b0424824363aa912cbf066546bf384",
     "object-assign": "4.1.1",
     "prop-types": "15.6.2",
     "pusher-js": "4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6294,9 +6294,9 @@ mojibaka@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mojibaka/-/mojibaka-1.0.2.tgz#4005571f68467ddad708c00f5b666c6df040217e"
 
-moment-duration-format@2.2.2:
+"moment-duration-format@https://github.com/ticky/moment-duration-format.git#951b8be1d1b0424824363aa912cbf066546bf384":
   version "2.2.2"
-  resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.2.2.tgz#b957612de26016c9ad9eb6087c054573e5127779"
+  resolved "https://github.com/ticky/moment-duration-format.git#951b8be1d1b0424824363aa912cbf066546bf384"
 
 moment@2.22.2:
   version "2.22.2"


### PR DESCRIPTION
This is intended to help improve performance on pages showing large quantities of timers.

Upstream PR is at jsmreese/moment-duration-format#122