### PR TITLE
Don't show the org as "current" in the nav if it requires SSO

### DIFF
--- a/app/lib/RelayPreloader.js
+++ b/app/lib/RelayPreloader.js
@@ -170,6 +170,7 @@ const QUERIES = {
         permissions {
           pipelineView {
             allowed
+            code
           }
           agentView {
             allowed


### PR DESCRIPTION
Not very exciting... This tweaks the behaviour around rendering the "current" so it won't render the org as "current" if it needs SSO.

This is to keep the behaviour consistent to when you're not part of the org to begin with.