### PR TITLE
Show the "Teams" button in navigation (most of the time)

### DIFF
--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -268,7 +268,7 @@ class Navigation extends React.PureComponent<Props, State> {
         }
       },
       // The settings page will redirect to the first section the user has access
-      // to. If they _just_ have teams admin enabled, skip the redirect and go
+      // to. If they _just_ have teams view enabled, skip the redirect and go
       // straight to the teams page.
       {
         all: {
@@ -276,11 +276,11 @@ class Navigation extends React.PureComponent<Props, State> {
           organizationInvitationCreate: false,
           notificationServiceUpdate: false,
           organizationBillingUpdate: false,
-          teamAdmin: true
+          teamView: true
         },
         render: () => {
           return (
-            <NavigationButton key={3} className="py0" href={`/organizations/${organization.slug}/teams`}>Settings</NavigationButton>
+            <NavigationButton key={3} className="py0" href={`/organizations/${organization.slug}/teams`}>Teams</NavigationButton>
           );
         }
       },
@@ -503,7 +503,7 @@ export default Relay.createContainer(Navigation, {
             organizationBillingUpdate {
               allowed
             }
-            teamAdmin {
+            teamView {
               allowed
             }
           }

--- a/app/components/member/Teams/index.js
+++ b/app/components/member/Teams/index.js
@@ -17,7 +17,13 @@ class TeamMemberships extends React.PureComponent {
   static propTypes = {
     organizationMember: PropTypes.shape({
       uuid: PropTypes.string.isRequired,
-      permissions: PropTypes.object,
+      organization: PropTypes.shape({
+        permissions: PropTypes.shape({
+          teamAdmin: PropTypes.shape({
+            allowed: PropTypes.bool.isRequired
+          }).isRequired
+        }).isRequired
+      }).isRequired,
       teams: PropTypes.shape({
         count: PropTypes.number.isRequired,
         edges: PropTypes.arrayOf(

--- a/app/components/organization/SettingsMenu.js
+++ b/app/components/organization/SettingsMenu.js
@@ -23,10 +23,13 @@ class SettingsMenu extends React.Component {
         organizationUpdate: PropTypes.shape({
           allowed: PropTypes.bool.isRequired
         }).isRequired,
-        organizationInvitationCreate: PropTypes.shape({
+        organizationMemberView: PropTypes.shape({
           allowed: PropTypes.bool.isRequired
         }).isRequired,
-        teamAdmin: PropTypes.shape({
+        teamView: PropTypes.shape({
+          allowed: PropTypes.bool.isRequired
+        }).isRequired,
+        teamEnabledChange: PropTypes.shape({
           allowed: PropTypes.bool.isRequired
         }).isRequired,
         notificationServiceUpdate: PropTypes.shape({
@@ -79,7 +82,7 @@ class SettingsMenu extends React.Component {
         )
       },
       {
-        always: true,
+        always: "organizationMemberView",
         render: (idx) => (
           <Menu.Button
             key={idx}
@@ -91,7 +94,10 @@ class SettingsMenu extends React.Component {
         )
       },
       {
-        always: true,
+        any: [
+          "teamEnabledChange",
+          "teamView"
+        ],
         render: (idx) => (
           <Menu.Button
             key={idx}
@@ -180,7 +186,7 @@ export default Relay.createContainer(SettingsMenu, {
           organizationUpdate {
             allowed
           }
-          organizationInvitationCreate {
+          organizationMemberView {
             allowed
           }
           notificationServiceUpdate {
@@ -189,7 +195,10 @@ export default Relay.createContainer(SettingsMenu, {
           organizationBillingUpdate {
             allowed
           }
-          teamAdmin {
+          teamView {
+            allowed
+          }
+          teamEnabledChange {
             allowed
           }
           auditEventsView {

--- a/app/lib/RelayPreloader.js
+++ b/app/lib/RelayPreloader.js
@@ -182,7 +182,7 @@ const QUERIES = {
           organizationBillingUpdate {
             allowed
           }
-          teamAdmin {
+          teamView {
             allowed
           }
         }
@@ -216,7 +216,7 @@ const QUERIES = {
           organizationUpdate {
             allowed
           }
-          organizationInvitationCreate {
+          organizationMemberView {
             allowed
           }
           notificationServiceUpdate {
@@ -225,10 +225,10 @@ const QUERIES = {
           organizationBillingUpdate {
             allowed
           }
-          teamAdmin {
+          teamView {
             allowed
           }
-          teamCreate {
+          teamEnabledChange {
             allowed
           }
           auditEventsView {


### PR DESCRIPTION
Like this:

<img width="585" alt="image" src="https://user-images.githubusercontent.com/25882/45400138-88609b80-b67d-11e8-86ae-0f667b1699ed.png">

Currently this button only shows if you're a team admin, but it's now based on the `teamView` permission which `true` if the organization has enabled teams.

The button *doesnt* show if your organisation admin, at which point just "Settings" shows.