### PR TITLE
Webpack 4 prep: Lazy Load CodeMirrors

### DIFF
--- a/app/components/user/graphql/GraphQLExplorerConsoleEditor.js
+++ b/app/components/user/graphql/GraphQLExplorerConsoleEditor.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable react/prop-types */
 
 import React from "react";
 import Loadable from "react-loadable";
@@ -135,6 +134,7 @@ class GraphQLExplorerConsoleEditor extends React.PureComponent<Props & LoadedPro
 // Instead of exporting the editor directly, we'll export a `Loadable`
 // Component that will allow us to load in dependencies and render the editor
 // until then.
+/* eslint-disable react/prop-types */
 export default Loadable.Map({
   loader: {
     CodeMirror: () => (

--- a/app/components/user/graphql/GraphQLExplorerConsoleResultsViewer.js
+++ b/app/components/user/graphql/GraphQLExplorerConsoleResultsViewer.js
@@ -28,8 +28,8 @@ type ReactLoadableLoadingProps = {
 };
 
 class GraphQLExplorerConsoleResultsViewer extends React.PureComponent<Props & LoadedProps> {
-  codeMirrorInstance: ?CodeMirrorInstance
-  resultsElement: ?HTMLDivElement
+  codeMirrorInstance: ?CodeMirrorInstance;
+  resultsElement: ?HTMLDivElement;
 
   componentDidMount() {
     if (this.resultsElement) {
@@ -49,10 +49,8 @@ class GraphQLExplorerConsoleResultsViewer extends React.PureComponent<Props & Lo
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.results !== prevProps.results) {
-      if (this.codeMirrorInstance) {
-        this.codeMirrorInstance.setValue(this.props.results);
-      }
+    if (this.codeMirrorInstance && this.props.results !== prevProps.results) {
+      this.codeMirrorInstance.setValue(this.props.results);
     }
   }
 

--- a/app/components/user/graphql/GraphQLExplorerConsoleResultsViewer.js
+++ b/app/components/user/graphql/GraphQLExplorerConsoleResultsViewer.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable react/prop-types */
 
 import React from "react";
 import Loadable from "react-loadable";
@@ -64,6 +63,7 @@ class GraphQLExplorerConsoleResultsViewer extends React.PureComponent<Props & Lo
 // Instead of exporting the viewer directly, we'll export a `Loadable`
 // Component that will allow us to load in dependencies and render the editor
 // until then.
+/* eslint-disable react/prop-types */
 export default Loadable.Map({
   loader: {
     CodeMirror: () => (

--- a/app/components/user/graphql/GraphQLExplorerExampleSection.js
+++ b/app/components/user/graphql/GraphQLExplorerExampleSection.js
@@ -102,6 +102,7 @@ class GraphQLExplorerExampleSection extends React.PureComponent<Props & LoadedPr
 // Instead of exporting the viewer directly, we'll export a `Loadable`
 // Component that will allow us to load in dependencies and render the editor
 // until then.
+/* eslint-disable react/prop-types */
 export default Loadable.Map({
   loader: {
     CodeMirror: () => (

--- a/app/components/user/graphql/GraphQLExplorerExampleSection.js
+++ b/app/components/user/graphql/GraphQLExplorerExampleSection.js
@@ -1,25 +1,41 @@
 // @flow
 
-import React from "react";
+import React from 'react';
+import Loadable from 'react-loadable';
 import PropTypes from 'prop-types';
 
 import Button from "../../shared/Button";
 import { interpolateQuery } from "./query";
 import consoleState from "./consoleState";
 
-import CodeMirror from './codemirror';
+type CodeMirrorInstance = {
+  showHint: ({}) => void,
+  on: (string, (any) => void) => mixed,
+  off: (string, (any) => void) => mixed,
+  getValue: () => string,
+  setValue: (?string) => void,
+  execCommand: (string) => void
+};
 
 type Props = {
   query: string,
   organization: ?Object
 };
 
-class GraphQLExplorerExampleSection extends React.PureComponent<Props> {
+type LoadedProps = {
+  CodeMirror: (HTMLDivElement, {}) => CodeMirrorInstance
+};
+
+type ReactLoadableLoadingProps = {
+  error?: string
+};
+
+class GraphQLExplorerExampleSection extends React.PureComponent<Props & LoadedProps> {
   static contextTypes = {
     router: PropTypes.object.isRequired
   };
 
-  editor: CodeMirror;
+  codeMirrorInstance: ?CodeMirrorInstance;
   exampleQueryContainerElement: ?HTMLDivElement;
 
   getInterpolatedQuery() {
@@ -32,25 +48,27 @@ class GraphQLExplorerExampleSection extends React.PureComponent<Props> {
   }
 
   componentDidMount() {
-    this.editor = CodeMirror(this.exampleQueryContainerElement, {
-      value: this.getInterpolatedQuery(),
-      mode: "graphql",
-      theme: "graphql",
-      readOnly: true
-    });
+    if (this.exampleQueryContainerElement) {
+      this.codeMirrorInstance = this.props.CodeMirror(this.exampleQueryContainerElement, {
+        value: this.getInterpolatedQuery(),
+        mode: "graphql",
+        theme: "graphql",
+        readOnly: true
+      });
+    }
   }
 
   componentWillUnmount() {
-    if (this.editor) {
-      this.editor = null;
+    if (this.codeMirrorInstance) {
+      this.codeMirrorInstance = null;
     }
   }
 
   componentDidUpdate(prevProps: { organization: ?Object }) {
     // If the organization changes, we'll need to re-interpolate the query as
     // the variables inside it will probably have changed.
-    if (this.props.organization !== prevProps.organization) {
-      this.editor.setValue(this.getInterpolatedQuery());
+    if (this.codeMirrorInstance && this.props.organization !== prevProps.organization) {
+      this.codeMirrorInstance.setValue(this.getInterpolatedQuery());
     }
   }
 
@@ -81,4 +99,39 @@ class GraphQLExplorerExampleSection extends React.PureComponent<Props> {
   };
 }
 
-export default GraphQLExplorerExampleSection;
+// Instead of exporting the viewer directly, we'll export a `Loadable`
+// Component that will allow us to load in dependencies and render the editor
+// until then.
+export default Loadable.Map({
+  loader: {
+    CodeMirror: () => (
+      import('./codemirror').then((module) => (
+        // Add a "zero" delay after the module has loaded, to allow their
+        // styles to take effect.
+        new Promise((resolve) => {
+          setTimeout(() => resolve(module.default), 0);
+        })
+      ))
+    )
+  },
+
+  loading(props: ReactLoadableLoadingProps) {
+    if (props.error) {
+      return (
+        <div>{props.error}</div>
+      );
+    }
+
+    return null;
+  },
+
+  render(loaded: LoadedProps, props: Props) {
+    return (
+      <GraphQLExplorerExampleSection
+        CodeMirror={loaded.CodeMirror}
+        query={props.query}
+        organization={props.organization}
+      />
+    );
+  }
+});


### PR DESCRIPTION
This should fix up the chunking issue we’d been having with Codemirror stuff; there was an entry point which wasn’t lazy-loaded, which means none of them got to be!

Pulled out of #511.