### PR TITLE
Fix undefined data race condition from Relay @include field

### DIFF
--- a/app/components/layout/Navigation/MyBuilds/index.js
+++ b/app/components/layout/Navigation/MyBuilds/index.js
@@ -135,8 +135,8 @@ class MyBuilds extends React.Component<Props, State> {
 
     // Finally, update the state
     this.setCachedState({
-      scheduledBuildsCount: viewer.scheduledBuilds.count,
-      runningBuildsCount: viewer.runningBuilds.count
+      scheduledBuildsCount: (viewer.scheduledBuilds ? viewer.scheduledBuilds.count : 0),
+      runningBuildsCount: (viewer.runningBuilds ? viewer.runningBuilds.count : 0)
     });
   }
 


### PR DESCRIPTION
Need to guard against `undefined` when accessing `viewer.scheduledBuilds` & `viewer.runningBuilds`. Because we’re selectively `@include`-ing these fields there appears to be a potential race condition around them being present.

<img width="901" alt="screen shot 2018-10-26 at 3 43 21 pm" src="https://user-images.githubusercontent.com/18076/47545074-0fb85480-d936-11e8-9f2a-d8c5c4cc7b9d.png">
