### PR TITLE
Fix the chooser select icon and positioning

### DIFF
--- a/app/components/shared/Chooser/select-option.js
+++ b/app/components/shared/Chooser/select-option.js
@@ -34,8 +34,7 @@ SelectOption.propTypes = {
 };
 
 function SelectIcon(props) {
-  const size = 25
-  const marginRight = 3;
+  const size = 25;
 
   if (props.saving) {
     return (

--- a/app/components/shared/Chooser/select-option.js
+++ b/app/components/shared/Chooser/select-option.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import Spinner from 'app/components/shared/Spinner';
+import Icon from 'app/components/shared/Icon';
 
 import Option from './option';
 
 function SelectOption(props) {
   return (
-    <Option value={props.value} className="btn block hover-bg-silver">
+    <Option value={props.value} className={classNames("btn block hover-bg-silver", { "bg-silver": props.selected })}>
       <div className="flex items-top">
         <div className="flex-none">
-          <Icon saving={props.saving} selected={props.selected} />
+          <SelectIcon saving={props.saving} selected={props.selected} />
         </div>
         <div>
           <span className="semi-bold block">{props.label}</span>
@@ -31,25 +33,26 @@ SelectOption.propTypes = {
   selected: PropTypes.bool
 };
 
-function Icon(props) {
-  const width = 25;
+function SelectIcon(props) {
+  const size = 25
+  const marginRight = 3;
 
   if (props.saving) {
     return (
-      <div style={{ width: width }}>
-        <Spinner className="fit absolute" size={16} style={{ marginTop: 3 }} color={false} />
+      <div className="inline-block relative" style={{ width: size, height: size }}>
+        <Spinner className="fit absolute" size={16} color={false} style={{ left: 3 }} />
       </div>
     );
   }
 
-  const tickColor = props.selected ? "green" : "gray";
+  const tickColor = props.selected ? "green" : "dark-gray";
 
   return (
-    <div className={tickColor} style={{ fontSize: 16, width: width }}>✔</div>
+    <Icon icon="permission-small-tick" className={classNames(tickColor, "relative")} style={{ width: size, height: size, top: -3, left: -2 }} />
   );
 }
 
-Icon.propTypes = {
+SelectIcon.propTypes = {
   saving: PropTypes.bool.isRequired,
   selected: PropTypes.bool.isRequired
 };

--- a/app/components/shared/PermissionDescription.js
+++ b/app/components/shared/PermissionDescription.js
@@ -17,7 +17,7 @@ export default class PermissionDescription extends React.PureComponent {
 
     return (
       <div className="flex mt1" style={{ lineHeight: 1.4 }}>
-        <Icon icon={icon} className="dark-gray flex-none mr1" style={{ marginTop: -3 }} />
+        <Icon icon={icon} className="dark-gray flex-none" style={{ width: 16, height: 16, marginRight: 3 }} />
         {words}
       </div>
     );


### PR DESCRIPTION
It seems the unicode character we were using in our choosers can't be coloured anymore in Safari, and our chooser has been broken as you can't tell which one is selected. This fixes that by using our icon, and makes a few small tweaks (like adding the hover background to the selected option as well).

Before:

![before](https://user-images.githubusercontent.com/153/51317361-7d929900-1aab-11e9-86b0-81de3712097e.gif)

After:

![after](https://user-images.githubusercontent.com/153/51317363-7ec3c600-1aab-11e9-807c-11a59c88e61c.gif)