### PR TITLE
Add centrifuge in parallel with pusher

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -94,6 +94,7 @@ window["Webpack"] = {
     "queries/Team": require("./queries/Team"),
     "queries/Viewer": require("./queries/Viewer"),
     "stores/FlashesStore": require("./stores/FlashesStore").default,
+    "stores/CentrifugeStore": require("./stores/CentrifugeStore").default,
     "stores/PusherStore": require("./stores/PusherStore").default
   },
 
@@ -127,7 +128,16 @@ if (window._graphql) {
   );
 }
 
-// Setup the PusherStore
+// Setup the CentrifugeStore, if configured
+if (window._centrifuge) {
+  const centrifugeStore = require("./stores/CentrifugeStore").default;
+  centrifugeStore.configure(window._centrifuge["url"], window._centrifuge["token"], window._centrifuge["options"]);
+  for (const channel of window._centrifuge["channels"]) {
+    centrifugeStore.listen(channel);
+  }
+}
+
+// Setup the PusherStore, if configured
 if (window._pusher) {
   const pusherStore = require("./stores/PusherStore").default;
   pusherStore.configure(window._pusher["key"], window._pusher["options"]);

--- a/app/components/OrganizationShow/Pipeline/index.js
+++ b/app/components/OrganizationShow/Pipeline/index.js
@@ -7,6 +7,7 @@ import Emojify from 'app/components/shared/Emojify';
 import PipelineStatus from 'app/components/shared/PipelineStatus';
 import permissions from 'app/lib/permissions';
 import PusherStore from 'app/stores/PusherStore';
+import CentrifugeStore from 'app/stores/CentrifugeStore';
 import Environment from 'app/lib/relay/environment';
 import Status from './Status';
 import Metrics from './Metrics';
@@ -30,11 +31,13 @@ class Pipeline extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    PusherStore.on("websocket:event", this.handlePusherWebsocketEvent);
+    PusherStore.on("websocket:event", this.handleWebsocketEvent);
+    CentrifugeStore.on("websocket:event", this.handleWebsocketEvent);
   }
 
   componentWillUnmount() {
-    PusherStore.off("websocket:event", this.handlePusherWebsocketEvent);
+    PusherStore.off("websocket:event", this.handleWebsocketEvent);
+    CentrifugeStore.off("websocket:event", this.handleWebsocketEvent);
   }
 
   render() {
@@ -128,8 +131,8 @@ class Pipeline extends React.Component<Props, State> {
     );
   }
 
