### PR TITLE
Keep multi-paragraph comments intact in GraphQL docs

### DIFF
--- a/app/components/user/graphql/GraphQLExplorerDocumentation/Comment.js
+++ b/app/components/user/graphql/GraphQLExplorerDocumentation/Comment.js
@@ -11,7 +11,7 @@ export default class Comment extends React.PureComponent<Props> {
   render() {
     return (
       <div className="cm-comment" style={{ whiteSpace: "pre" }}>
-        {wrap(this.props.text || "n/a", { width: 70, indent: "# ", newline: "\n# " })}
+        {wrap(this.props.text || "n/a", { width: 70, indent: '' }).replace(/(^|\n)/g, "$1# ")}
       </div>
     );
   }


### PR DESCRIPTION
Just a minor tweak to make sure multi-paragraph documentation comments are kept together logically.

### Before, kind of confusing
<img width="561" alt="screen shot 2018-09-05 at 2 24 25 pm" src="https://user-images.githubusercontent.com/282113/45122017-8e9fc680-b117-11e8-988f-4e07b0147b47.png">

### After, solid!
<img width="557" alt="screen shot 2018-09-05 at 2 24 41 pm" src="https://user-images.githubusercontent.com/282113/45122019-8f385d00-b117-11e8-9e0c-f00169ba66ad.png">