### PR TITLE
Remove nested animation-spin in the spinner

### DIFF
--- a/app/components/icons/BuildState.js
+++ b/app/components/icons/BuildState.js
@@ -133,7 +133,7 @@ class BuildState extends React.PureComponent {
         defs = (
           <mask id={maskId} x="9" y="9" width="14" height="14" maskUnits="userSpaceOnUse">
             <polygon
-              className="animation-spin"
+              className="animation-spin-slow"
               style={{ transformOrigin: 'center' }}
               fill="#fff"
               points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"

--- a/app/components/icons/__snapshots__/BuildState.spec.js.snap
+++ b/app/components/icons/__snapshots__/BuildState.spec.js.snap
@@ -238,7 +238,7 @@ exports[`BuildState BuildState.Regular renders correctly for build state \`RUNNI
       y="9"
     >
       <polygon
-        className="animation-spin"
+        className="animation-spin-slow"
         fill="#fff"
         points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
         style={
@@ -300,7 +300,7 @@ exports[`BuildState BuildState.Regular renders correctly for build state \`SCHED
       y="9"
     >
       <polygon
-        className="animation-spin"
+        className="animation-spin-slow"
         fill="#fff"
         points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
         style={
@@ -642,7 +642,7 @@ exports[`BuildState BuildState.Small renders correctly for build state \`RUNNING
       y="9"
     >
       <polygon
-        className="animation-spin"
+        className="animation-spin-slow"
         fill="#fff"
         points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
         style={
@@ -704,7 +704,7 @@ exports[`BuildState BuildState.Small renders correctly for build state \`SCHEDUL
       y="9"
     >
       <polygon
-        className="animation-spin"
+        className="animation-spin-slow"
         fill="#fff"
         points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
         style={
@@ -1046,7 +1046,7 @@ exports[`BuildState BuildState.XSmall renders correctly for build state \`RUNNIN
       y="9"
     >
       <polygon
-        className="animation-spin"
+        className="animation-spin-slow"
         fill="#fff"
         points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
         style={
@@ -1108,7 +1108,7 @@ exports[`BuildState BuildState.XSmall renders correctly for build state \`SCHEDU
       y="9"
     >
       <polygon
-        className="animation-spin"
+        className="animation-spin-slow"
         fill="#fff"
         points="16 16 9 16 9 9 16 9 16 16 23 16 23 23 16 23 16 16"
         style={

--- a/app/components/shared/Spinner.js
+++ b/app/components/shared/Spinner.js
@@ -44,11 +44,9 @@ export default class Spinner extends React.PureComponent {
               </clipPath>
             </defs>
             <g transform="translate(10, 10)">
-              <g className="animation-spin">
-                <g transform="translate(-10, -10)">
-                  <g clipPath="url(#spinner-clip-path)">
-                    <circle fill="transparent" className={this.props.color ? "stroke-lime" : "stroke-dark-gray"} strokeMiterlimit="10" strokeWidth="3" cx="10" cy="10" r="7" />
-                  </g>
+              <g transform="translate(-10, -10)">
+                <g clipPath="url(#spinner-clip-path)">
+                  <circle fill="transparent" className={this.props.color ? "stroke-lime" : "stroke-dark-gray"} strokeMiterlimit="10" strokeWidth="3" cx="10" cy="10" r="7" />
                 </g>
               </g>
             </g>

--- a/app/css/animations.css
+++ b/app/css/animations.css
@@ -89,12 +89,12 @@
 
 .animation-spin {
   will-change: transform;
-  animation: animation-spin 1.1s infinite linear;
+  animation: animation-spin 0.55s infinite linear;
 }
 
 .animation-spin-slow {
   will-change: transform;
-  animation: animation-spin 2.1s infinite linear;
+  animation: animation-spin 1.05s infinite linear;
 }
 
 /* Allow CSS animations to be disabled (used in integration tests) */


### PR DESCRIPTION
Looks like we have a double animation happening inside our spinner, which goes against the performance comment at the top of the file. This removes the nested `animation-spin` and fixes up the other uses of the class to work with the new values.