-  handlePusherWebsocketEvent = (payload) => {
-    if (payload.event === "project:updated" && payload.graphql.id === this.props.pipeline.id) {
+  handleWebsocketEvent = (payload) => {
+    if (payload.subevent === "project:updated" && payload.graphql.id === this.props.pipeline.id) {
       const { pipeline: { id }, includeGraphData } = this.props;
       this.props.relay.refetch({ id, includeGraphData });
     }

--- a/app/components/agent/Index/agents.js
+++ b/app/components/agent/Index/agents.js
@@ -11,6 +11,7 @@ import Spinner from 'app/components/shared/Spinner';
 import { formatNumber } from 'app/lib/number';
 
 import PusherStore from 'app/stores/PusherStore';
+import CentrifugeStore from 'app/stores/CentrifugeStore';
 
 import AgentRow from './row';
 
@@ -49,6 +50,7 @@ class Agents extends React.PureComponent {
     this.props.relay.forceFetch({ isMounted: true }, (readyState) => {
       if (readyState.done) {
         PusherStore.on('organization_stats:change', this.fetchUpdatedData);
+        CentrifugeStore.on('organization_stats:change', this.fetchUpdatedData);
         this.startTimeout();
       }
     });
@@ -56,6 +58,7 @@ class Agents extends React.PureComponent {
 
   componentWillUnmount() {
     PusherStore.off('organization_stats:change', this.fetchUpdatedData);
+    CentrifugeStore.off('organization_stats:change', this.fetchUpdatedData);
     clearTimeout(this._agentListRefreshTimeout);
   }
 

--- a/app/components/build/AnnotationsList.js
+++ b/app/components/build/AnnotationsList.js
@@ -4,6 +4,7 @@ import React from 'react';
 import Relay from 'react-relay/classic';
 
 import PusherStore from 'app/stores/PusherStore';
+import CentrifugeStore from 'app/stores/CentrifugeStore';
 
 type Props = {
   build: {
@@ -25,11 +26,13 @@ type Props = {
 
 class AnnnotationsList extends React.Component<Props> {
   componentDidMount() {
-    PusherStore.on("build:annotations_change", this.handlePusherWebsocketEvent);
+    PusherStore.on("build:annotations_change", this.handleWebsocketEvent);
+    CentrifugeStore.on("build:annotations_change", this.handleWebsocketEvent);
   }
 
   componentWillUnmount() {
-    PusherStore.off("build:annotations_change", this.handlePusherWebsocketEvent);
+    PusherStore.off("build:annotations_change", this.handleWebsocketEvent);
+    CentrifugeStore.off("build:annotations_change", this.handleWebsocketEvent);
   }
 
   render() {
@@ -138,7 +141,7 @@ class AnnnotationsList extends React.Component<Props> {
     );
   }
 
-  handlePusherWebsocketEvent = (payload) => {
+  handleWebsocketEvent = (payload) => {
     if (payload.buildID === this.props.build.id) {
       this.props.relay.forceFetch();
     }

--- a/app/components/layout/Flashes/index.js
+++ b/app/components/layout/Flashes/index.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import FlashesStore, { type FlashItem } from 'app/stores/FlashesStore';
 import PusherStore from 'app/stores/PusherStore';
+import CentrifugeStore from 'app/stores/CentrifugeStore';
 import Flash from './flash';
 
 const FLASH_CONN_ERROR_ID = 'FLASH_CONN_ERROR';
@@ -29,6 +30,8 @@ class Flashes extends React.PureComponent<{}, State> {
     FlashesStore.on('reset', this.handleStoreReset);
     PusherStore.on('unavailable', this.handleConnectionError);
     PusherStore.on('connected', this.handleConnectionSuccess);
+    CentrifugeStore.on('disconnect', this.handleConnectionError);
+    CentrifugeStore.on('connect', this.handleConnectionSuccess);
   }
 
   componentWillUnmount() {
@@ -36,6 +39,8 @@ class Flashes extends React.PureComponent<{}, State> {
     FlashesStore.off('reset', this.handleStoreReset);
     PusherStore.off('unavailable', this.handleConnectionError);
     PusherStore.off('connected', this.handleConnectionSuccess);
+    CentrifugeStore.off('disconnect', this.handleConnectionError);
+    CentrifugeStore.off('connect', this.handleConnectionSuccess);
   }
 
   handleStoreChange = (payload: FlashItem) => {

--- a/app/components/layout/Navigation/MyBuilds/build.js
+++ b/app/components/layout/Navigation/MyBuilds/build.js
@@ -7,6 +7,7 @@ import Emojify from 'app/components/shared/Emojify';
 import Duration from 'app/components/shared/Duration';
 
 import PusherStore from 'app/stores/PusherStore';
+import CentrifugeStore from 'app/stores/CentrifugeStore';
 import BuildState from 'app/components/icons/BuildState';
 
 import { buildStatus } from 'app/lib/builds';
@@ -28,15 +29,17 @@ class BuildsDropdownBuild extends React.PureComponent {
   }
 
   componentDidMount() {
-    PusherStore.on("websocket:event", this.handlePusherWebsocketEvent);
+    PusherStore.on("websocket:event", this.handleWebsocketEvent);
+    CentrifugeStore.on("websocket:event", this.handleWebsocketEvent);
   }
 
   componentWillUnmount() {
-    PusherStore.off("websocket:event", this.handlePusherWebsocketEvent);
+    PusherStore.off("websocket:event", this.handleWebsocketEvent);
+    CentrifugeStore.off("websocket:event", this.handleWebsocketEvent);
   }
 
-  handlePusherWebsocketEvent = (payload) => {
-    if (payload.event === "build:updated" && payload.graphql.id === this.props.build.id) {
+  handleWebsocketEvent = (payload) => {
+    if (payload.subevent === "build:updated" && payload.graphql.id === this.props.build.id) {
       this.props.relay.forceFetch();
     }
   };

--- a/app/components/organization/AgentsCount.js
+++ b/app/components/organization/AgentsCount.js
@@ -5,6 +5,7 @@ import throttle from 'throttleit';
 import { seconds } from 'metrick/duration';
 
 import PusherStore from 'app/stores/PusherStore';
+import CentrifugeStore from 'app/stores/CentrifugeStore';
 
 import { formatNumber } from 'app/lib/number';
 
@@ -28,16 +29,18 @@ class AgentsCount extends React.PureComponent {
   };
 
   componentDidMount() {
-    PusherStore.on('organization_stats:change', this.handlePusherWebsocketEvent);
+    PusherStore.on('organization_stats:change', this.handleWebsocketEvent);
+    CentrifugeStore.on('organization_stats:change', this.handleWebsocketEvent);
   }
 
   componentWillUnmount() {
-    PusherStore.off('organization_stats:change', this.handlePusherWebsocketEvent);
+    PusherStore.off('organization_stats:change', this.handleWebsocketEvent);
+    CentrifugeStore.off('organization_stats:change', this.handleWebsocketEvent);
   }
 
   // Like in MyBuilds, we don't take the Pusher data for granted - we instead
   // take it as a cue to update the data store backing the component.
-  handlePusherWebsocketEvent = ({ agentsConnectedCount }) => {
+  handleWebsocketEvent = ({ agentsConnectedCount }) => {
     // We need a "global" last agents connected count so we only ask it to update
     // once per changed count. This prevents calls from multiple AgentsCount
     // components triggering repeated forceFetch calls for one Pusher event

--- a/app/components/pipeline/Header/builds.js
+++ b/app/components/pipeline/Header/builds.js
@@ -5,6 +5,7 @@ import Relay from 'react-relay/classic';
 import BuildStateSwitcher from 'app/components/build/StateSwitcher';
 
 import PusherStore from 'app/stores/PusherStore';
+import CentrifugeStore from 'app/stores/CentrifugeStore';
 
 class Builds extends React.Component {
   static propTypes = {
@@ -16,11 +17,13 @@ class Builds extends React.Component {
   };
 
   componentDidMount() {
-    PusherStore.on("websocket:event", this.handlePusherWebsocketEvent);
+    PusherStore.on("websocket:event", this.handleWebsocketEvent);
+    CentrifugeStore.on("websocket:event", this.handleWebsocketEvent);
   }
 
   componentWillUnmount() {
-    PusherStore.off("websocket:event", this.handlePusherWebsocketEvent);
+    PusherStore.off("websocket:event", this.handleWebsocketEvent);
+    CentrifugeStore.off("websocket:event", this.handleWebsocketEvent);
   }
 
   render() {
@@ -37,8 +40,8 @@ class Builds extends React.Component {
     );
   }
 
-  handlePusherWebsocketEvent = (payload) => {
-    if (payload.event === "project:updated" && payload.graphql.id === this.props.pipeline.id) {
+  handleWebsocketEvent = (payload) => {
+    if (payload.subevent === "project:updated" && payload.graphql.id === this.props.pipeline.id) {
       this.props.relay.forceFetch();
     }
   };

--- a/app/components/user/BuildCountsBreakdown.js
+++ b/app/components/user/BuildCountsBreakdown.js
@@ -4,6 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import PusherStore from 'app/stores/PusherStore';
+import CentrifugeStore from 'app/stores/CentrifugeStore';
 import StateSwitcher from 'app/components/build/StateSwitcher';
 
 type Props = {
@@ -51,10 +52,12 @@ export default class BuildCountsBreakdown extends React.PureComponent<Props, Sta
 
   componentDidMount() {
     PusherStore.on("user_stats:change", this.handleStoreChange);
+    CentrifugeStore.on("user_stats:change", this.handleStoreChange);
   }
 
   componentWillUnmount() {
     PusherStore.off("user_stats:change", this.handleStoreChange);
+    CentrifugeStore.off("user_stats:change", this.handleStoreChange);
   }
 
   render() {

--- a/app/components/user/NewChangelogsBadge.js
+++ b/app/components/user/NewChangelogsBadge.js
@@ -7,6 +7,7 @@ import { CSSTransition } from 'react-transition-group';
 import classNames from 'classnames';
 
 import PusherStore from 'app/stores/PusherStore';
+import CentrifugeStore from 'app/stores/CentrifugeStore';
 
 type Props = {
   className?: string,
@@ -32,14 +33,16 @@ class NewChangelogsBadge extends React.PureComponent<Props> {
   };
 
   componentDidMount() {
-    PusherStore.on("user_stats:change", this.handlePusherWebsocketEvent);
+    PusherStore.on("user_stats:change", this.handleWebsocketEvent);
+    CentrifugeStore.on("user_stats:change", this.handleWebsocketEvent);
   }
 
   componentWillUnmount() {
-    PusherStore.off("user_stats:change", this.handlePusherWebsocketEvent);
+    PusherStore.off("user_stats:change", this.handleWebsocketEvent);
+    CentrifugeStore.off("user_stats:change", this.handleWebsocketEvent);
   }
 
-  handlePusherWebsocketEvent = () => {
+  handleWebsocketEvent = () => {
     this.props.relay.forceFetch();
   };
 

--- a/app/stores/CentrifugeStore.js
+++ b/app/stores/CentrifugeStore.js
@@ -1,0 +1,42 @@
+// @flow
+
+import EventEmitter from 'eventemitter3';
+import Centrifuge from 'centrifuge';
+import Logger from 'app/lib/Logger';
+
+class CentrifugeStore extends EventEmitter {
+  centrifuge: Centrifuge;
+
+  constructor() {
+    super();
+  }
+
+  configure(url: string, token: string, options: Object) {
+    this.centrifuge = new Centrifuge(url, options);
+    this.centrifuge.setToken(token);
+    this.centrifuge.on('connect', (context) => {
+      Logger.info('[CentrifugeStore] Connect', context);
+      this.emit('connect', context);
+    });
+    this.centrifuge.on('disconnect', (context) => {
+      Logger.info('[CentrifugeStore] Disconnect', context);
+      this.emit('disconnect', context);
+    });
+    Logger.info('[CentrifugeStore] Connecting');
+    this.centrifuge.connect();
+  }
+
+  isConfigured() {
+    return !!this.centrifuge;
+  }
+
+  listen(channel: string) {
+    Logger.info(`[CentrifugeStore] Listening to channel '${channel}'`);
+    this.centrifuge.subscribe(channel, function({ data: { event, ...payload } }) {
+      Logger.info(`[CentrifugeStore] ${event}`, payload);
+      this.emit(event, payload);
+    }.bind(this));
+  }
+}
+
+export default new CentrifugeStore();

--- a/app/stores/PusherStore.js
+++ b/app/stores/PusherStore.js
@@ -5,21 +5,18 @@ import Pusher from 'pusher-js';
 import Logger from 'app/lib/Logger';
 
 class PusherStore extends EventEmitter {
-  name: string;
   pusher: Pusher;
 
-  constructor(name: string = 'PusherStore') {
+  constructor() {
     super();
-    this.name = name;
   }
 
   configure(key: string, options: Object) {
     this.pusher = new Pusher(key, options);
-
     this.pusher.connection.bind(
       'state_change',
       ({ current, ...context }) => {
-        Logger.info(`[${this.name}]`, current, context);
+        Logger.info('[PusherStore]', current, context);
 
         this.emit(current, context);
       }
@@ -31,10 +28,10 @@ class PusherStore extends EventEmitter {
   }
 
   listen(channel: string) {
-    Logger.info(`[${this.name}] Listening to channel '${channel}'`);
+    Logger.info(`[PusherStore] Listening to channel '${channel}'`);
 
     this.pusher.subscribe(channel).bind_global((event, payload) => {
-      Logger.info(`[${this.name}]`, event, payload);
+      Logger.info('[PusherStore]', event, payload);
 
       this.emit(event, payload);
     });

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "buffer-crc32": "0.2.13",
     "bugsnag-js": "4.7.3",
     "bugsnag-react": "1.1.1",
+    "centrifuge": "^2.0.0",
     "classnames": "2.2.6",
     "codemirror": "5.41.0",
     "codemirror-graphql": "0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,6 +1152,59 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
   integrity sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
 "@storybook/addon-a11y@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-4.0.0.tgz#f51812fc9c918ad735a4fca67b9d1da363bb6e06"
@@ -1498,10 +1551,20 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
   integrity sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA==
 
+"@types/long@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
+  integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
+
 "@types/node@*":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
   integrity sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==
+
+"@types/node@^10.1.0":
+  version "10.12.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.15.tgz#20e85651b62fd86656e57c9c9bc771ab1570bc59"
+  integrity sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==
 
 "@types/node@^8.0.24":
   version "8.10.36"
@@ -4014,6 +4077,13 @@ center-align@^0.1.1:
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
+
+centrifuge@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/centrifuge/-/centrifuge-2.0.0.tgz#6dc2cc28208d16ebba9debc8fd9223703355f2d5"
+  integrity sha512-g2CmFCJUmAr77lCPaccYJOIbrWLgPZdcYw8gf0vc+kAmlTfDUufaZuMVLsshd1ua7RfkQAB1zDTjhVUKoD3OmQ==
+  dependencies:
+    protobufjs "^6.8.6"
 
 chalk@2.4.1, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
@@ -9926,6 +9996,11 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 longest@^1.0.0, longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -12116,6 +12191,25 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+protobufjs@^6.8.6:
+  version "6.8.8"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
+  integrity sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    "@types/node" "^10.1.0"
+    long "^4.0.0"
 
 proxy-addr@~2.0.2:
   version "2.0.2"


### PR DESCRIPTION
This gives us the ability to switch on a centrifuge client instead of pusher, if configured. It should have zero impact unless window._centrifugo is set.

I'm very aware that this doesn't move us to a better push infrastructure throughout the frontend, it's just a straight swap to get us away from Pusher. Once we're not bound by pricing constraints we'll be able split things up and use pubsub more effectively.

I'm a little worried about the bundle size bloat given all the protobuf stuff which we probably won't use. I wonder if there's a way to push a fix upstream to make it easier to optimise that stuff out.