### PR TITLE
Remove FRONTEND_HOST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM node:10-stretch
 
 EXPOSE 4890
 
-ENV FRONTEND_HOST=http://buildkite.localhost:4890/_frontend/dist/ \
-    EMOJI_HOST=http://buildkite.localhost/_frontend/vendor/emojis
+ENV EMOJI_HOST=http://buildkite.localhost/_frontend/vendor/emojis
 
 WORKDIR /frontend
 

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 # PORT=5700
-webpack: NODE_ENV=development FRONTEND_HOST=http://buildkite.localhost:$PORT/ ./node_modules/.bin/webpack-dev-server --config webpack/config.js --colors --cache --inline --hot --host "buildkite.localhost" --port "$PORT"
+webpack: NODE_ENV=development yarn run webpack-dev-server --no-progress
 
 # PORT=5800 (unused)
 relay: script/watch_graph

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build: .
     environment:
       - EMOJI_HOST
-      - FRONTEND_HOST
       - BUILDKITE
       - BUILDKITE_COMMIT
       - BUILDKITE_ORGANIZATION_SLUG

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prebuild-production": "yarn run relay-compile",
     "build-production": "NODE_ENV=production webpack --config webpack/config.js --progress --bail",
     "bundle-analyze": "COLLECT_BUNDLE_STATS=true yarn run build-production",
-    "webpack-dev-server": "NODE_ENV=development webpack-dev-server --config webpack/config.js --progress --colors --cache --inline --hot --host buildkite.localhost --port 4890",
+    "webpack-dev-server": "NODE_ENV=development webpack-dev-server --config webpack/config.js --progress --colors --cache --inline --hot --host localhost --port ${PORT:-4890} --output-public-path http://localhost:${PORT:-4890}",
     "storybook": "start-storybook -p $PORT --ci",
     "build-storybook": "build-storybook",
     "build-storybook-sketch": "mkdir -p dist && yarn run html-sketchapp --url 'http://localhost:6006/iframe.html?selectedKind=Sketch&selectedStory=Export' --out-dir dist"

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -3,19 +3,9 @@ const webpack = require('webpack');
 const AssetsPlugin = require('assets-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-// Ensure a FRONTEND_HOST is setup since we embed it in the assets.json file
-if (!process.env.FRONTEND_HOST) {
-  throw "No FRONTEND_HOST set";
-}
-
 // Ensure a NODE_ENV is also present
 if (!process.env.NODE_ENV) {
   throw "No NODE_ENV set";
-}
-
-// The FRONTEND_HOST must end with a /
-if (process.env.FRONTEND_HOST.slice(-1) !== "/") {
-  throw "FRONTEND_HOST must end with a /";
 }
 
 // Ensure a EMOJI_HOST is setup since we need it for emoji
@@ -92,8 +82,7 @@ module.exports = {
   output: {
     filename: `${filenameFormat}.js`,
     chunkFilename: `${chunkFilenameFormat}.js`,
-    path: path.join(__dirname, '..', 'dist'),
-    publicPath: process.env.FRONTEND_HOST
+    path: path.join(__dirname, '..', 'dist')
   },
 
   resolve: {


### PR DESCRIPTION
Remove fixed `$FRONTEND_HOST`. Remove the public path by default, too. We can set a public path using window._frontendPublicPath at runtime now. This makes a manifest with relative URLs:

```json
{
    "" : {
        "js" : [
            "0.chunk.js",
            "1.chunk.js"
        ],
        "jpg" : "ff9cb1e83fd7a9ee6c7e34f43b9a85e4.jpg",
        "png" : "4b65a0c3d4a3c63cc7873be27a9c6cd8.png"
    },
    "app" : {
        "js" : "app.js"
    },
    "emoji" : {
        "js" : "emoji.chunk.js"
    },
    "vendor" : {
        "js" : "vendor.chunk.js"
    }
}
```

But when running webpack dev server it needs to do middleware magic via a separate host, so make sure it always has an explicit public path, which will be output in the manifest, overriding buildkite's default `$FRONTEND_HOST` in development and preserving hot module replacement gear:

```json
{
    "" : {
        "js" : [
            "http://localhost:4890/0.chunk.js",
            "http://localhost:4890/1.chunk.js"
        ],
        "jpg" : "http://localhost:4890/ff9cb1e83fd7a9ee6c7e34f43b9a85e4.jpg",
        "png" : "http://localhost:4890/4b65a0c3d4a3c63cc7873be27a9c6cd8.png"
    },
    "app" : {
        "js" : "http://localhost:4890/app.js"
    },
    "emoji" : {
        "js" : "http://localhost:4890/emoji.chunk.js"
    },
    "vendor" : {
        "js" : "http://localhost:4890/vendor.chunk.js"
    }
}
```

But we'll also be able to download a compiled production asset bundle into `vendor/frontend/dist` including the manifest and it should all work in development or test. 🎉 