### PR TITLE
Added and exposed the `rails/ujs` package

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -40,6 +40,7 @@ window["Webpack"] = {
     "react-dom": require("react-dom"),
     "react-relay": require("react-relay/classic"),
     "react-addons-pure-render-mixin": require("react-addons-pure-render-mixin"),
+    "@rails/ujs": require("@rails/ujs"),
 
     "components/AnonymousNavigation": require("./components/AnonymousNavigation").default,
     "components/billing/BillingHeader": require("./components/billing/BillingHeader").default,

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "winston": "^3.1.0"
   },
   "dependencies": {
+    "@rails/ujs": "^6.0.0-alpha",
     "autosize": "^4.0.2",
     "basscss": "^8.0.10",
     "blueimp-load-image": "^2.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,6 +1204,11 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@rails/ujs@^6.0.0-alpha":
+  version "6.0.0-alpha"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.0.0-alpha.tgz#d5761d93e19215f5f342229f934d5ca8f6dd22a5"
+  integrity sha512-6AZcab77PeJQv8RdfryDYh6tAGcndcRnqYaciLiFclADBPFE9Ip978pGCPiKcKGgCg8S1P1nZII+1GNIrUrx+g==
+
 "@storybook/addon-a11y@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-4.0.0.tgz#f51812fc9c918ad735a4fca67b9d1da363bb6e06"


### PR DESCRIPTION
We use a bunch of rails ujs helpers in the app to do various things. They're provided to use by `jquery_ujs`.

First step in removing jQuery is removing the things that depend on jQuery, and a big part of that is `jquery_ujs`. Lucky for us, Rails make available the same helpers without the jQuery dependency via npm - so this change just includes the package and makes it available to the app.

It's not used on any SPA pages (that would break many things) so it's just used on pages managed by Rails.