### PR TITLE
Show more annotations button

### DIFF
--- a/app/components/build/AnnotationsList.js
+++ b/app/components/build/AnnotationsList.js
@@ -35,7 +35,12 @@ type State = {
   loadingMore: boolean
 };
 
-class AnnnotationsList extends React.Component<Props> {
+class AnnnotationsList extends React.Component<Props, State> {
+
+  state = {
+    loadingMore: false
+  };
+
   componentDidMount() {
     PusherStore.on("build:annotations_change", this.handleWebsocketEvent);
     CentrifugeStore.on("build:annotations_change", this.handleWebsocketEvent);
@@ -64,6 +69,7 @@ class AnnnotationsList extends React.Component<Props> {
       return (
         <ShowMoreFooter
           connection={this.props.build.annotations}
+          loading={this.state.loadingMore}
           onShowMore={this.handleShowMoreAnnotations}
         />
       );

--- a/app/components/build/AnnotationsList.js
+++ b/app/components/build/AnnotationsList.js
@@ -65,7 +65,7 @@ class AnnnotationsList extends React.Component<Props, State> {
   }
 
   renderShowMore() {
-    if (this.props.build.annotations.pageInfo.hasNextPage) {
+    if (this.props.build.annotations) {
       return (
         <ShowMoreFooter
           connection={this.props.build.annotations}
@@ -213,10 +213,6 @@ export default Relay.createContainer(AnnnotationsList, {
               }
             }
             cursor
-          }
-          pageInfo {
-            hasNextPage
-            hasPreviousPage
           }
           ${ShowMoreFooter.getFragment('connection')}
         }

--- a/app/components/build/AnnotationsList.js
+++ b/app/components/build/AnnotationsList.js
@@ -8,6 +8,8 @@ import CentrifugeStore from 'app/stores/CentrifugeStore';
 
 import Button from 'app/components/shared/Button';
 
+const PAGE_SIZE = 5;
+
 type Props = {
   build: {
     id: string,
@@ -24,6 +26,10 @@ type Props = {
     }
   },
   relay: Object
+};
+
+type State = {
+  loadingMore: boolean
 };
 
 class AnnnotationsList extends React.Component<Props> {
@@ -48,7 +54,6 @@ class AnnnotationsList extends React.Component<Props> {
         {this.renderShowMore()}
       </div>
     );
-
   }
 
   renderShowMore() {
@@ -57,13 +62,28 @@ class AnnnotationsList extends React.Component<Props> {
         <Button
           outline={true}
           theme="default"
-          // onClick={this.props.onShowMore}
+          onClick={this.handleShowMoreAnnotations}
         >
           Show more annotations
         </Button>
       );
     }
   }
+
+  handleShowMoreAnnotations = () => {
+    this.setState({ loadingMore: true });
+
+    this.props.relay.setVariables(
+      {
+        pageSize: this.props.relay.variables.pageSize + PAGE_SIZE
+      },
+      (readyState) => {
+        if (readyState.done) {
+          this.setState({ loadingMore: false });
+        }
+      }
+    );
+  };
 
   handleAnnotationClick = (event: MouseEvent) => {
     // Don't change anything if the user is using any modifier keys
@@ -169,11 +189,15 @@ class AnnnotationsList extends React.Component<Props> {
 }
 
 export default Relay.createContainer(AnnnotationsList, {
+  initialVariables: {
+    pageSize: PAGE_SIZE
+  },
+
   fragments: {
     build: () => Relay.QL`
       fragment on Build {
         id
-        annotations(first: 5) {
+        annotations(first: $pageSize) {
           edges {
             node {
               id

--- a/app/components/build/AnnotationsList.js
+++ b/app/components/build/AnnotationsList.js
@@ -6,7 +6,7 @@ import Relay from 'react-relay/classic';
 import PusherStore from 'app/stores/PusherStore';
 import CentrifugeStore from 'app/stores/CentrifugeStore';
 
-import Button from 'app/components/shared/Button';
+import ShowMoreFooter from 'app/components/shared/ShowMoreFooter';
 
 const PAGE_SIZE = 5;
 
@@ -62,13 +62,10 @@ class AnnnotationsList extends React.Component<Props> {
   renderShowMore() {
     if (this.props.build.annotations.pageInfo.hasNextPage) {
       return (
-        <Button
-          outline={true}
-          theme="default"
-          onClick={this.handleShowMoreAnnotations}
-        >
-          Show more annotations
-        </Button>
+        <ShowMoreFooter
+          connection={this.props.build.annotations}
+          onShowMore={this.handleShowMoreAnnotations}
+        />
       );
     }
   }
@@ -215,6 +212,7 @@ export default Relay.createContainer(AnnnotationsList, {
             hasNextPage
             hasPreviousPage
           }
+          ${ShowMoreFooter.getFragment('connection')}
         }
       }
     `

--- a/app/components/build/AnnotationsList.js
+++ b/app/components/build/AnnotationsList.js
@@ -6,6 +6,8 @@ import Relay from 'react-relay/classic';
 import PusherStore from 'app/stores/PusherStore';
 import CentrifugeStore from 'app/stores/CentrifugeStore';
 
+import Button from 'app/components/shared/Button';
+
 type Props = {
   build: {
     id: string,
@@ -41,8 +43,26 @@ class AnnnotationsList extends React.Component<Props> {
     });
 
     return (
-      <div>{annotations}</div>
+      <div>
+        {annotations}
+        {this.renderShowMore()}
+      </div>
     );
+
+  }
+
+  renderShowMore() {
+    if (this.props.build.annotations.pageInfo.hasNextPage) {
+      return (
+        <Button
+          outline={true}
+          theme="default"
+          // onClick={this.props.onShowMore}
+        >
+          Show more annotations
+        </Button>
+      );
+    }
   }
 
   handleAnnotationClick = (event: MouseEvent) => {

--- a/app/components/build/AnnotationsList.js
+++ b/app/components/build/AnnotationsList.js
@@ -22,7 +22,10 @@ type Props = {
             html: ?string
           }
         }
-      }>
+      }>,
+      pageInfo: {
+        hasNextPage: boolean
+      }
     }
   },
   relay: Object

--- a/app/components/build/AnnotationsList.js
+++ b/app/components/build/AnnotationsList.js
@@ -162,6 +162,11 @@ export default Relay.createContainer(AnnnotationsList, {
                 html
               }
             }
+            cursor
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
           }
         }
       }

--- a/app/lib/RelayPreloader.js
+++ b/app/lib/RelayPreloader.js
@@ -518,7 +518,7 @@ const QUERIES = {
     query BuildAnnotations($build: ID!) {
       build(slug: $build) {
         id
-	annotations(first: 10) {
+	annotations(first: 5) {
           edges {
             node {
               id


### PR DESCRIPTION
We currently only display the first 5 annotations for any build. I've used the `ShowMoreFooter` component for consistency, but I'm not sure if I'm happy with how it fits into the page here. Thoughts?
<img width="463" alt="screen shot 2019-01-31 at 11 34 48 am" src="https://user-images.githubusercontent.com/1931350/52022333-8cb62400-254c-11e9-8fd4-5fc3656141cf.png">

Here's the gist I used for >5 annotations.
https://gist.github.com/eleanorakh/ed0ccde127431e46e92d29b93b0fe44a