### PR TITLE
Remove webpack config sha prefix

### DIFF
--- a/.buildkite/steps/webpack.sh
+++ b/.buildkite/steps/webpack.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Add the SHA1 sum of the webpack file to the host path
-WEBPACK_CONFIG_SHA1=$(openssl sha1 webpack/config.js | sed 's/^.* //')
-FRONTEND_HOST="$FRONTEND_HOST$WEBPACK_CONFIG_SHA1/"
-
-echo "--- :information_desk_person: Appending SHA1 of webpack/config.js to \$FRONTEND_HOST"
-
-echo "\$FRONTEND_HOST is now $FRONTEND_HOST"
-
 mkdir -p bundle-analysis dist
 
 echo "--- :webpack: Building Webpack assets for production, and analysing bundle"


### PR DESCRIPTION
This needs to be removed to do variable frontend paths. It's part of the public path which is being replaced on the fly, and we don't store this prefix anywhere else useful.

I remember we did this because webpack config changes weren't changing asset names and caches weren't expiring correctly. I think maybe something to do with the way the md5 extension thing we were using at the time was generating hashes. But the [chunkhash] we use now is based on the content of the asset and avoid that whole problem, so I'm pretty sure we don't need it any more.

Can anybody think of a reason we need to keep it?