### PR TITLE
Don't use componentWillMount in BuildState

### DIFF
--- a/app/components/icons/BuildState.js
+++ b/app/components/icons/BuildState.js
@@ -41,14 +41,12 @@ class BuildState extends React.PureComponent {
     style: PropTypes.object
   };
 
-  state = {
-    uuid: ''
-  };
+  constructor(props) {
+    super(props);
 
-  componentWillMount() {
-    this.setState({
+    this.state = {
       uuid: uuid()
-    });
+    };
   }
 
   render() {


### PR DESCRIPTION
This was a part of #634, but I figure this is the bit that’s shippable.