### PR TITLE
React 17 Prep

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,7 +110,7 @@ module.exports = {
     'react/no-array-index-key': WARN,
     'react/no-danger': OFF,
     'react/no-danger-with-children': ERROR,
-    'react/no-deprecated': WARN,
+    'react/no-deprecated': ERROR,
     'react/no-did-mount-set-state': ERROR,
     'react/no-did-update-set-state': ERROR,
     'react/no-direct-mutation-state': ERROR,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,12 @@ module.exports = {
     'relay',
     'graphql'
   ],
+  settings: {
+    react: {
+      version: "16.6",
+      flowVersion: "0.84"
+    }
+  },
   rules: {
   'array-bracket-spacing': [ ERROR, 'never' ],
     'arrow-parens': WARN,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -126,6 +126,7 @@ module.exports = {
     'react/no-string-refs': ERROR,
     'react/no-unescaped-entities': ERROR,
     'react/no-unknown-property': ERROR,
+    'react/no-unsafe': WARN,
     'react/no-unused-prop-types': ERROR,
     'react/prefer-es6-class': ERROR,
     'react/prefer-stateless-function': OFF,

--- a/app/components/agent/Index/installation.js
+++ b/app/components/agent/Index/installation.js
@@ -57,7 +57,7 @@ class AgentInstallation extends React.PureComponent {
     );
   };
 
-  componentWillReceiveProps = (nextProps) => {
+  UNSAFE_componentWillReceiveProps = (nextProps) => {
     if (nextProps.organization.agents && this.props.organization.agents && nextProps.organization.agents.count > this.props.organization.agents.count) {
       this.setState({ isDialogOpen: true });
     }

--- a/app/components/job/Index/index.js
+++ b/app/components/job/Index/index.js
@@ -28,7 +28,7 @@ class JobIndex extends React.Component {
     this.state = { query: query, searchInputValue: query };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // When the `q` param in the URL changes, do a new search
     const query = nextProps.location.query.q;
     if (query !== undefined && this.state.query !== query){

--- a/app/components/job/Index/jobs.js
+++ b/app/components/job/Index/jobs.js
@@ -43,7 +43,7 @@ class Jobs extends React.PureComponent {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.query !== nextProps.query) {
       const variables = this.parseSearchQuery(nextProps.query);
 

--- a/app/components/layout/Flashes/index.js
+++ b/app/components/layout/Flashes/index.js
@@ -20,7 +20,7 @@ class Flashes extends React.PureComponent<{}, State> {
     lastConnected: true // assume we were connected when the page loaded
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (FlashesStore.preloaded) {
       this.setState({ flashes: FlashesStore.preloaded });
     }

--- a/app/components/layout/Navigation/index.js
+++ b/app/components/layout/Navigation/index.js
@@ -59,7 +59,7 @@ class Navigation extends React.PureComponent<Props, State> {
     UserSessionStore.on('change', this.handleSessionDataChange);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     // When the page loads, we want to pull the last default team out of the UserSessionStore.
     if (this.props.organization && this.props.organization.id) {
       this.setState({
@@ -68,7 +68,7 @@ class Navigation extends React.PureComponent<Props, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // If we're moving between organizations, we need to pull out the new
     // organization's default team setting, if it's available.
     if (

--- a/app/components/member/Edit/form.js
+++ b/app/components/member/Edit/form.js
@@ -39,7 +39,7 @@ class Form extends React.PureComponent {
     ssoMode: null
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({
       role: this.props.organizationMember.role,
       ssoMode: this.props.organizationMember.sso.mode

--- a/app/components/member/New.js
+++ b/app/components/member/New.js
@@ -68,7 +68,7 @@ class MemberNew extends React.PureComponent {
     this.props.relay.forceFetch({ isMounted: true });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // Initialize state teams to default teams when mounted and we get props
     if (this.state.teams === null && nextProps.organization.teams) {
       const defaultTeams = nextProps.organization.teams.edges

--- a/app/components/organization/AgentsCount.js
+++ b/app/components/organization/AgentsCount.js
@@ -48,7 +48,7 @@ class AgentsCount extends React.PureComponent {
   };
 
   // Only once Relay comes back with an updated agentCount do we trust that data!
-  componentWillReceiveProps = (nextProps) => {
+  UNSAFE_componentWillReceiveProps = (nextProps) => {
     if (nextProps.organization.agents) {
       this.setState({ agentCount: nextProps.organization.agents.count });
     }

--- a/app/components/organization/Pipeline/graph.js
+++ b/app/components/organization/Pipeline/graph.js
@@ -62,7 +62,7 @@ class Graph extends React.Component {
     }, 0);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const thisLatestBuild = this.props.pipeline.builds.edges[0];
     const nextLatestBuild = nextProps.pipeline.builds.edges[0];
 

--- a/app/components/organization/Pipelines.js
+++ b/app/components/organization/Pipelines.js
@@ -100,7 +100,7 @@ class OrganizationPipelines extends React.Component {
     this.maybeUpdateDefaultTeam(this.props.organization.id, this.props.team);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const nextRelayVariables = {};
 
     // Are we switching teams?

--- a/app/components/pipeline/CreateBuildDialog.js
+++ b/app/components/pipeline/CreateBuildDialog.js
@@ -58,7 +58,7 @@ class CreateBuildDialog extends React.PureComponent<Props, State> {
   buildCommitTextField: FormTextField;
   buildBranchTextField: FormTextField;
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const [hashPath, hashQuery] = window.location.hash.split('?');
 
     if (hashPath === '#new') {

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -69,7 +69,7 @@ class Header extends React.Component<Props, State> {
 
   actionsDropdown: ?Dropdown;
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (window.location.hash.split('?').shift() === '#new') {
       this.setState({
         showingCreateBuildDialog: true

--- a/app/components/shared/Autocomplete/Dialog/index.js
+++ b/app/components/shared/Autocomplete/Dialog/index.js
@@ -23,7 +23,7 @@ class AutocompleteDialog extends React.PureComponent {
     searching: false
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.items && this.state.searching) {
       // We can turn off searching now since we've got some items
       this.setState({ searching: false });

--- a/app/components/shared/Autocomplete/Field/index.js
+++ b/app/components/shared/Autocomplete/Field/index.js
@@ -22,7 +22,7 @@ class AutocompleteField extends React.PureComponent {
     visible: false
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.items) {
       let found = false;
 

--- a/app/components/shared/BuildStatusDescription.js
+++ b/app/components/shared/BuildStatusDescription.js
@@ -48,7 +48,7 @@ class BuildStatusDescription extends React.PureComponent {
     this.maybeClearInterval();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { build, updateFrequency } = nextProps;
 
     if (updateFrequency !== this.props.updateFrequency) {

--- a/app/components/shared/CreditCardInput.js
+++ b/app/components/shared/CreditCardInput.js
@@ -48,7 +48,7 @@ export default class CreditCardInput extends React.PureComponent {
   // NOTE: We make the input a controlled component within the
   // context of the credit card field so that usages can reset the value
   // via defaultValue without controlling the entire component themselves
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.defaultValue) {
       this.setState({ value: this.props.defaultValue });
     }
@@ -59,7 +59,7 @@ export default class CreditCardInput extends React.PureComponent {
     this.input.addEventListener('paste', this.handlePaste);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.defaultValue !== this.props.defaultValue) {
       this.setState({ value: nextProps.defaultValue || '' });
     }

--- a/app/components/shared/Dialog.js
+++ b/app/components/shared/Dialog.js
@@ -109,7 +109,7 @@ class Dialog extends React.Component {
     document.documentElement.removeEventListener('keydown', this.handleDocumentKeyDown);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // Opening the dialog
     if (!this.props.isOpen && nextProps.isOpen) {
       this.setState({ rendered: true }, () => {

--- a/app/components/shared/FriendlyTime.js
+++ b/app/components/shared/FriendlyTime.js
@@ -51,7 +51,7 @@ export default class FriendlyTime extends React.PureComponent {
     this.maybeClearInterval();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { value, capitalized, seconds, updateFrequency } = nextProps;
 
     if (updateFrequency !== this.props.updateFrequency) {

--- a/app/components/shared/Menu/button.js
+++ b/app/components/shared/Menu/button.js
@@ -28,7 +28,7 @@ class Button extends React.Component {
     lastPathname: null
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({
       lastPathname: window.location.pathname
     });

--- a/app/components/shared/SearchField.js
+++ b/app/components/shared/SearchField.js
@@ -34,13 +34,13 @@ export default class SearchField extends React.PureComponent {
   // NOTE: We make the input a controlled component within the
   // context of the search field so that usages can reset the value
   // via defaultValue without controlling the entire component themselves
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.defaultValue) {
       this.setState({ value: this.props.defaultValue });
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.defaultValue !== this.props.defaultValue) {
       this.setState({ value: nextProps.defaultValue || '' });
     }


### PR DESCRIPTION
This preps us for React 17 by re-enabling the `react/no-deprecated` lint, and moving the remaining usages of `componentWill{Mount,ReceiveProps}` to their `UNSAFE_` counterparts, which will survive the upgrade to React 17 (for now!)

It also adds lints to warn us against using the UNSAFE_ methods, and we should look at porting away over time.