### PR TITLE
Fix header styling

### DIFF
--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -45,7 +45,7 @@ const HeaderBuilds = styled(Builds)`
     margin-left: 10px;
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 767px) {
     margin-top: 10px;
     order: 3;
   }
@@ -212,7 +212,7 @@ class Header extends React.Component<Props, State> {
 
     return (
       <Dropdown
-        className="sm-hide md-hide lg-hide ml2"
+        className="md-hide lg-hide ml2"
         width={200}
         ref={(actionsDropdown) => this.actionsDropdown = actionsDropdown}
         onToggle={this.handleActionsDropdownToggle}
@@ -246,7 +246,7 @@ class Header extends React.Component<Props, State> {
     ));
 
     return (
-      <div className="flex xs-hide">
+      <div className="flex xs-hide sm-hide">
         {content}
       </div>
     );

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -27,7 +27,6 @@ const HeaderContent = styled.header`
 `;
 
 const HeaderVitals = styled.div`
-
   display: flex;
   flex: 1 1 auto;
   min-width: 0;
@@ -41,7 +40,12 @@ const HeaderBuilds = styled(Builds)`
   flex: 1;
   margin-bottom: 5px;
 
-  @media (max-width: 991px) {
+  @media (min-width: 768px) {
+    white-space: nowrap;
+    margin-left: 10px;
+  }
+
+  @media (max-width: 768px) {
     margin-top: 10px;
     order: 3;
   }
@@ -49,7 +53,6 @@ const HeaderBuilds = styled(Builds)`
   @media (min-width: 992px) {
     flex: 0 0 auto;
     margin-bottom: 0;
-    margin-left: 10px;
   }
 `;
 
@@ -102,7 +105,7 @@ class Header extends React.Component<Props, State> {
                     src={this.props.pipeline.organization.iconUrl || defaultAvatar}
                     width="38"
                     height="38"
-                    className="block xs-hide circle border border-gray bg-white mr2 flex-none"
+                    className="block circle border border-gray bg-white mr2 flex-none"
                     alt={`Icon for ${this.props.pipeline.organization.name}`}
                     title={`Icon for ${this.props.pipeline.organization.name}`}
                   />

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -21,24 +21,20 @@ const HeaderContent = styled.header`
   display: flex;
   flex: 1 1 auto;
 
