### PR TITLE
Make the public badge the same as the beta badge

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -56,6 +56,7 @@ window["Webpack"] = {
     "components/pipeline/Header": require("./components/pipeline/Header").default,
     "components/pipeline/Teams": require("./components/pipeline/Teams").default,
     "components/pipeline/SettingsMenu": require("./components/pipeline/SettingsMenu").default,
+    "components/shared/BetaBadge": require("./components/shared/BetaBadge").default,
     "components/shared/BuildStatusDescription": require("./components/shared/BuildStatusDescription").default,
     "components/shared/Button": require("./components/shared/Button").default,
     "components/shared/CollapsableFormField": require("./components/shared/CollapsableFormField").default,

--- a/app/components/OrganizationShow/Pipeline/index.js
+++ b/app/components/OrganizationShow/Pipeline/index.js
@@ -50,10 +50,10 @@ class Pipeline extends React.Component<Props, State> {
         <a href={this.props.pipeline.url} className="flex flex-auto items-center px2 text-decoration-none color-inherit mr3">
           <div className="truncate">
             <div className="flex items-center">
-              <h2 data-testid="pipeline__name" className="inline h3 regular m0 mr1 line-height-2">
+              <h2 data-testid="pipeline__name" className="inline h3 regular m0 line-height-2">
                 <Emojify text={this.props.pipeline.name} />
               </h2>
-              {this.props.pipeline.public ? <PipelineStatus showLabel={true} /> : null}
+              <PipelineStatus public={this.props.pipeline.public} />
             </div>
             {this.renderDescription()}
           </div>

--- a/app/components/OrganizationShow/__tests__/OrganizationShow_test.js
+++ b/app/components/OrganizationShow/__tests__/OrganizationShow_test.js
@@ -174,7 +174,7 @@ describe('OrganizationShow', () => {
       // Pipeline 2 is public
       expect(pipelines.at(1).find('[data-testid="pipeline__name"]').text()).toEqual('Pipeline 2');
       expect(pipelines.at(1).find('[data-testid="pipeline__status"]').exists()).toBeTruthy();
-      expect(pipelines.at(1).find('[data-testid="pipeline__status"]').text()).toEqual('PUBLIC');
+      expect(pipelines.at(1).find('[data-testid="pipeline__status"]').text()).toEqual('Public');
 
       // Pipeline 3 is private
       expect(pipelines.at(2).find('[data-testid="pipeline__name"]').text()).toEqual('Pipeline 3');

--- a/app/components/agent/Index/AgentTokenItem.js
+++ b/app/components/agent/Index/AgentTokenItem.js
@@ -44,7 +44,7 @@ class AgentTokenItem extends React.PureComponent {
   renderPublicBadge() {
     if (this.props.agentToken.public) {
       return (
-        <Badge outline={true} className="regular" title="Agents registered with this token will be visible to everyone, including people outside this organization">Public</Badge>
+        <Badge outline={true} className="regular very-dark-gray" title="Agents registered with this token will be visible to everyone, including people outside this organization">Public</Badge>
       );
     }
   }

--- a/app/components/agent/Index/row.js
+++ b/app/components/agent/Index/row.js
@@ -115,7 +115,7 @@ class AgentRow extends React.PureComponent<Props> {
   renderPublicBadge() {
     if (this.props.agent.public) {
       return (
-        <Badge outline={true} className="regular" title="Visible to everyone, including people outside this organization">Public</Badge>
+        <Badge outline={true} className="regular very-dark-gray" title="Visible to everyone, including people outside this organization">Public</Badge>
       );
     }
   }

--- a/app/components/agent/Show.js
+++ b/app/components/agent/Show.js
@@ -439,7 +439,7 @@ class AgentShow extends React.Component {
   renderPublicBadge() {
     if (this.props.agent.public) {
       return (
-        <Badge outline={true} className="regular bg-white" title="Visible to everyone, including people outside this organization">Public</Badge>
+        <Badge outline={true} className="regular very-dark-gray" title="Visible to everyone, including people outside this organization">Public</Badge>
       );
     }
   }

--- a/app/components/pipeline/Header/index.js
+++ b/app/components/pipeline/Header/index.js
@@ -109,7 +109,7 @@ class Header extends React.Component<Props, State> {
               ) : null}
               <div className="flex flex-column justify-center" style={{ minWidth: 0 }}>
                 <div className="flex items-center">
-                  <h2 className="inline-block line-height-1 h3 regular m0 mr1 line-height-2 truncate">
+                  <h2 className="inline-block line-height-1 h3 regular m0 line-height-2 truncate">
                     <a className="color-inherit hover-color-inherit text-decoration-none hover-lime hover-color-inherit-parent" href={`/${this.props.pipeline.organization.slug}`}>
                       <Emojify text={this.props.pipeline.organization.name} />
                     </a>
@@ -118,7 +118,7 @@ class Header extends React.Component<Props, State> {
                       <Emojify text={this.props.pipeline.name} />
                     </a>
                   </h2>
-                  {this.props.pipeline.public ? <PipelineStatus showLabel={true} /> : null}
+                  <PipelineStatus public={this.props.pipeline.public} />
                 </div>
                 {this.props.pipeline.description ? (
                   <div className="dark-gray truncate">

--- a/app/components/shared/Badge.js
+++ b/app/components/shared/Badge.js
@@ -8,7 +8,9 @@ type Props = {
   children: React.Node,
   title?: string,
   className?: string,
-  outline?: boolean
+  outline?: boolean,
+  caps?: boolean,
+  bold?: boolean
 };
 
 export default class Badge extends React.PureComponent<Props> {
@@ -16,20 +18,23 @@ export default class Badge extends React.PureComponent<Props> {
     children: PropTypes.node,
     className: PropTypes.string,
     title: PropTypes.string,
-    outline: PropTypes.bool
+    outline: PropTypes.bool,
+    bold: PropTypes.bool
   };
 
   render() {
     const { children, className, title } = this.props;
 
     const badgeClassName = classNames(
-      "inline-block rounded ml1 small p1 line-height-1 tabular-numerals",
-      (this.props.outline ? 'border border-gray dark-gray' : 'bg-black white'),
+      "inline-block rounded ml1 small line-height-1 tabular-numerals",
+      (this.props.outline ? 'border border-gray very-dark-gray' : 'bg-black white'),
+      (this.props.caps && 'caps'),
+      (this.props.bold && 'semi-bold'),
       className
     );
 
     return (
-      <span className={badgeClassName} title={title}>{children}</span>
+      <span className={badgeClassName} title={title} style={{ padding: '4px 5px' }}>{children}</span>
     );
   }
 }

--- a/app/components/shared/BetaBadge.js
+++ b/app/components/shared/BetaBadge.js
@@ -1,0 +1,20 @@
+// @flow
+
+import * as React from 'react';
+import Badge from 'app/components/shared/Badge';
+
+type Props = {
+  forumTopicUrl: string
+};
+
+export default class BetaBadge extends React.PureComponent<Props> {
+  render() {
+    return (
+      <a title="Community Forum Topic" href={this.props.forumTopicUrl}>
+        <Badge outline={true} className="btn-outline bg-white regular very-dark-gray">
+          Beta
+        </Badge>
+      </a>
+    );
+  }
+}

--- a/app/components/shared/FormRadioGroup.js
+++ b/app/components/shared/FormRadioGroup.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 import FormInputHelp from './FormInputHelp';
 import FormInputErrors from './FormInputErrors';
+import Badge from 'app/components/shared/Badge';
 
 class FormRadioGroup extends React.Component {
   static propTypes = {
@@ -74,7 +75,7 @@ class FormRadioGroup extends React.Component {
                 onChange={this.props.onChange}
               />
               <span className="bold block" style={{ marginBottom: -5 }}> {option.label}</span>
-              {option.badge && <div className="ml1 regular small border border-gray rounded dark-gray px1">{option.badge}</div>}
+              {option.badge && <Badge outline={true}>{option.badge}</Badge>}
             </div>
             <FormInputHelp>{option.help}</FormInputHelp>
           </label>

--- a/app/components/shared/PipelineStatus/index.js
+++ b/app/components/shared/PipelineStatus/index.js
@@ -12,8 +12,6 @@ const Status = styled.div`
 `;
 
 const Label = styled.span`
-  /*margin-left: 4px;*/
-  color: #BBBBBB;
   text-transform: uppercase;
   font-size: 11px;
   line-height: 1;
@@ -41,7 +39,7 @@ export default class PipelineStatus extends React.PureComponent<Props> {
             </g>
           </svg>
           */}
-          {this.props.showLabel ? <Label>PUBLIC</Label> : null}
+          {this.props.showLabel ? <Label>Public</Label> : null}
         </Status>
       </div>
     );

--- a/app/components/shared/PipelineStatus/index.js
+++ b/app/components/shared/PipelineStatus/index.js
@@ -1,49 +1,22 @@
 // @flow
 
 import * as React from 'react';
-import styled from 'styled-components';
-
-const Status = styled.div`
-  padding: 3px 4px;
-  display: flex;
-  align-items: center;
-  border: 1px solid #DDDDDD;
-  border-radius: 3px;
-`;
-
-const Label = styled.span`
-  text-transform: uppercase;
-  font-size: 11px;
-  line-height: 1;
-`;
+import Badge from 'app/components/shared/Badge';
 
 type Props = {
-  showLabel?: boolean
+  public: boolean
 };
 
 export default class PipelineStatus extends React.PureComponent<Props> {
-  static defaultProps = {
-    showLabel: true
-  }
-
   render() {
-    return (
-      <div data-testid="pipeline__status">
-        <Status title="Public Pipeline">
-          {/*
-          <svg width="17px" height="11px" viewBox="0 0 17 11" version="1.1">
-            <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-              <path d="M2.40224507e-14,5.5 C0.803635183,2.36191956 4.30383301,0 8.5,0 C12.696167,0 16.1963648,2.36191956 17,5.5 C16.1963648,8.63808044 12.696167,11 8.5,11 C4.30383301,11 0.803635183,8.63808044 9.96147609e-14,5.5 Z M8.5,9.9 C10.8472102,9.9 12.75,7.9300529 12.75,5.5 C12.75,3.0699471 10.8472102,1.1 8.5,1.1 C6.15278981,1.1 4.25,3.0699471 4.25,5.5 C4.25,7.9300529 6.15278981,9.9 8.5,9.9 Z" fill="#BBBBBB" />
-              <circle fill="#FFFFFF" cx="8.5" cy="5.5" r="4.5" />
-              <path d="M5.15421324,4.46935666 C5.4285886,5.07706618 6.03990356,5.5 6.75,5.5 C7.71649831,5.5 8.5,4.71649831 8.5,3.75 C8.5,3.03990356 8.07706618,2.4285886 7.46935666,2.15421324 C7.79518404,2.05396278 8.14129018,2 8.5,2 C10.4329966,2 12,3.56700338 12,5.5 C12,7.43299662 10.4329966,9 8.5,9 C6.56700338,9 5,7.43299662 5,5.5 C5,5.14129018 5.05396278,4.79518404 5.15421324,4.46935666 Z" fill="#BBBBBB" />
-            </g>
-          </svg>
-          */}
-          {this.props.showLabel ? <Label>Public</Label> : null}
-        </Status>
-      </div>
-    );
+    if (this.props.public) {
+      return (
+        <div data-testid="pipeline__status">
+          <Badge className="very-dark-gray" outline={true} title="Public Pipeline">Public</Badge>
+        </div>
+      );
+    }
+
+    return null;
   }
 }
-
-

--- a/app/css/colors.css
+++ b/app/css/colors.css
@@ -1,8 +1,9 @@
-.black      { color: var(--black) }
-.gray       { color: var(--gray) }
-.dark-gray  { color: var(--dark-gray) }
-.silver     { color: var(--silver) }
-.white      { color: var(--white) }
+.black          { color: var(--black) }
+.gray           { color: var(--gray) }
+.dark-gray      { color: var(--dark-gray) }
+.very-dark-gray { color: var(--very-dark-gray) }
+.silver         { color: var(--silver) }
+.white          { color: var(--white) }
 
 .aqua       { color: var(--aqua) }
 .blue       { color: var(--blue) }

--- a/app/css/variables.css
+++ b/app/css/variables.css
@@ -2,7 +2,7 @@
   --black:  #111111;
   --gray: #DDDDDD;
   --dark-gray: #8E8E8E;
-  --very-dark-gray: #222;
+  --very-dark-gray: #444;
   --silver: #F9FAFB;
   --white:  #FFFFFF;
 


### PR DESCRIPTION
This cleans up all our badges (text and numbers) to use a single, consistent component with decent contrast and no more all-caps. It also exposes a BetaBadge component we can use for badging beta features (there's a matching Rails partial which makes use of it).

Before:

<img width="605" alt="image" src="https://user-images.githubusercontent.com/153/51317802-a9624e80-1aac-11e9-8138-b8a2c5c11d8f.png">

After:

<img width="601" alt="image" src="https://user-images.githubusercontent.com/153/51317757-8a63bc80-1aac-11e9-97c1-2c464a0795b6.png">