### PR TITLE
Make build footer text colour muted again

### DIFF
--- a/app/components/build/Header/index.js
+++ b/app/components/build/Header/index.js
@@ -207,7 +207,7 @@ class BuildHeaderComponent extends React.PureComponent {
 
   timeAgoNode = () => {
     return (
-      <small className="build-secondary-time">
+      <small className="dark-gray build-secondary-time">
         <BuildStatusDescription build={this.props.build} />
       </small>
     );
@@ -235,7 +235,7 @@ class BuildHeaderComponent extends React.PureComponent {
     let triggeredFromNode;
 
     const sourceNode = (
-      <small>
+      <small className="dark-gray">
         {`Triggered from ${this.sourceLabel(this.props.build.source)}`}
       </small>
     );
@@ -246,7 +246,7 @@ class BuildHeaderComponent extends React.PureComponent {
       className += ' with-rebuild-information';
 
       rebuiltFromNode = (
-        <small>
+        <small className="dark-gray">
           <br />
           {'Rebuilt from '}
           <a href={this.props.build.rebuiltFrom.url} className="semi-bold color-inherit hover-color-inherit">
@@ -262,7 +262,7 @@ class BuildHeaderComponent extends React.PureComponent {
       className += ' with-rebuild-information truncate';
 
       triggeredFromNode = (
-        <small>
+        <small className="dark-gray">
           <br />
           <a href={this.props.build.triggeredFrom.url} className="semi-bold color-inherit hover-color-inherit">
             <span>


### PR DESCRIPTION
Currently on master the build footer looks like this, and uses `color-inherit`:

<img width="466" alt="image" src="https://user-images.githubusercontent.com/153/51504535-a57c5680-1e35-11e9-9d83-1bf03c52efa4.png">

The idea was to fix the colour in the container, and to pick better colours, but we need to get the layout fixes done first, so this brings it back to matching the current colour on production:

<img width="472" alt="image" src="https://user-images.githubusercontent.com/153/51504499-7665e500-1e35-11e9-93f5-44dda6d20378.png">