-  @media (max-width: 991px) {
-    flex-wrap: wrap;
+  @media (max-width: 767px) {
+    flex-direction: column;
   }
 `;
 
 const HeaderVitals = styled.div`
   display: flex;
   flex: 1 1 auto;
+  align-items: center;
   min-width: 0;
-
-  @media (min-width: 768px) {
-    flex-basis: 320px;
-  }
 `;
 
 const HeaderBuilds = styled(Builds)`
   flex: 1;
-  margin-bottom: 5px;
 
   @media (min-width: 768px) {
     white-space: nowrap;

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -17,12 +17,20 @@ import defaultAvatar from 'app/images/avatar_default.png';
 import permissions from 'app/lib/permissions';
 import { repositoryProviderIcon } from 'app/lib/repositories';
 
-declare var Features;
+const HeaderContent = styled.header`
+  display: flex;
+  flex: 1 1 auto;
 
-const HeaderVitals = styled.div.attrs({
-  className: 'flex flex-auto items-center'
-})`
-  flex-basis: 100%;
+  @media (max-width: 991px) {
+    flex-wrap: wrap;
+  }
+`;
+
+const HeaderVitals = styled.div`
+
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
 
   @media (min-width: 768px) {
     flex-basis: 320px;
@@ -30,15 +38,16 @@ const HeaderVitals = styled.div.attrs({
 `;
 
 const HeaderBuilds = styled(Builds)`
-  flex: 1 1 auto;
+  flex: 1;
   margin-bottom: 5px;
 
-  @media (min-width: 768px) and (max-width: 991px) {
+  @media (max-width: 991px) {
+    margin-top: 10px;
     order: 3;
   }
 
   @media (min-width: 992px) {
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     margin-bottom: 0;
     margin-left: 10px;
   }
@@ -84,7 +93,7 @@ class Header extends React.Component<Props, State> {
 
     return (
       <div data-testid="PipelineHeader">
-        <div className="flex mb2 items-center flex-wrap">
+        <HeaderContent className="mb2">
           <HeaderVitals>
             <div className="flex flex-auto">
               {!this.props.isCurrentOrganizationMember ? (
@@ -99,7 +108,7 @@ class Header extends React.Component<Props, State> {
                   />
                 </a>
               ) : null}
-              <div className="flex flex-column justify-center">
+              <div className="flex flex-column justify-center" style={{ minWidth: 0 }}>
                 <div className="flex items-center">
                   <h2 className="inline-block line-height-1 h3 regular m0 mr1 line-height-2 truncate">
                     <a className="color-inherit hover-color-inherit text-decoration-none hover-lime hover-color-inherit-parent" href={`/${this.props.pipeline.organization.slug}`}>
@@ -113,15 +122,12 @@ class Header extends React.Component<Props, State> {
                   {this.props.pipeline.public ? <PipelineStatus showLabel={true} /> : null}
                 </div>
                 {this.props.pipeline.description ? (
-                  <div className="truncate dark-gray">
+                  <div className="dark-gray truncate">
                     <Emojify className="h4 regular" text={this.props.pipeline.description} />
                   </div>
                 ) : null}
               </div>
             </div>
-
-
-
             {this.renderProviderBadge()}
             {this.renderDropdownForActions(actions)}
           </HeaderVitals>
@@ -131,7 +137,7 @@ class Header extends React.Component<Props, State> {
             buildState={this.props.buildState}
           />
           {this.renderButtonsForActions(actions)}
-        </div>
+        </HeaderContent>
         <CreateBuildDialog
           isOpen={this.state.showingCreateBuildDialog}
           onRequestClose={this.handleCreateBuildDialogClose}

--- a/app/css/container.css
+++ b/app/css/container.css
@@ -1,4 +1,5 @@
 .container {
+  width: 100%;
   margin-left: auto;
   margin-right: auto;
   padding-left: 15px;


### PR DESCRIPTION
Noticed that our build pipelines headers are not in great shape at the moment. 😐

### Before

Things get pretty bad with super long descriptions...
<img width="616" alt="screen shot 2019-01-11 at 3 02 54 pm" src="https://user-images.githubusercontent.com/18076/51012679-7d2d6600-15b2-11e9-86c2-e75e97b4e823.png">
<img width="902" alt="screen shot 2019-01-11 at 3 03 00 pm" src="https://user-images.githubusercontent.com/18076/51012680-7dc5fc80-15b2-11e9-81fa-5b286d87db26.png">
<img width="1138" alt="screen shot 2019-01-11 at 3 03 05 pm" src="https://user-images.githubusercontent.com/18076/51012681-7dc5fc80-15b2-11e9-9c97-6b1b176eefd6.png">
<img width="1328" alt="screen shot 2019-01-11 at 3 03 09 pm" src="https://user-images.githubusercontent.com/18076/51012682-7e5e9300-15b2-11e9-9ab8-40778d06ba23.png">

But even with short descriptions things are pretty janky.
<img width="616" alt="screen shot 2019-01-11 at 3 04 00 pm" src="https://user-images.githubusercontent.com/18076/51012683-7e5e9300-15b2-11e9-892f-38aa83c7cb18.png">
<img width="758" alt="screen shot 2019-01-11 at 3 04 08 pm" src="https://user-images.githubusercontent.com/18076/51012684-7ef72980-15b2-11e9-88f2-48896e1fe278.png">
<img width="908" alt="screen shot 2019-01-11 at 3 04 11 pm" src="https://user-images.githubusercontent.com/18076/51012685-7ef72980-15b2-11e9-9a31-3f3d59cd0269.png">
<img width="1129" alt="screen shot 2019-01-11 at 3 04 15 pm" src="https://user-images.githubusercontent.com/18076/51012686-7f8fc000-15b2-11e9-931e-6ad1718c5823.png">


### After

| Authenticated | Anonymous   |
| :-------------: |:-------------:|
| <img width="616" alt="screen shot 2019-01-11 at 2 53 43 pm" src="https://user-images.githubusercontent.com/18076/51012364-e57b4800-15b0-11e9-924e-32c21424bcbd.png"> | <img width="616" alt="screen shot 2019-01-11 at 2 54 35 pm" src="https://user-images.githubusercontent.com/18076/51012375-e7dda200-15b0-11e9-9060-f610f89bd224.png"> |
| <img width="880" alt="screen shot 2019-01-11 at 2 53 51 pm" src="https://user-images.githubusercontent.com/18076/51012365-e57b4800-15b0-11e9-877c-3ab99adfee36.png"> | <img width="879" alt="screen shot 2019-01-11 at 2 54 30 pm" src="https://user-images.githubusercontent.com/18076/51012374-e7450b80-15b0-11e9-954e-70a50425771d.png"> |
| <img width="1106" alt="screen shot 2019-01-11 at 2 53 58 pm" src="https://user-images.githubusercontent.com/18076/51012366-e613de80-15b0-11e9-93a0-f88be5143772.png"> | <img width="1104" alt="screen shot 2019-01-11 at 2 54 20 pm" src="https://user-images.githubusercontent.com/18076/51012373-e7450b80-15b0-11e9-9bbd-0b1916ade1bb.png"> |
| <img width="1313" alt="screen shot 2019-01-11 at 2 54 04 pm" src="https://user-images.githubusercontent.com/18076/51012367-e613de80-15b0-11e9-9552-6b0c0d16a980.png"> | <img width="1313" alt="screen shot 2019-01-11 at 2 54 12 pm" src="https://user-images.githubusercontent.com/18076/51012372-e6ac7500-15b0-11e9-8d4c-1f3d11770809.png"> |


