### PR TITLE
Make sure HMR always works

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 # PORT=5700
-webpack: NODE_ENV=development ./node_modules/.bin/webpack-dev-server --config webpack/config.js --colors --cache --inline --hot --host "buildkite.localhost" --port "$PORT"
+webpack: NODE_ENV=development FRONTEND_HOST=http://buildkite.localhost:$PORT/ ./node_modules/.bin/webpack-dev-server --config webpack/config.js --colors --cache --inline --hot --host "buildkite.localhost" --port "$PORT"
 
 # PORT=5800 (unused)
 relay: script/watch_graph


### PR DESCRIPTION
Webpack dev server seems to serve slightly different assets to what are compiled by messing with them in middleware, and it needs to talk directly to its own host because it uses socket io or something to do websocket-y hot module reloading. So make sure it always spits out a manifest with a fully-qualified public path.

This should fix some hot-reloading behaviour seen in dev while also still allowing us to build or download frontend assets for local use instead.