### PR TITLE
Very basic handling of showing audit logs with no actor

### DIFF
--- a/app/components/audit_log/Drawer/actorSection.js
+++ b/app/components/audit_log/Drawer/actorSection.js
@@ -8,7 +8,7 @@ import { Section, SectionHeading } from './shared';
 
 type Props = {
   auditEvent: {
-    actor: {
+    actor?: {
       name?: string,
       type?: string,
       uuid?: string,
@@ -35,12 +35,16 @@ class AuditLogActorSection extends React.PureComponent<Props> {
             url: PropTypes.string.isRequired
           }).isRequired
         })
-      }).isRequired
+      })
     }).isRequired
   };
 
   render() {
     const { actor } = this.props.auditEvent;
+
+    if (!actor) {
+      return null;
+    }
 
     return (
       <Section>

--- a/app/components/audit_log/row.js
+++ b/app/components/audit_log/row.js
@@ -180,14 +180,14 @@ class AuditLogRow extends React.PureComponent<Props, State> {
           style={{ width: 39, height: 39 }}
           user={this.props.auditEvent.actor.node}
         />
-      )
-    } else {
-      return (
-        <div style={{ width: 39, height: 39 }} className="circle border border-gray flex items-center justify-center">
-          <span class="dark-gray">?</span>
-        </div>
-      )
+      );
     }
+
+    return (
+      <div style={{ width: 39, height: 39 }} className="circle border border-gray flex items-center justify-center">
+        <span className="dark-gray">?</span>
+      </div>
+    );
   }
 
   renderEventSentence() {

--- a/app/components/audit_log/row.js
+++ b/app/components/audit_log/row.js
@@ -110,11 +110,6 @@ class AuditLogRow extends React.PureComponent<Props, State> {
   }
 
   render() {
-    let actorName;
-    if (this.props.auditEvent.actor) {
-      actorName = this.props.auditEvent.actor.name || this.props.auditEvent.actor.node && this.props.auditEvent.actor.node.name;
-    }
-
     return (
       <Panel.Row>
         <div>
@@ -134,9 +129,7 @@ class AuditLogRow extends React.PureComponent<Props, State> {
               </div>
               <div className="flex-auto md-flex lg-flex items-center">
                 <h2 className="flex-auto line-height-3 font-size-1 h4 regular m0">
-                  {actorName && (
-                    <span className="semi-bold block">{actorName}</span>
-                  )}
+                  {this.renderActorName()}
                   {this.renderEventSentence()}
                 </h2>
                 <FriendlyTime
@@ -170,6 +163,20 @@ class AuditLogRow extends React.PureComponent<Props, State> {
           </TransitionMaxHeight>
         </div>
       </Panel.Row>
+    );
+  }
+
+  renderActorName() {
+    if (this.props.auditEvent.actor) {
+      const actorName = this.props.auditEvent.actor.name || this.props.auditEvent.actor.node && this.props.auditEvent.actor.node.name;
+
+      return (
+        <div className="semi-bold">{actorName}</div>
+      );
+    }
+
+    return (
+      <div className="dark-gray">No Actor</div>
     );
   }
 

--- a/app/components/audit_log/row.js
+++ b/app/components/audit_log/row.js
@@ -25,7 +25,7 @@ type Props = {
     uuid: string,
     type: string,
     occurredAt: string,
-    actor: {
+    actor?: {
       name?: string,
       node?: {
         name?: string,
@@ -76,7 +76,7 @@ class AuditLogRow extends React.PureComponent<Props, State> {
             url: PropTypes.string
           })
         })
-      }).isRequired,
+      }),
       subject: PropTypes.shape({
         type: PropTypes.string.isRequired,
         name: PropTypes.string,
@@ -110,7 +110,10 @@ class AuditLogRow extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const actorName = this.props.auditEvent.actor.name || this.props.auditEvent.actor.node && this.props.auditEvent.actor.node.name;
+    let actorName;
+    if (this.props.auditEvent.actor) {
+      actorName = this.props.auditEvent.actor.name || this.props.auditEvent.actor.node && this.props.auditEvent.actor.node.name;
+    }
 
     return (
       <Panel.Row>
@@ -126,18 +129,14 @@ class AuditLogRow extends React.PureComponent<Props, State> {
             onClick={this.handleHeaderClick}
           >
             <div className="flex-auto flex items-center">
-              {this.props.auditEvent.actor.node && (
-                <div className="flex-none self-start icon-mr">
-                  <UserAvatar
-                    style={{ width: 39, height: 39 }}
-                    user={this.props.auditEvent.actor.node}
-                  />
-                </div>
-              )}
+              <div className="flex-none self-start icon-mr">
+                {this.renderAvatar()}
+              </div>
               <div className="flex-auto md-flex lg-flex items-center">
                 <h2 className="flex-auto line-height-3 font-size-1 h4 regular m0">
-                  <span className="semi-bold">{actorName}</span>
-                  <br />
+                  {actorName && (
+                    <span className="semi-bold block">{actorName}</span>
+                  )}
                   {this.renderEventSentence()}
                 </h2>
                 <FriendlyTime
@@ -172,6 +171,23 @@ class AuditLogRow extends React.PureComponent<Props, State> {
         </div>
       </Panel.Row>
     );
+  }
+
+  renderAvatar() {
+    if (this.props.auditEvent.actor && this.props.auditEvent.actor.node) {
+      return (
+        <UserAvatar
+          style={{ width: 39, height: 39 }}
+          user={this.props.auditEvent.actor.node}
+        />
+      )
+    } else {
+      return (
+        <div style={{ width: 39, height: 39 }} className="circle border border-gray flex items-center justify-center">
+          <span class="dark-gray">?</span>
+        </div>
+      )
+    }
   }
 
   renderEventSentence() {


### PR DESCRIPTION
The audit log data model says that actors can be optional. This change just tweaks the UI so it doesn't break when showing an audit log with no user.