### PR TITLE
Codemod for re-writing all our relative paths to ones resolved by “app/”

### DIFF
--- a/codemods/no-relative-required.js
+++ b/codemods/no-relative-required.js
@@ -1,0 +1,42 @@
+import path, {resolve, normalize, relative, dirname, parse} from 'path';
+
+export const parser = 'flow';
+
+function isRelativePath(path) {
+  return path.slice(0, 3) === '../';
+}
+
+// This codemod rewrites relative imports to 'absolute', module style imports.
+export default function removeRelativeImports(file, api, options) {
+  const {dir: fileDir} = parse(file.path)
+  const {jscodeshift} = api;
+  const printOptions = options.printOptions || {quote: 'single'};
+  const root = jscodeshift(file.source)
+  const nodesToUpdate = new Set();
+
+  root
+    .find(jscodeshift.ImportDeclaration)
+    .find(jscodeshift.Literal)
+    .filter(node => isRelativePath(node.value.value))
+    .forEach(path => nodesToUpdate.add(path));
+
+  root
+    .find(jscodeshift.ExportNamedDeclaration)
+    .filter(path => path.value.source !== null)
+    .find(jscodeshift.Literal)
+    .filter(node => isRelativePath(node.value.value))
+    .forEach(path => nodesToUpdate.add(path));
+
+  root
+    .find(jscodeshift.ExportAllDeclaration)
+    .find(jscodeshift.Literal)
+    .filter(node => isRelativePath(node.value.value))
+    .forEach(path => nodesToUpdate.add(path));
+
+  nodesToUpdate.forEach(node => {
+    const newPath = normalize(path.join(fileDir, node.value.value));
+    jscodeshift(node).replaceWith(() => jscodeshift.literal(newPath));
+  });
+
+  return nodesToUpdate.size ? root.toSource(printOptions) : null;
+};

--- a/codemods/no-relative-required.js
+++ b/codemods/no-relative-required.js
@@ -1,4 +1,4 @@
-import path, {resolve, normalize, relative, dirname, parse} from 'path';
+import path, { normalize, parse } from 'path';
 
 export const parser = 'flow';
 
@@ -8,35 +8,35 @@ function isRelativePath(path) {
 
 // This codemod rewrites relative imports to 'absolute', module style imports.
 export default function removeRelativeImports(file, api, options) {
-  const {dir: fileDir} = parse(file.path)
-  const {jscodeshift} = api;
-  const printOptions = options.printOptions || {quote: 'single'};
-  const root = jscodeshift(file.source)
+  const { dir: fileDir } = parse(file.path);
+  const { jscodeshift } = api;
+  const printOptions = options.printOptions || { quote: 'single' };
+  const root = jscodeshift(file.source);
   const nodesToUpdate = new Set();
 
   root
     .find(jscodeshift.ImportDeclaration)
     .find(jscodeshift.Literal)
-    .filter(node => isRelativePath(node.value.value))
-    .forEach(path => nodesToUpdate.add(path));
+    .filter((node) => isRelativePath(node.value.value))
+    .forEach((path) => nodesToUpdate.add(path));
 
   root
     .find(jscodeshift.ExportNamedDeclaration)
-    .filter(path => path.value.source !== null)
+    .filter((path) => path.value.source !== null)
     .find(jscodeshift.Literal)
-    .filter(node => isRelativePath(node.value.value))
-    .forEach(path => nodesToUpdate.add(path));
+    .filter((node) => isRelativePath(node.value.value))
+    .forEach((path) => nodesToUpdate.add(path));
 
   root
     .find(jscodeshift.ExportAllDeclaration)
     .find(jscodeshift.Literal)
-    .filter(node => isRelativePath(node.value.value))
-    .forEach(path => nodesToUpdate.add(path));
+    .filter((node) => isRelativePath(node.value.value))
+    .forEach((path) => nodesToUpdate.add(path));
 
-  nodesToUpdate.forEach(node => {
+  nodesToUpdate.forEach((node) => {
     const newPath = normalize(path.join(fileDir, node.value.value));
     jscodeshift(node).replaceWith(() => jscodeshift.literal(newPath));
   });
 
   return nodesToUpdate.size ? root.toSource(printOptions) : null;
-};
+}


### PR DESCRIPTION
Had this lying around from a previous project. I won’t run it just yet as it touches ~134 files, but I’ll add it here for visibility and look to run it soon and then follow up with another PR.

You can test it out locally using the following command from the root of the Frontend repo.

```
jscodeshift app/ --transform codemods/no-relative-required.js
```