### PR TITLE
Allow for graceful Agent stopping

### DIFF
--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -207,9 +207,9 @@ class AgentShow extends React.Component {
       ));
     } else if (agent.connectionState === 'stopped' || agent.connectionState === 'stopping') {
       extras.push(this.renderExtraItem(
-        'Stopped',
+        'Stopped By',
         <span>
-          <FriendlyTime value={agent.stoppedAt} /> by {agent.stoppedBy.name}
+          {agent.stoppedBy.name} <FriendlyTime value={agent.stoppedAt} capitalized={false} />
         </span>
       ));
 

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -377,21 +377,23 @@ class AgentShow extends React.Component {
     // if the agent is not stopping, and we got this far, we can show a "stop" button
     if (this.props.agent.connectionState !== 'stopping') {
       return (
-        <Panel.Row className="flex flex-wrap items-center">
-          <Button
-            theme="default"
-            outline={true}
-            loading={this.state.stopping ? "Stopping…" : false}
-            onClick={this.handleStopButtonClick}
-            className="mb1 mr3"
-          >
-            Stop Agent
-          </Button>
-          {this.props.agent.job && (
-            <span className="dark-gray">
-              The agent will stop when the running job finishes.
-            </span>
-          )}
+        <Panel.Row>
+          <div className="flex flex-wrap items-center">
+            <Button
+              theme="default"
+              outline={true}
+              loading={this.state.stopping ? "Stopping…" : false}
+              onClick={this.handleStopButtonClick}
+              className="mb1 mr3"
+            >
+              Stop Agent
+            </Button>
+            {this.props.agent.job && (
+              <span className="dark-gray">
+                The agent will stop when the running job finishes.
+              </span>
+            )}
+          </div>
         </Panel.Row>
       );
     }
@@ -409,22 +411,24 @@ class AgentShow extends React.Component {
 
     // finally, show a "force stop" button
     return (
-      <Panel.Row className="flex flex-wrap items-center">
-        <Button
-          theme="error"
-          outline={true}
-          loading={this.state.stopping ? "Force Stopping…" : false}
-          onClick={this.handleForceStopButtonClick}
-          className="mb1 mr3"
-        >
-          Force Stop Agent
-        </Button>
-        <span className="dark-gray">
-          This agent has already been asked to stop gracefully.
-          {this.props.agent.job && (
-            <React.Fragment><br />If force-stopped, the running job will be canceled.</React.Fragment>
-          )}
-        </span>
+      <Panel.Row>
+        <div className="flex flex-wrap items-center">
+          <Button
+            theme="error"
+            outline={true}
+            loading={this.state.stopping ? "Force Stopping…" : false}
+            onClick={this.handleForceStopButtonClick}
+            className="mb1 mr3"
+          >
+            Force Stop Agent
+          </Button>
+          <span className="dark-gray">
+            This agent has already been asked to stop gracefully.
+            {this.props.agent.job && (
+              <React.Fragment><br />If force-stopped, the running job will be canceled.</React.Fragment>
+            )}
+          </span>
+        </div>
       </Panel.Row>
     );
   }

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -218,11 +218,6 @@ class AgentShow extends React.Component {
           'Disconnected',
           <FriendlyTime value={agent.disconnectedAt} />
         ));
-      } else {
-        extras.push(this.renderExtraItem(
-          'Disconnected',
-          '-'
-        ));
       }
     }
 

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -184,13 +184,15 @@ class AgentShow extends React.Component {
     if (agent.connectedAt) {
       extras.push(this.renderExtraItem(
         'Connected',
-        <span>
-          <FriendlyTime value={agent.connectedAt} />
-          {agent.pingedAt && agent.connectionState === 'connected' &&
-            <span> (last check-in was <FriendlyTime value={agent.pingedAt} capitalized={false} />)</span>
-          }
-        </span>
+        <FriendlyTime value={agent.connectedAt} />
       ));
+
+      if (agent.pingedAt) {
+        extras.push(this.renderExtraItem(
+          'Last Ping',
+          <FriendlyTime value={agent.pingedAt} />
+        ));
+      }
     }
 
     if (agent.connectionState === 'disconnected') {

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -116,9 +116,9 @@ class AgentShow extends React.Component {
     );
   }
 
-  renderExtraItem(title, content) {
+  renderExtraItem(title, content, options) {
     return (
-      <tr key={title} style={{ marginTop: 3 }} className="border-gray border-bottom flex-wrap">
+      <tr key={title} style={{ marginTop: 3 }} className={`${(!options || options.borderBottom !== false) && 'border-gray border-bottom'} flex-wrap`}>
         <th className="h4 p2 semi-bold left-align align-top" width={120}>{title}</th>
         <td className="h4 p2" style={{ flexGrow: 1 }}>{content}</td>
       </tr>
@@ -234,8 +234,9 @@ class AgentShow extends React.Component {
       });
     }
     extras.push(this.renderExtraItem(
-      'Meta-data',
-      <pre className="black bg-silver rounded border border-gray p2 m0 mb1 monospace" style={{ fontSize: 13, whiteSpace: 'pre-wrap' }}>{metaDataContent}</pre>
+      'Tags',
+      <pre className="black bg-silver rounded border border-gray p2 m0 mb1 monospace" style={{ fontSize: 13, whiteSpace: 'pre-wrap' }}>{metaDataContent}</pre>,
+      { borderBottom: false }
     ));
 
     return (
@@ -350,10 +351,12 @@ class AgentShow extends React.Component {
 
             <Panel.Row key="info">
               {this.renderExtras(agent)}
-              <p>
-                You can use the agent’s meta-data to target the agent in your pipeline’s step configuration, or to set the agent’s queue.
-                See the <a className="blue hover-navy text-decoration-none hover-underline" href="/docs/agent/agent-meta-data">Agent Meta-data Documentation</a> and <a className="blue hover-navy text-decoration-none hover-underline" href="/docs/agent/queues">Agent Queues Documentation</a> for more details.
-              </p>
+              {(this.props.agent.connectionState === 'connected' || this.props.agent.connectionState === 'stopping') &&
+                <p className="m0">
+                  You can use the agent’s tags to target the agent in your pipeline’s step configuration, or to set the agent’s queue.
+                  See the <a className="blue hover-navy text-decoration-none hover-underline" href="/docs/agent/v3/cli-start">Agent Tags and Queue Documentation</a> for more details.
+                </p>
+              }
             </Panel.Row>
 
             {this.renderStopRow()}

--- a/app/components/api_access_token_code/APIAccessTokenCodeAuthorize.js
+++ b/app/components/api_access_token_code/APIAccessTokenCodeAuthorize.js
@@ -96,8 +96,7 @@ class APIAccessTokenCodeAuthorize extends React.Component<Props, State> {
     this.setState({ authorizing: true });
 
     const mutation = new APIAccessTokenCodeAuthorizeMutation({
-      apiAccessTokenCode: this.props.apiAccessTokenCode,
-      graceful: false
+      apiAccessTokenCode: this.props.apiAccessTokenCode
     });
 
     Relay.Store.commitUpdate(mutation, {


### PR DESCRIPTION
This changes the behaviour of the existing Agents page, which treats the "Stop" button as an immediate, ungraceful, force stop. This means we don't have any user-facing way to gracefully stop an agent!

Following this change, "Stop" now gracefully stops.

If the Agent takes more than 5 (±3) seconds to stop, we then show an additional "Force Stop Agent" section below, with a warning that it'll cancel the running job (as the current warning does) and will function the same as our current behaviour.