### PR TITLE
Sharpen and minify the BK QR image

### DIFF
--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/buildkite.svg
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/buildkite.svg
@@ -1,16 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="100px" height="70px" viewBox="0 0 100 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 51.1 (57501) - http://www.bohemiancoding.com/sketch -->
-    <title>buildkite</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="buildkite" fill-rule="nonzero">
-            <polygon id="Combined-Shape" fill="#FFFFFF" points="80 5 85 5 85 10 100 10 100 60 85 60 85 65 80 65 80 70 60 70 60 45 55 45 55 50 45 50 45 55 35 55 25 55 25 50 15 50 15 45 0 45 0 0 15 0 15 5 25 5 25 10 35 10 45 10 45 5 55 5 55 0 60 0 80 0"></polygon>
-            <polygon id="Combined-Shape" fill="#30F2A2" points="25 15 35 15 35 50 25 50 25 45 15 45 15 40 10 40 5 40 5 5 10 5 15 5 15 10 25 10"></polygon>
-            <polygon id="Combined-Shape" fill="#30F2A2" points="85 15 95 15 95 50 85 50 85 45 75 45 75 40 70 40 65 40 65 5 70 5 75 5 75 10 85 10"></polygon>
-            <polygon id="Combined-Shape" fill="#14CC80" points="55 40 55 45 45 45 45 50 35 50 35 15 45 15 45 10 55 10 55 5 65 5 65 40"></polygon>
-            <polygon id="Combined-Shape" fill="#14CC80" points="85 55 85 60 75 60 75 65 65 65 65 35 75 35 75 30 85 30 85 25 95 25 95 55"></polygon>
-        </g>
-    </g>
-</svg>
+<svg height="70" width="100" viewBox="0 0 100 70" xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges"><g fill="none"><path d="m80 5h5v5h15v50h-15v5h-5v5h-20v-25h-5v5h-10v5h-10-10v-5h-10v-5h-15v-45h15v5h10v5h10 10v-5h10v-5h5 20z" fill="#fff"/><path d="m25 15h10v35h-10v-5h-10v-5h-5-5v-35h5 5v5h10z" fill="#30f2a2"/><path d="m85 15h10v35h-10v-5h-10v-5h-5-5v-35h5 5v5h10z" fill="#30f2a2"/><g fill="#14cc80"><path d="m55 40v5h-10v5h-10v-35h10v-5h10v-5h10v35z"/><path d="m85 55v5h-10v5h-10v-30h10v-5h10v-5h10v30z"/></g></g></svg>

--- a/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
+++ b/app/components/user/TwoFactor/TwoFactorConfigure/TwoFactorConfigureActivate/index.js
@@ -53,7 +53,7 @@ export default class TwoFactorConfigureActivate extends React.PureComponent<Prop
           <div className="flex justify-center items-center">
             <div className="mt1 mb3">
               <figure style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <img style={{ position: 'absolute' }} src={buildkiteqr} />
+                <img style={{ position: 'absolute', width: 102, marginTop: 6 }} src={buildkiteqr} />
                 <QRCode
                   renderAs="svg"
                   fgColor="currentColor"


### PR DESCRIPTION
I noticed the QR image doesn't quite match the code size most of the time:
<img width="279" alt="before-3" src="https://user-images.githubusercontent.com/153/47885353-b5b11500-de88-11e8-875a-a4862b15d668.png">
<img width="305" alt="before-1" src="https://user-images.githubusercontent.com/153/47885350-b47fe800-de88-11e8-8a27-ad607944520b.png">
<img width="279" alt="before-2" src="https://user-images.githubusercontent.com/153/47885351-b5187e80-de88-11e8-9477-4922854e2030.png">

This cleans it up most of the time, and also moves it down a tad (the mark should always sit a bit lower than completely centre):
<img width="281" alt="after-1" src="https://user-images.githubusercontent.com/153/47885361-c06baa00-de88-11e8-9db1-c8bf2ce982b6.png">
<img width="281" alt="after-2" src="https://user-images.githubusercontent.com/153/47885362-c1044080-de88-11e8-9687-59e2fda4ad25.png">
<img width="281" alt="after-3" src="https://user-images.githubusercontent.com/153/47885363-c1044080-de88-11e8-9cda-11fe444da783.png">