### PR TITLE
Random visual tweaks to MFA components

### DIFF
--- a/app/components/RecoveryCodeList/index.js
+++ b/app/components/RecoveryCodeList/index.js
@@ -48,25 +48,26 @@ function recoveryCodeText(recoveryCodes: TOTPRecoveryCodes): ?string {
 let saveFileSupported;
 try {
   saveFileSupported = !!new Blob;
-} catch (e) {}
+} catch (exception) {
+  // empty
+}
 
-class RecoveryCodeList extends React.PureComponent<Props> {
+class RecoveryCodeList extends React.PureComponent<Props, State> {
   state = {
     copied: false
   }
 
   render() {
     return (
-      <div className="border border-gray rounded flex items-center justify-center" style={{minHeight: 330}}>
+      <div className="border border-gray rounded flex items-center justify-center" style={{ minHeight: 330 }}>
         {this.props.isLoading ? (
-          <Spinner/>
-        ): this.renderCodes()}
+          <Spinner />
+        ) : this.renderCodes()}
       </div>
     );
   }
 
   renderCodes() {
-
     return (
       <div className="flex-auto">
         <div className="flex justify-center items-center">
@@ -123,7 +124,7 @@ class RecoveryCodeList extends React.PureComponent<Props> {
   };
 
   handleRecoveryCodeDownload = () => {
-    var blob = new Blob([recoveryCodeText(this.props.recoveryCodes)], { type: "text/plain;charset=utf-8" });
+    const blob = new Blob([recoveryCodeText(this.props.recoveryCodes)], { type: "text/plain;charset=utf-8" });
 
     saveAs(blob, "Buildkite Recovery Codes.txt");
   }

--- a/app/components/RecoveryCodeList/index.js
+++ b/app/components/RecoveryCodeList/index.js
@@ -36,9 +36,7 @@ type State = {
   copied: boolean
 };
 
-type TOTPRecoveryCodes = $PropertyType<RecoveryCodes_totp, 'recoveryCodes'>;
-
-function recoveryCodeText(recoveryCodes: TOTPRecoveryCodes): ?string {
+function recoveryCodeText(recoveryCodes: ?RecoveryCodeList_recoveryCodes): ?string {
   if (recoveryCodes && recoveryCodes.codes) {
     return recoveryCodes.codes.reduce((memo, { code }) => memo.concat(code), []).join('\n');
   }

--- a/app/components/RecoveryCodeList/index.js
+++ b/app/components/RecoveryCodeList/index.js
@@ -2,8 +2,11 @@
 
 import React from "react";
 import { createFragmentContainer, graphql } from 'react-relay/compat';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 import styled from 'styled-components';
+import saveAs from 'file-saver';
 import Spinner from 'app/components/shared/Spinner';
+import Button from 'app/components/shared/Button';
 import type { RecoveryCodeList_recoveryCodes } from './__generated__/RecoveryCodeList_recoveryCodes.graphql';
 
 const List = styled.ul`
@@ -29,12 +32,45 @@ type Props = {
   recoveryCodes: ?RecoveryCodeList_recoveryCodes
 };
 
+type State = {
+  copied: boolean
+};
+
+type TOTPRecoveryCodes = $PropertyType<RecoveryCodes_totp, 'recoveryCodes'>;
+
+function recoveryCodeText(recoveryCodes: TOTPRecoveryCodes): ?string {
+  if (recoveryCodes && recoveryCodes.codes) {
+    return recoveryCodes.codes.reduce((memo, { code }) => memo.concat(code), []).join('\n');
+  }
+  return '';
+}
+
+let saveFileSupported;
+try {
+  saveFileSupported = !!new Blob;
+} catch (e) {}
+
 class RecoveryCodeList extends React.PureComponent<Props> {
+  state = {
+    copied: false
+  }
+
   render() {
     return (
-      <div className="flex justify-center items-center" style={{ minHeight: "310px" }}>
-        {this.props.isLoading ? <Spinner /> : (
-          <List className="list-reset center p4">
+      <div className="border border-gray rounded flex items-center justify-center" style={{minHeight: 330}}>
+        {this.props.isLoading ? (
+          <Spinner/>
+        ): this.renderCodes()}
+      </div>
+    );
+  }
+
+  renderCodes() {
+
+    return (
+      <div className="flex-auto">
+        <div className="flex justify-center items-center">
+          <List className="list-reset center">
             {(this.props.recoveryCodes && this.props.recoveryCodes.codes) ? (
               this.props.recoveryCodes.codes.map(({ code, consumed }) => (
                 <ListItem key={code}>
@@ -47,9 +83,49 @@ class RecoveryCodeList extends React.PureComponent<Props> {
               ))
             ) : null}
           </List>
-        )}
+        </div>
+
+        <div className="flex justify-center border-top border-gray p2">
+          <CopyToClipboard
+            text={recoveryCodeText(this.props.recoveryCodes)}
+            onCopy={this.handleRecoveryCodeCopy}
+          >
+            <Button outline={true} theme="default" disabled={this.state.copied}>
+              {this.state.copied
+                ? 'Copied to Clipboard!'
+                : 'Copy to Clipboard'}
+            </Button>
+          </CopyToClipboard>
+
+          {saveFileSupported ? (
+            <Button
+              outline={true}
+              theme="default"
+              className="ml2"
+              onClick={this.handleRecoveryCodeDownload}
+            >
+              Download
+            </Button>
+          ) : null}
+        </div>
       </div>
     );
+  }
+
+  handleRecoveryCodeCopy = (_text, result) => {
+    if (!result) {
+      alert('We couldnʼt put this on your clipboard for you, please copy it manually!');
+    }
+    this.setState({ copied: true });
+    setTimeout(() => {
+      this.setState({ copied: false });
+    }, 1000);
+  };
+
+  handleRecoveryCodeDownload = () => {
+    var blob = new Blob([recoveryCodeText(this.props.recoveryCodes)], { type: "text/plain;charset=utf-8" });
+
+    saveAs(blob, "Buildkite Recovery Codes.txt");
   }
 }
 

--- a/app/components/user/TwoFactor/RecoveryCodes/index.js
+++ b/app/components/user/TwoFactor/RecoveryCodes/index.js
@@ -26,7 +26,7 @@ class RecoveryCodes extends React.PureComponent<Props, State> {
   render() {
     return (
       <div className="p4">
-        <h2 className="m0 h2 semi-bold mb5">Current Recovery Codes</h2>
+        <h2 className="m0 h2 semi-bold mb5">Recovery Codes</h2>
         <p>Recovery codes are the only way to get access to your account if you lose access to your authenticator application.</p>
         <p>Recovery codes should be treated like your password. We suggest saving them in a secure password manager, or printing them and storing them somewhere safe.</p>
         <RecoveryCodeList

--- a/app/components/user/TwoFactor/RecoveryCodes/index.js
+++ b/app/components/user/TwoFactor/RecoveryCodes/index.js
@@ -2,9 +2,7 @@
 
 import * as React from 'react';
 import { createFragmentContainer, graphql, commitMutation } from 'react-relay/compat';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Button from 'app/components/shared/Button';
-import Panel from 'app/components/shared/Panel';
 import RecoveryCodeList from 'app/components/RecoveryCodeList';
 import type { RecoveryCodes_totp } from './__generated__/RecoveryCodes_totp.graphql';
 import type { RelayProp } from 'react-relay';
@@ -19,15 +17,6 @@ type State = {
   generatingNewCodes: boolean
 };
 
-type TOTPRecoveryCodes = $PropertyType<RecoveryCodes_totp, 'recoveryCodes'>;
-
-function recoveryCodeText(recoveryCodes: TOTPRecoveryCodes): ?string {
-  if (recoveryCodes && recoveryCodes.codes) {
-    return recoveryCodes.codes.reduce((memo, { code }) => memo.concat(code), []).join('\n');
-  }
-  return '';
-}
-
 class RecoveryCodes extends React.PureComponent<Props, State> {
   state = {
     copiedRecoveryCodes: false,
@@ -40,29 +29,15 @@ class RecoveryCodes extends React.PureComponent<Props, State> {
         <h2 className="m0 h2 semi-bold mb5">Current Recovery Codes</h2>
         <p>Recovery codes are used if you lose access to your code generator.</p>
         <p>These codes should be treated just like your password. Weʼd suggest saving them into a secure password manager.</p>
-        <Panel className="mb3">
-          <Panel.Section>
-            <CopyToClipboard
-              text={recoveryCodeText(this.props.totp.recoveryCodes)}
-              onCopy={this.handleRecoveryCodeCopy}
-            >
-              <Button theme="default" outline={true}>
-                {this.state.copiedRecoveryCodes
-                  ? 'Copied!'
-                  : 'Copy'}
-              </Button>
-            </CopyToClipboard>
-            <RecoveryCodeList
-              recoveryCodes={this.props.totp.recoveryCodes}
-              isLoading={this.state.generatingNewCodes}
-            />
-          </Panel.Section>
-        </Panel>
-        <h2 className="m0 h4 semi-bold mb5">Generate New Recovery Codes</h2>
+        <RecoveryCodeList
+          recoveryCodes={this.props.totp.recoveryCodes}
+          isLoading={this.state.generatingNewCodes}
+        />
+        <h2 className="m0 mt3 h4 semi-bold mb5">Generate New Recovery Codes</h2>
         <p>When you generate new recovery codes, your current codes will be removed. Please ensure you copy your new recovery codes after they’ve been generated.</p>
         <Button
           className="col-12"
-          theme="warning"
+          theme="default"
           outline={true}
           onClick={this.handleRegenerateRecoveryCodes}
           loading={this.state.generatingNewCodes && "Generating New Recovery Codes…"}
@@ -73,13 +48,6 @@ class RecoveryCodes extends React.PureComponent<Props, State> {
       </div>
     );
   }
-
-  handleRecoveryCodeCopy = (_text, result) => {
-    if (!result) {
-      alert('We couldnʼt put this on your clipboard for you, please copy it manually!');
-    }
-    this.setState({ copiedRecoveryCodes: true });
-  };
 
   handleRegenerateRecoveryCodes = () => {
     this.setState({ generatingNewCodes: true });

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
@@ -16,7 +16,6 @@ type ValidationError = {
 };
 
 type Props = {
-  hasActivatedTotp: boolean,
   onActivateOtp: (token: string, callback?: () => void) => void,
   provisioningUri: string
 };

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
@@ -63,7 +63,7 @@ export default class TwoFactorConfigureActivate extends React.PureComponent<Prop
                   bgColor="transparent"
                   width="260"
                   height="260"
-                  className="block my4 mx-auto"
+                  className="block mx-auto"
                   level="H" // approx 30% error correction
                   style={{ maxWidth: '100%' }}
                   value={this.props.provisioningUri}

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
@@ -51,7 +51,7 @@ export default class TwoFactorConfigureActivate extends React.PureComponent<Prop
         </p>
         <Panel className="mb3">
           <div className="flex justify-center items-center">
-            <div class="mt1 mb3">
+            <div className="mt1 mb3">
               <figure style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 <img style={{ position: 'absolute' }} src={buildkiteqr} />
                 <QRCode
@@ -67,7 +67,7 @@ export default class TwoFactorConfigureActivate extends React.PureComponent<Prop
                 />
               </figure>
               <div className="dark-gray center mt2">
-                Can’t use the barcode?<br/>Type in this secret key instead: <span className="monospace rounded" style={{fontSize: 13}}>{provisioningUriSecret}</span>
+                Can’t use the barcode?<br />Type in this secret key instead: <span className="monospace rounded" style={{ fontSize: 13 }}>{provisioningUriSecret}</span>
               </div>
             </div>
           </div>

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from "react";
-import { CopyToClipboard } from 'react-copy-to-clipboard';
 import QRCode from 'qrcode.react';
 import { parseUrl } from 'query-string';
 import ValidationErrors from 'app/lib/ValidationErrors';
@@ -48,52 +47,30 @@ export default class TwoFactorConfigureActivate extends React.PureComponent<Prop
     return (
       <React.Fragment>
         <p>
-          To activate two-factor authentication, scan this
-          QR Code with your authenticator application, then enter the generated One Time Password below.
+          To activate two-factor authentication, scan this barcode with your authenticator application, then enter the generated One Time Password below.
         </p>
         <Panel className="mb3">
-          <div className="flex justify-center items-center" style={{ minHeight: "300px" }}>
-            <figure style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <img style={{ position: 'absolute' }} src={buildkiteqr} />
-              <QRCode
-                renderAs="svg"
-                fgColor="currentColor"
-                bgColor="transparent"
-                width="260"
-                height="260"
-                className="block mx-auto"
-                level="H" // approx 30% error correction
-                style={{ maxWidth: '100%' }}
-                value={this.props.provisioningUri}
-              />
-            </figure>
-          </div>
-          <Panel.Section>
-            <div>
-              <strong>Secret Key</strong>
-            </div>
-            <div className="dark-gray mb1">
-              Can’t use the QR code? You can use this secret key instead.
-            </div>
-            <div className="flex">
-              <div className="input mr2 monospace" style={{ lineHeight: 1.8 }}>
-                {provisioningUriSecret}
+          <div className="flex justify-center items-center">
+            <div class="mt1 mb3">
+              <figure style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <img style={{ position: 'absolute' }} src={buildkiteqr} />
+                <QRCode
+                  renderAs="svg"
+                  fgColor="currentColor"
+                  bgColor="transparent"
+                  width="260"
+                  height="260"
+                  className="block mx-auto"
+                  level="H" // approx 30% error correction
+                  style={{ maxWidth: '100%' }}
+                  value={this.props.provisioningUri}
+                />
+              </figure>
+              <div className="dark-gray center mt2">
+                Can’t use the barcode?<br/>Type in this secret key instead: <span className="monospace rounded" style={{fontSize: 13}}>{provisioningUriSecret}</span>
               </div>
-              <CopyToClipboard
-                text={provisioningUriSecret}
-                onCopy={this.handleOTPSecretCopy}
-              >
-                <Button
-                  theme="default"
-                  outline={true}
-                  loading={this.state.copiedOTPSecretKey && "Copied!"}
-                  disabled={this.state.copiedOTPSecretKey}
-                >
-                  Copy
-                </Button>
-              </CopyToClipboard>
             </div>
-          </Panel.Section>
+          </div>
         </Panel>
         <div className="py3 mb3">
           <TokenCodeInput
@@ -136,12 +113,4 @@ export default class TwoFactorConfigureActivate extends React.PureComponent<Prop
       });
     });
   }
-
-  handleOTPSecretCopy = (_text: string, result: boolean) => {
-    if (!result) {
-      alert('We couldnʼt copy this to your clipboard, please copy it manually!');
-      return;
-    }
-    this.setState({ copiedOTPSecretKey: true });
-  };
 }

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
@@ -49,7 +49,7 @@ export default class TwoFactorConfigureActivate extends React.PureComponent<Prop
     return (
       <React.Fragment>
         <p>
-          To {this.props.hasActivatedTotp ? 'reconfigure' : 'activate'} two-factor authentication, scan this
+          To activate two-factor authentication, scan this
           QR Code with your Authenticator Application, and then confirm.
         </p>
         <Panel className="mb3">

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
@@ -53,24 +53,22 @@ export default class TwoFactorConfigureActivate extends React.PureComponent<Prop
           QR Code with your authenticator application, then enter the generated One Time Password below.
         </p>
         <Panel className="mb3">
-          <Panel.Section>
-            <div className="flex justify-center items-center" style={{ minHeight: "300px" }}>
-              <figure style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <img style={{ position: 'absolute' }} src={buildkiteqr} />
-                <QRCode
-                  renderAs="svg"
-                  fgColor="currentColor"
-                  bgColor="transparent"
-                  width="260"
-                  height="260"
-                  className="block mx-auto"
-                  level="H" // approx 30% error correction
-                  style={{ maxWidth: '100%' }}
-                  value={this.props.provisioningUri}
-                />
-              </figure>
-            </div>
-          </Panel.Section>
+          <div className="flex justify-center items-center" style={{ minHeight: "300px" }}>
+            <figure style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <img style={{ position: 'absolute' }} src={buildkiteqr} />
+              <QRCode
+                renderAs="svg"
+                fgColor="currentColor"
+                bgColor="transparent"
+                width="260"
+                height="260"
+                className="block mx-auto"
+                level="H" // approx 30% error correction
+                style={{ maxWidth: '100%' }}
+                value={this.props.provisioningUri}
+              />
+            </figure>
+          </div>
           <Panel.Section>
             <div>
               <strong>Secret Key</strong>

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureRecoveryCodes/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureRecoveryCodes/index.js
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import { createFragmentContainer, graphql } from 'react-relay/compat';
-import Panel from 'app/components/shared/Panel';
 import Button from 'app/components/shared/Button';
 import RecoveryCodeList from 'app/components/RecoveryCodeList';
 import type {

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureRecoveryCodes/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureRecoveryCodes/index.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from "react";
-import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { createFragmentContainer, graphql } from 'react-relay/compat';
 import Panel from 'app/components/shared/Panel';
 import Button from 'app/components/shared/Button';
@@ -13,18 +12,15 @@ import type {
 type Props = {
   onCreateNewTotp: (callback?: () => void) => void,
   onNextStep: () => void,
-  recoveryCodes: recoveryCodes,
-  hasActivatedTotp: boolean
+  recoveryCodes: recoveryCodes
 };
 
 type State = {
-  isLoading: boolean,
-  didCopyRecoveryCodes: boolean
+  isLoading: boolean
 };
 
 class TwoFactorConfigureRecoveryCodes extends React.PureComponent<Props, State> {
   state = {
-    didCopyRecoveryCodes: false,
     isLoading: true
   }
 
@@ -41,33 +37,12 @@ class TwoFactorConfigureRecoveryCodes extends React.PureComponent<Props, State> 
           Recovery codes are used if you lose access to your OTP generator application. They’re the only way to get
           back into your account if you lose access to your Authenticator Application once it’s configured.
         </p>
-        <Panel className="mb3 orange border-orange">
-          <Panel.Section>
-            <div>
-              {this.props.hasActivatedTotp ? this.renderReconfigure() : this.renderConfigure()}
-            </div>
-          </Panel.Section>
-        </Panel>
-        <Panel className="mb3">
-          <Panel.Section>
-            <div className="flex justify-between">
-              <CopyToClipboard text={this.recoveryCodeText()} onCopy={this.handleRecoveryCodeCopy}>
-                <Button
-                  theme="success"
-                  disabled={this.state.isLoading}
-                >
-                  {this.state.didCopyRecoveryCodes ? 'Copied!' : 'Copy'}
-                </Button>
-              </CopyToClipboard>
-            </div>
-            <RecoveryCodeList
-              recoveryCodes={this.props.recoveryCodes}
-              isLoading={this.state.isLoading}
-            />
-          </Panel.Section>
-        </Panel>
+        <RecoveryCodeList
+          recoveryCodes={this.props.recoveryCodes}
+          isLoading={this.state.isLoading}
+        />
         <Button
-          className="col-12"
+          className="col-12 mt3"
           disabled={this.state.isLoading}
           theme="success"
           onClick={this.props.onNextStep}
@@ -83,14 +58,6 @@ class TwoFactorConfigureRecoveryCodes extends React.PureComponent<Props, State> 
       return '';
     }
     return this.props.recoveryCodes.codes.map(({ code }) => code).join('\n');
-  }
-
-  handleRecoveryCodeCopy = (_text: string, result: boolean) => {
-    if (!result) {
-      alert('We couldnʼt put this on your clipboard for you, please copy it manually!');
-      return;
-    }
-    this.setState({ didCopyRecoveryCodes: true });
   }
 
   renderReconfigure = () => {

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureRecoveryCodes/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureRecoveryCodes/index.js
@@ -33,9 +33,8 @@ class TwoFactorConfigureRecoveryCodes extends React.PureComponent<Props, State> 
   render() {
     return (
       <React.Fragment>
-        <p>
-          Recovery codes are the only way to get access to your account if you lose access to your authenticator application.
-        </p>
+        <p>Recovery codes are the only way to login to your account if you lose access to your authenticator application.</p>
+        <p>They should be treated like your password, so we suggest saving them in a secure password manager, or printing them and storing them somewhere safe.</p>
         <RecoveryCodeList
           recoveryCodes={this.props.recoveryCodes}
           isLoading={this.state.isLoading}

--- a/app/components/user/TwoFactor/TwoFactorConfigure/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/index.js
@@ -107,7 +107,7 @@ class TwoFactorConfigure extends React.Component<Props, State> {
 
   render() {
     return (
-      <div className="p3">
+      <div className="p4">
         <PageHeader>
           <PageHeader.Title>
             {this.getStepTitle()}

--- a/app/components/user/TwoFactor/TwoFactorConfigure/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/index.js
@@ -93,13 +93,6 @@ class TwoFactorConfigure extends React.Component<Props, State> {
     return 'Step 2: Configure Authenticator Application';
   }
 
-  getStepNotice(): string {
-    if (this.state.step === STEPS.RECOVERY_CODES && this.hasActivatedTotp) {
-      return "Youʼre about to reconfigure two-factor authentication. \
-      This will invalidate your existing configuration and recovery codes."
-    }
-  }
-
   componentWillUnmount() {
     if (this.state.newTotpConfig && !this.state.didActivateNewOtp) {
       TotpDeleteMutation({
@@ -116,12 +109,12 @@ class TwoFactorConfigure extends React.Component<Props, State> {
   render() {
     return (
       <div className="p4">
-        {this.renderStepNotice()}
-        <div class="flex items-top mb3">
-          <div class="flex-auto">
-            <div class="flex">
+        {this.renderReconfigureNotice()}
+        <div className="flex items-top mb3">
+          <div className="flex-auto">
+            <div className="flex">
               <Icon icon="two-factor" className="mr1" />
-              <h1 className="m0 h2 semi-bold">Setup Two-Factor Authentication</h1>
+              <h1 className="m0 h2 semi-bold">{this.hasActivatedTotp ? "Reconfigure" : "Setup"} Two-Factor Authentication</h1>
             </div>
             <h2 className="m0 mt3 h4 bold mb5">{this.getStepTitle()}</h2>
           </div>
@@ -137,14 +130,12 @@ class TwoFactorConfigure extends React.Component<Props, State> {
     );
   }
 
-  renderStepNotice() {
-    const notice = this.getStepNotice();
-
-    if (notice) {
+  renderReconfigureNotice() {
+    if (this.state.step === STEPS.RECOVERY_CODES && this.hasActivatedTotp) {
       return (
-        <div class="mb4 border orange rounded border-orange p3">
-          <div class="bold mb1">Heads up!</div>
-          <div>{notice}</div>
+        <div className="mb4 border orange rounded border-orange p3">
+          <div className="bold">Youʼre about to reconfigure two-factor authentication.</div>
+          <div>This will invalidate your existing configuration and recovery codes.</div>
         </div>
       )
     }

--- a/app/components/user/TwoFactor/TwoFactorConfigure/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/index.js
@@ -4,6 +4,7 @@ import * as React from "react";
 import { createRefetchContainer, graphql, fetchQuery, commitMutation } from 'react-relay/compat';
 import GraphQLErrors from 'app/constants/GraphQLErrors';
 import PageHeader from "app/components/shared/PageHeader";
+import Icon from "app/components/shared/Icon";
 import WorkflowProgress from "app/components/shared/WorkflowProgress";
 import TwoFactorConfigureRecoveryCodes from './TwoFactorConfigureRecoveryCodes';
 import TwoFactorConfigureActivate from './TwoFactorConfigureActivate';
@@ -89,7 +90,7 @@ class TwoFactorConfigure extends React.Component<Props, State> {
     if (this.state.step === STEPS.RECOVERY_CODES) {
       return 'Step 1: Save Recovery Codes';
     }
-    return 'Step 2: Activate Authenticator Application';
+    return 'Step 2: Configure Authenticator Application';
   }
 
   getStepNotice(): string {
@@ -116,8 +117,14 @@ class TwoFactorConfigure extends React.Component<Props, State> {
     return (
       <div className="p4">
         {this.renderStepNotice()}
-        <div class="flex items-center mb3">
-          <h1 className="m0 h2 semi-bold flex-auto">{this.getStepTitle()}</h1>
+        <div class="flex items-top mb3">
+          <div class="flex-auto">
+            <div class="flex">
+              <Icon icon="two-factor" className="mr1" />
+              <h1 className="m0 h2 semi-bold">Activate Two-Factor Authentication</h1>
+            </div>
+            <h2 className="m0 mt3 h4 bold mb5">{this.getStepTitle()}</h2>
+          </div>
           <WorkflowProgress
             stepCount={this.steps.length}
             currentStepIndex={this.currentStepIndex(this.state.step)}

--- a/app/components/user/TwoFactor/TwoFactorConfigure/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/index.js
@@ -87,9 +87,16 @@ class TwoFactorConfigure extends React.Component<Props, State> {
 
   getStepTitle(): string {
     if (this.state.step === STEPS.RECOVERY_CODES) {
-      return 'Recovery Codes';
+      return 'Step 1: Save Recovery Codes';
     }
-    return 'Activate Authenticator Application';
+    return 'Step 2: Activate Authenticator Application';
+  }
+
+  getStepNotice(): string {
+    if (this.state.step === STEPS.RECOVERY_CODES && this.hasActivatedTotp) {
+      return "Youʼre about to reconfigure two-factor authentication. \
+      This will invalidate your existing configuration and recovery codes."
+    }
   }
 
   componentWillUnmount() {
@@ -108,22 +115,32 @@ class TwoFactorConfigure extends React.Component<Props, State> {
   render() {
     return (
       <div className="p4">
-        <PageHeader>
-          <PageHeader.Title>
-            {this.getStepTitle()}
-          </PageHeader.Title>
-          <PageHeader.Menu>
-            <WorkflowProgress
-              stepCount={this.steps.length}
-              currentStepIndex={this.currentStepIndex(this.state.step)}
-            />
-          </PageHeader.Menu>
-        </PageHeader>
+        {this.renderStepNotice()}
+        <div class="flex items-center mb3">
+          <h1 className="m0 h2 semi-bold flex-auto">{this.getStepTitle()}</h1>
+          <WorkflowProgress
+            stepCount={this.steps.length}
+            currentStepIndex={this.currentStepIndex(this.state.step)}
+          />
+        </div>
         <div>
           {this.renderCurrentStep()}
         </div>
       </div>
     );
+  }
+
+  renderStepNotice() {
+    const notice = this.getStepNotice();
+
+    if (notice) {
+      return (
+        <div class="mb4 border orange rounded border-orange p3">
+          <div class="bold mb1">Heads up!</div>
+          <div>{notice}</div>
+        </div>
+      )
+    }
   }
 
   renderCurrentStep() {
@@ -134,7 +151,6 @@ class TwoFactorConfigure extends React.Component<Props, State> {
             onNextStep={this.handleNextStep}
             recoveryCodes={this.recoveryCodes}
             onCreateNewTotp={this.handleCreateNewTotp}
-            hasActivatedTotp={this.hasActivatedTotp}
           />
         );
       case STEPS.ACTIVATE_TOTP:

--- a/app/components/user/TwoFactor/TwoFactorConfigure/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/index.js
@@ -121,7 +121,7 @@ class TwoFactorConfigure extends React.Component<Props, State> {
           <div class="flex-auto">
             <div class="flex">
               <Icon icon="two-factor" className="mr1" />
-              <h1 className="m0 h2 semi-bold">Activate Two-Factor Authentication</h1>
+              <h1 className="m0 h2 semi-bold">Setup Two-Factor Authentication</h1>
             </div>
             <h2 className="m0 mt3 h4 bold mb5">{this.getStepTitle()}</h2>
           </div>

--- a/app/components/user/TwoFactor/TwoFactorConfigure/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/index.js
@@ -3,7 +3,6 @@
 import * as React from "react";
 import { createRefetchContainer, graphql, fetchQuery, commitMutation } from 'react-relay/compat';
 import GraphQLErrors from 'app/constants/GraphQLErrors';
-import PageHeader from "app/components/shared/PageHeader";
 import Icon from "app/components/shared/Icon";
 import WorkflowProgress from "app/components/shared/WorkflowProgress";
 import TwoFactorConfigureRecoveryCodes from './TwoFactorConfigureRecoveryCodes';
@@ -137,7 +136,7 @@ class TwoFactorConfigure extends React.Component<Props, State> {
           <div className="bold">Youʼre about to reconfigure two-factor authentication.</div>
           <div>This will invalidate your existing configuration and recovery codes.</div>
         </div>
-      )
+      );
     }
   }
 

--- a/app/components/user/TwoFactor/index.js
+++ b/app/components/user/TwoFactor/index.js
@@ -163,7 +163,7 @@ class TwoFactor extends React.PureComponent<Props, State> {
                     </Panel>
                     <Dialog
                       isOpen={this.state.configureDialogOpen}
-                      width={600}
+                      width={540}
                       onRequestClose={this.handleConfigureDialogClose}
                     >
                       <TwoFactorConfigure

--- a/app/components/user/TwoFactor/index.js
+++ b/app/components/user/TwoFactor/index.js
@@ -134,7 +134,7 @@ class TwoFactor extends React.PureComponent<Props, State> {
                       <Panel.Section>
                         <header className="mb1 flex align-center">
                           <ActiveStateBadge active={this.hasTotp()} />
-                          <h3 className="h3 m0">Recovery Code</h3>
+                          <h3 className="h3 m0">Recovery Codes</h3>
                           {this.hasTotp() ? <span className="ml3">{this.recoveryCodesRemaining} remaining</span> : null}
                         </header>
                         <div>
@@ -162,7 +162,7 @@ class TwoFactor extends React.PureComponent<Props, State> {
                     </Panel>
                     <Dialog
                       isOpen={this.state.configureDialogOpen}
-                      width={540}
+                      width={570}
                       onRequestClose={this.handleConfigureDialogClose}
                     >
                       <TwoFactorConfigure
@@ -183,7 +183,7 @@ class TwoFactor extends React.PureComponent<Props, State> {
                     {this.props.viewer.totp ? (
                       <Dialog
                         isOpen={this.state.recoveryCodeDialogOpen}
-                        width={540}
+                        width={570}
                         onRequestClose={this.handleRecoveryCodeDialogClose}
                       >
                         <RecoveryCodes

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "escape-html": "1.0.3",
     "eventemitter3": "3.1.0",
     "fetch-jsonp": "1.1.3",
+    "file-saver": "^2.0.0-rc.4",
     "global": "4.3.2",
     "graphql": "14.0.2",
     "graphql-relay": "0.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6564,6 +6564,11 @@ file-loader@2.0.0, file-loader@^2.0.0:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
+file-saver@^2.0.0-rc.4:
+  version "2.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.0-rc.4.tgz#aaefae8145193257050a0d92d90941516b4b759b"
+  integrity sha512-6Runcc5CffLF9Rpf/MLc3db9eOi2f7b+DvBXpSpJ/hEy+olM+Bw0kx/bOnnp1X4QgOkFZe8ojrM4iZ0JCWmVMQ==
+
 file-system-cache@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/file-system-cache/-/file-system-cache-1.0.5.tgz#84259b36a2bbb8d3d6eb1021d3132ffe64cfff4f"


### PR DESCRIPTION
A bunch of random stuff in here! I tightened some stuff up and made the recovery code boxes consistent between viewing and saving them.

A few notable changes:

- [x] Use the rad icon in the dialogs (because it looks rad)
- [x] Show "Step 1", "Step 2"
- [x] Added a "Download" button for recovery codes
- [x] Moved the "you're reconfiguring" message to the top of the dialog

### Before

<img width="250" alt="image" src="https://user-images.githubusercontent.com/25882/47845567-590a1780-de00-11e8-892e-53ffc4fe5147.png" align="left" >
<img width="250" alt="image" src="https://user-images.githubusercontent.com/25882/47845593-64f5d980-de00-11e8-96a1-7fd8755b66fc.png" align="left" >
<img width="250" alt="image" src="https://user-images.githubusercontent.com/25882/47845604-7212c880-de00-11e8-8f1e-e175261fdc21.png" align="left" >
<img width="250" alt="image" src="https://user-images.githubusercontent.com/25882/47845614-76d77c80-de00-11e8-88ed-e70920cd40ed.png" >

### After

<img width="250" alt="image" src="https://user-images.githubusercontent.com/25882/47845742-c027cc00-de00-11e8-8399-ddfc498e0a2b.png" align="left"  >
<img width="250" alt="image" src="https://user-images.githubusercontent.com/25882/47845747-c453e980-de00-11e8-9c8f-76830dac1c9d.png" align="left"  >
<img width="250" alt="image" src="https://user-images.githubusercontent.com/25882/47845772-d6ce2300-de00-11e8-992e-f70bac430586.png" align="left"  >
<img width="250" alt="image" src="https://user-images.githubusercontent.com/25882/47845776-da61aa00-de00-11e8-9cbc-6aacc1140e78.png">