### PR TITLE
Allow overriding public path dynamically

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,5 +1,7 @@
 // @flow
 
+import './public-path';
+
 import React from 'react';
 import Relay from 'react-relay/classic';
 import reactRender from './lib/reactRenderer';

--- a/app/public-path.js
+++ b/app/public-path.js
@@ -1,0 +1,9 @@
+/* global __webpack_public_path__:true */
+/* exported __webpack_public_path__ */
+
+// Allow overriding the webpack public path
+// Must be done in a module so that it is executed before all other imports.
+// See https://webpack.js.org/guides/public-path/#on-the-fly
+if (window._frontendPublicPath) {
+  __webpack_public_path__ = window._frontendPublicPath;
+}


### PR DESCRIPTION
This uses a special webpack variable, `__webpack_public_path__`, to optionally allow dynamically overriding the asset host on the fly at runtime using `window._frontendPublicPath`:

https://webpack.js.org/guides/public-path/#on-the-fly

This means we can use the same assets baked into the Docker image for testing by hosting them in a static directory and overriding the public path, as well as the asset cdn on the production assets, or download and use them locally in development too. I also want to try putting up a cloudfront version of  `buildkite.com` with a static `/_frontend` (and `/assets`, etc) so we can same-domain all the assets and utilise http/2.

It has to be in a separate module imported at the top of the entry point to be effective due to load and execute ordering.

After this PR, the next step will be to get the backend exporting `FRONTEND_HOST` as `window._frontendPublicPath`:

https://github.com/buildkite/buildkite/compare/frontend-dynamic-public-path

Then we can remove knowledge of `FRONTEND_HOST` from webpack entirely:

https://github.com/buildkite/frontend/compare/dynamic-public-path...remove-frontend-host