### PR TITLE
Some workflow tweaks

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -78,7 +78,9 @@ rules:
   no-new-require: error
   no-trailing-spaces: error
   no-unsafe-negation: error
-  no-unused-vars: error
+  no-unused-vars:
+    - error
+    - varsIgnorePattern: ^_
   no-useless-rename: warn
   no-var: warn
 

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -120,6 +120,7 @@ rules:
 
   import/extensions: error
   import/unambiguous: off
+  import/no-unresolved: off  # Covered by flow
 
   react/display-name:
     - error

--- a/.flowconfig
+++ b/.flowconfig
@@ -11,6 +11,7 @@ all=warn
 
 [options]
 emoji=true
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError
 module.use_strict=true
 module.ignore_non_literal_requires=true
-suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError
+module.name_mapper='^app/\(.*\)$' -> '<PROJECT_ROOT>/app/\1'

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -97,6 +97,12 @@ module.exports = {
     publicPath: process.env.FRONTEND_HOST
   },
 
+  resolve: {
+    alias: {
+      app: path.resolve(__dirname, '../app')
+    }
+  },
+
   optimization: {
     splitChunks: {
       cacheGroups: {


### PR DESCRIPTION
Commit log has the changes, but to repeat here with some more detail;

- Allow Webpack to resolve module paths that are within `app/*` to be resolved in imports using a module path, not a relative one. This makes refactoring code around on the filesystem a _lot_ easier as you don’t have to wrestle with relative paths, it also has huge gainz for find-replacing, etc etc. Of course both relative and modules imports continue to work, but using module imports for all our code is so much easier on the brain.🧠✨
  - **Before** https://github.com/buildkite/frontend/blob/9b027afcc6f41ddd14e38b436cf5814e320aae76/app/components/user/TwoFactor/RecoveryCodes/dialog.js#L7-L11
  - **After** https://github.com/buildkite/frontend/blob/c4dc7bd0794ceae995c040e3f2885cd94a76d2ea/app/components/user/TwoFactor/RecoveryCodes/RecoveryCodeDialog.js#L6-L9
- Allow flow to resolve paths in `app/` (really just the flow side of the above)
- Don’t error on unresolved or missing modules / imports. Flow already does this and usually does a better job. No point throwing two errors 🤷🏼‍♀️
- Allow unused vars if prefixed by `_` — this is a nice to have for times you want to annotate / explain what unused positional args are.
