### PR TITLE
Fix loading of CSS variables in JS

### DIFF
--- a/app/components/audit_log/row.js
+++ b/app/components/audit_log/row.js
@@ -14,7 +14,7 @@ import AuditLogDrawer from './Drawer';
 
 import { indefiniteArticleFor } from '../../lib/words';
 
-import cssVariables from '../../css';
+import cssVariables from '../../css/variables';
 
 const TransitionMaxHeight = styled.div`
   transition: max-height 400ms;

--- a/app/components/shared/TabControl/Tab.js
+++ b/app/components/shared/TabControl/Tab.js
@@ -7,6 +7,8 @@ import styled from 'styled-components';
 
 import Badge from '../Badge';
 
+import cssVariables from '../../../css/variables';
+
 import { formatNumber } from '../../../lib/number';
 
 const ACTIVE_CLASS_NAME = 'active';
@@ -21,12 +23,12 @@ const TabButton = styled(Link).attrs({
   margin-bottom: -1px;
   height: 44px; /* Needed because the badge causes the height to increase */
 
-  &:hover {
-    border-color: #D5EBA4;
-  }
-
   &.${ACTIVE_CLASS_NAME} {
-    border-color: #14CC80;
+    border-color: ${cssVariables['--lime']};
+  }
+  
+  &:hover:not(&.${ACTIVE_CLASS_NAME}) {
+    border-color: ${cssVariables['--light-lime']};
   }
 `;
 

--- a/app/css/index.js
+++ b/app/css/index.js
@@ -1,1 +1,0 @@
-export default require('!css-variables-loader!./main.css');

--- a/app/css/variables.js
+++ b/app/css/variables.js
@@ -1,0 +1,1 @@
+export default require('!css-variables-loader!./variables.css');


### PR DESCRIPTION
Undoes the hardcoding in #679 by fixing the CSS variable importing, by only importing `variables.css` file, which is probably clearer and faster anyhow.